### PR TITLE
Prefer MMCEMAN devices (mmce0/mmce1) and add device-agnostic boot/path fallback

### DIFF
--- a/bin/POPSLDR/pops_profiles.lua
+++ b/bin/POPSLDR/pops_profiles.lua
@@ -24,11 +24,11 @@ PLDR.PROFILES = {
     DESC="Latest popstarter with increased USB delay";
   },
   {
-    ELF=System.currentDirectory().."POPSLDR/PROFILES/USBDELAY_DEBUG/POPSTARTER.ELF";
+    ELF=System.currentDirectory().."/POPSLDR/PROFILES/USBDELAY_DEBUG/POPSTARTER.ELF";
     DESC="Latest popstarter with increased USB delay & debug menus enabled";
   },
   {
-    ELF="mass:/POPS/POPSTARTER.ELF";
+    ELF=ResolvePreferredPath("POPS/POPSTARTER.ELF");
     DESC="the POPSTARTER ELF located on the POPS folder";
   },
 }

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -24,9 +24,22 @@ if doesFolderExist("POPSLDR/IRX/") then
     end
   end
 end
+local function resolvePreferredPath(relative_path)
+  local preferred = PREFERRED_DEVICE or "mass:/"
+  local candidate = preferred..relative_path
+  if doesFileExist(candidate) then return candidate end
+  if preferred ~= "mass:/" then
+    local fallback = "mass:/"..relative_path
+    if doesFileExist(fallback) then return fallback end
+  end
+  return candidate
+end
+
+ResolvePreferredPath = resolvePreferredPath
+
 PLDR = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
-  POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
+  POPSTARTER_PATH = resolvePreferredPath("POPS/POPSTARTER.ELF");
   CHECK_POPSTARTER_FILES = false;
   GAMEPATH = ".";
   GAMES = {};
@@ -81,7 +94,7 @@ end
 function PLDR.CheckPOPStarterDEPS(device)
   if not PLDR.CHECK_POPSTARTER_FILES then return true, true, true end
   if device == UI.SCENES.GUSB then
-    return doesFileExist("mass:/POPS/POPS_IOX.PAK")
+    return doesFileExist(ResolvePreferredPath("POPS/POPS_IOX.PAK"))
   elseif device == UI.SCENES.GHDD then
     local a = HDD.MountPartition("hdd0:__common", 1, FIO_MT_RDONLY)
     if a then

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,19 @@
-package.path = "./POPSLDR/?.lua;./?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+local function safeDoesFolderExist(path)
+  local ok, result = pcall(doesFolderExist, path)
+  return ok and result
+end
+
+local function detectPreferredDevice()
+  if safeDoesFolderExist("mmce0:/") then return "mmce0:/" end
+  if safeDoesFolderExist("mmce1:/") then return "mmce1:/" end
+  if safeDoesFolderExist("mass:/") then return "mass:/" end
+  return "mass:/"
+end
+
+PREFERRED_DEVICE = detectPreferredDevice()
+BOOT_DEVICE_ROOT = PREFERRED_DEVICE
+
+package.path = string.format("./POPSLDR/?.lua;./?.lua;%sPOPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua", BOOT_DEVICE_ROOT)
 function LOG(...)
   print_uart(...)
 end

--- a/src/elf_loader/include/elf-loader.h
+++ b/src/elf_loader/include/elf-loader.h
@@ -44,7 +44,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[]);
  * dont forget about leading ":"
  *
  * It is not necessary that filename should be on that partition
- * filename - mass:/TEST.ELF
+ * filename - <device>:/TEST.ELF (e.g. mass:/TEST.ELF or mmce0:/TEST.ELF)
  * partition - pfs:/__common
  * will be valid usage
  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,52 +41,108 @@ extern unsigned int size_iomanX_irx;
 extern unsigned char fileXio_irx[];
 extern unsigned int size_fileXio_irx;
 
-extern unsigned char sio2man_irx;
+extern unsigned char sio2man_irx[];
 extern unsigned int size_sio2man_irx;
 
-extern unsigned char mcman_irx;
+extern unsigned char mcman_irx[];
 extern unsigned int size_mcman_irx;
 
-extern unsigned char mcserv_irx;
+extern unsigned char mcserv_irx[];
 extern unsigned int size_mcserv_irx;
 
-extern unsigned char padman_irx;
+extern unsigned char padman_irx[];
 extern unsigned int size_padman_irx;
 
-extern unsigned char libsd_irx;
+extern unsigned char libsd_irx[];
 extern unsigned int size_libsd_irx;
 
-extern unsigned char cdfs_irx;
+extern unsigned char cdfs_irx[];
 extern unsigned int size_cdfs_irx;
 
-extern unsigned char usbd_irx;
+extern unsigned char usbd_irx[];
 extern unsigned int size_usbd_irx;
 
-extern unsigned char bdm_irx;
+extern unsigned char bdm_irx[];
 extern unsigned int size_bdm_irx;
 
-extern unsigned char bdmfs_fatfs_irx;
+extern unsigned char bdmfs_fatfs_irx[];
 extern unsigned int size_bdmfs_fatfs_irx;
 
-extern unsigned char usbmass_bd_irx;
+extern unsigned char usbmass_bd_irx[];
 extern unsigned int size_usbmass_bd_irx;
 
-extern unsigned char audsrv_irx;
+extern unsigned char audsrv_irx[];
 extern unsigned int size_audsrv_irx;
 
-extern unsigned char ds34usb_irx;
+extern unsigned char ds34usb_irx[];
 extern unsigned int size_ds34usb_irx;
 
-extern unsigned char ds34bt_irx;
+extern unsigned char ds34bt_irx[];
 extern unsigned int size_ds34bt_irx;
 
-extern unsigned char mmceman_irx;
+extern unsigned char mmceman_irx[];
 extern unsigned int size_mmceman_irx;
 
 char boot_path[255];
+static const char *kMmceDevices[] = {"mmce0:/", "mmce1:/"};
+static const char *kFallbackDevice = "mass:/";
+static const int kDeviceRetries = 50;
 
-void setLuaBootPath(int argc, char ** argv, int idx)
+static bool hasDevicePrefix(const char *path)
 {
+    return path != NULL && strchr(path, ':') != NULL;
+}
+
+static void normalizeDevicePath(char *path)
+{
+    if (path == NULL) {
+        return;
+    }
+
+    char *colon = strchr(path, ':');
+    if (colon == NULL) {
+        return;
+    }
+
+    char *slash = colon + 1;
+    while (slash[0] == '/' && slash[1] == '/') {
+        memmove(slash + 1, slash + 2, strlen(slash + 2) + 1);
+    }
+}
+
+static int waitForDevice(const char *device, int retries)
+{
+    struct stat buffer;
+    int ret = -1;
+
+    while (ret != 0 && retries > 0) {
+        ret = stat(device, &buffer);
+        /* Wait until the device is ready */
+        nopdelay();
+        retries--;
+    }
+
+    return ret;
+}
+
+static const char *detectPreferredDevice(void)
+{
+    for (size_t idx = 0; idx < (sizeof(kMmceDevices) / sizeof(kMmceDevices[0])); ++idx) {
+        if (waitForDevice(kMmceDevices[idx], kDeviceRetries) == 0) {
+            return kMmceDevices[idx];
+        }
+    }
+
+    if (waitForDevice(kFallbackDevice, kDeviceRetries) == 0) {
+        return kFallbackDevice;
+    }
+
+    return kFallbackDevice;
+}
+
+void setLuaBootPath(int argc, char ** argv, int idx, const char *preferred_device)
+{
+    boot_path[0] = '\0';
     if (argc>=(idx+1))
     {
 
@@ -111,11 +167,11 @@ void setLuaBootPath(int argc, char ** argv, int idx)
     }
     
     // check if path needs patching
-    if( !strncmp( boot_path, "mass:/", 6) && (strlen (boot_path)>6))
-    {
-        strcpy((char *)&boot_path[5],(const char *)&boot_path[6]);
+    normalizeDevicePath(boot_path);
+
+    if (boot_path[0] == '\0' || !hasDevicePrefix(boot_path)) {
+        snprintf(boot_path, sizeof(boot_path), "%s", preferred_device);
     }
-      
     
 }
 
@@ -204,22 +260,10 @@ int main(int argc, char * argv[])
 
     LOAD_IRX_NARG(audsrv_irx);
 
-    //waitUntilDeviceIsReady by fjtrujy
+    const char *preferred_device = detectPreferredDevice();
+    DPRINTF("Preferred device: %s\n", preferred_device);
 
-    struct stat buffer;
-    int ret = -1;
-    int retries = 50;
-
-    while(ret != 0 && retries > 0)
-    {
-        ret = stat("mass:/", &buffer);
-        /* Wait until the device is ready */
-        nopdelay();
-
-        retries--;
-    }
-	
-        setLuaBootPath (argc, argv, 0);
+    setLuaBootPath (argc, argv, 0, preferred_device);
 	// Lua init
 	// init internals library
     
@@ -260,4 +304,3 @@ int main(int argc, char * argv[])
 
 	return 0;
 }
-


### PR DESCRIPTION
### Motivation
- Ensure MMCEMAN-provided mounts (`mmce0:/`, `mmce1:/`) are detected and preferred over `mass:/` when present so boot paths and file I/O use the correct device.
- Remove hardcoded `mass:/` assumptions spread across EE C++ and Lua so the system can gracefully fall back to USB if MMC is unavailable.
- Fix IRX symbol declarations to array types to avoid silent linking/loader issues with embedded IRX blobs.

### Description
- EE loader (`src/main.cpp`) updates: corrected IRX externs to array declarations, added device utilities (`detectPreferredDevice`, `waitForDevice`, `normalizeDevicePath`, `hasDevicePrefix`), made `setLuaBootPath` accept a `preferred_device` and use detected device instead of always waiting on `mass:/`, and replaced the `stat(

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69672f591d948321a7684575a9ab21d7)