### PR TITLE
Flatten runtime layout, export BOOT_PATH to Lua, probe X:/POPS and add sio2man variant builds

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -58,13 +58,16 @@ jobs:
       run: |
         make clean elfloader all SIO2MAN_IRX=${{ matrix.sio2man_irx }} ENABLE_USB_MASS=1
         mv bin/POPSLOADER.ELF bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
+        make package EE_BIN_PKD=bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF POPSLDR_PKG=POPSLoader_${{ steps.variant.outputs.variant_name }}.7z
 
     - name: Upload artifacts
       if: ${{ success() }}
       uses: actions/upload-artifact@v4
       with:
         name: POPSLOADER_${{ steps.variant.outputs.variant_name }}
-        path: bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
+        path: |
+          bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
+          POPSLoader_${{ steps.variant.outputs.variant_name }}.7z
  
     - name: Create pre-release
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -12,13 +12,29 @@ on:
     types: [run_build]
 
 jobs:
+  list-variants:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v5
+    - id: matrix
+      run: |
+        files=$(find sio2man -type f -name sio2man.irx | sort)
+        if [ -z "$files" ]; then
+          echo "No sio2man variants found under sio2man/*/sio2man.irx" >&2
+          exit 1
+        fi
+        json=$(printf '%s\n' "$files" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+        echo "matrix=${json}" >> "$GITHUB_OUTPUT"
+
   build:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
+    needs: list-variants
     strategy:
       matrix:
-        sio2man_irx:
-          - sio2man/sio2man/sio2man.irx
+        sio2man_irx: ${{ fromJson(needs.list-variants.outputs.matrix) }}
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
+    strategy:
+      matrix:
+        sio2man_irx:
+          - sio2man/sio2man/sio2man.irx
     steps:
     - name: Install dependencies
       run: |
@@ -28,16 +32,23 @@ jobs:
     - run: |
         git fetch --prune --unshallow
 
+    - name: Prepare variant name
+      id: variant
+      run: |
+        variant_name=$(echo "${{ matrix.sio2man_irx }}" | sed -e 's#^sio2man/##' -e 's#/sio2man.irx##' -e 's#[^A-Za-z0-9._-]#_#g')
+        echo "variant_name=sio2man_${variant_name}" >> "$GITHUB_OUTPUT"
+
     - name: Compile project
       run: |
-        make clean elfloader all package
+        make clean elfloader all SIO2MAN_IRX=${{ matrix.sio2man_irx }} ENABLE_USB_MASS=1
+        mv bin/POPSLOADER.ELF bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
 
     - name: Upload artifacts
       if: ${{ success() }}
       uses: actions/upload-artifact@v4
       with:
-        name: POPSLDR
-        path: POPSLoader.7z
+        name: POPSLOADER_${{ steps.variant.outputs.variant_name }}
+        path: bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
  
     - name: Create pre-release
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -67,6 +67,7 @@ jobs:
         name: POPSLOADER_${{ steps.variant.outputs.variant_name }}
         path: |
           bin/POPSLOADER_${{ steps.variant.outputs.variant_name }}.ELF
+          bin/pkg/*
           POPSLoader_${{ steps.variant.outputs.variant_name }}.7z
  
     - name: Create pre-release

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,8 @@ IRXTAG = $(subst -,_,$(notdir $(addsuffix _irx, $(basename $<))))
 $(EE_ASM_DIR)%.c: %.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ $(IRXTAG)
 
-SIO2MAN_VARIANT ?= sio2man
-SIO2MAN_DIR = sio2man/$(SIO2MAN_VARIANT)
-SIO2MAN_IRX = $(SIO2MAN_DIR)/sio2man.irx
-SIO2MAN_VARIANTS := $(notdir $(dir $(wildcard sio2man/*/sio2man.irx)))
+SIO2MAN_IRX ?= sio2man/sio2man/sio2man.irx
+SIO2MAN_IRX_PATHS := $(wildcard sio2man/*/sio2man.irx)
 
 ifeq ($(wildcard $(SIO2MAN_IRX)),)
 $(error Missing $(SIO2MAN_IRX). Place an old sio2man.irx under sio2man/<variant>/sio2man.irx)
@@ -188,14 +186,22 @@ reset:
 POPSLDR_PKG = POPSLoader.7z
 package: $(EE_BIN_PKD)
 	rm -f $(POPSLDR_PKG)
-	7z a $(POPSLDR_PKG) $(EE_BIN_PKD) bin/changelog bin/*.lua bin/*.png bin/PATCH_5.BIN LICENSE README.md
+	rm -rf $(BINDIR)pkg
+	mkdir -p $(BINDIR)pkg
+	cp $(EE_BIN_PKD) $(BINDIR)pkg/
+	if [ -f $(BINDIR)POPSTARTER.ELF ]; then cp $(BINDIR)POPSTARTER.ELF $(BINDIR)pkg/; fi
+	cp $(BINDIR)*.lua $(BINDIR)pkg/
+	cp $(BINDIR)*.png $(BINDIR)pkg/
+	cp $(BINDIR)PATCH_5.BIN $(BINDIR)pkg/
+	7z a $(POPSLDR_PKG) $(BINDIR)pkg/* LICENSE README.md
 
 variants:
-	@if [ -z "$(SIO2MAN_VARIANTS)" ]; then echo "No sio2man variants found under sio2man/*/sio2man.irx"; exit 1; fi
-	@for v in $(SIO2MAN_VARIANTS); do \
-		echo "Building variant $$v"; \
+	@if [ -z "$(SIO2MAN_IRX_PATHS)" ]; then echo "No sio2man variants found under sio2man/*/sio2man.irx"; exit 1; fi
+	@for v in $(SIO2MAN_IRX_PATHS); do \
+		variant=$$(basename $$(dirname $$v)); \
+		echo "Building variant $$variant"; \
 		$(MAKE) cleanbin; \
-		$(MAKE) SIO2MAN_VARIANT=$$v EE_BIN=$(BINDIR)enceladus_$$v.elf EE_BIN_PKD=$(BINDIR)POPSLOADER_$$v.ELF; \
+		$(MAKE) SIO2MAN_IRX=$$v EE_BIN=$(BINDIR)enceladus_$$variant.elf EE_BIN_PKD=$(BINDIR)POPSLOADER_$$variant.ELF; \
 	done
 
 dummys:

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ package: $(EE_BIN_PKD)
 	cp $(BINDIR)*.lua $(BINDIR)pkg/
 	cp $(BINDIR)*.png $(BINDIR)pkg/
 	cp $(BINDIR)PATCH_5.BIN $(BINDIR)pkg/
+	if [ -f EMBED/builtin_font.ttf ]; then cp EMBED/builtin_font.ttf $(BINDIR)pkg/; fi
 	7z a $(POPSLDR_PKG) $(BINDIR)pkg/* LICENSE README.md
 
 variants:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An open source Launcher for POPStarter scripted in lua.
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
 ## Usage
-move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory on mmce0:/ or internal HDD
+move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under X:/POPS/ on your chosen device.
 
 ### Tips
 - (MMCE) if you want POPStarter IGR to go back to POPSLoader automatically, place the runtime files in the mmce0:/ root, and copy the `POPSLOADER.ELF` renamed as `BOOT.ELF`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An open source Launcher for POPStarter scripted in lua.
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
 ## Usage
-move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under X:/POPS/ on your chosen device.
+move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under the POPS/ directory on one of: mmce1:/, mmce0:/, mass0:/, mass1:/, mass2:/, mass3:/.
 
 ### Tips
 - (MMCE) if you want POPStarter IGR to go back to POPSLoader automatically, place the runtime files in the mmce0:/ root, and copy the `POPSLOADER.ELF` renamed as `BOOT.ELF`

--- a/bin/README.md
+++ b/bin/README.md
@@ -4,7 +4,7 @@ An open source Launcher for POPStarter scripted in lua.
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
 ## Usage
-move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory on mmce0:/ or internal HDD
+move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under X:/POPS/ on your chosen device.
 
 ### Tips
 - (MMCE) if you want POPStarter IGR to go back to POPSLoader automatically, place the runtime files in the mmce0:/ root, and copy the `POPSLOADER.ELF` renamed as `BOOT.ELF`

--- a/bin/README.md
+++ b/bin/README.md
@@ -4,7 +4,7 @@ An open source Launcher for POPStarter scripted in lua.
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
 ## Usage
-move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under X:/POPS/ on your chosen device.
+move the POPSLOADER.ELF, POPSTARTER.ELF, Lua scripts, PNG assets, and PATCH_5.BIN into the same directory (no POPSLDR subfolder). Games must live under the POPS/ directory on one of: mmce1:/, mmce0:/, mass0:/, mass1:/, mass2:/, mass3:/.
 
 ### Tips
 - (MMCE) if you want POPStarter IGR to go back to POPSLoader automatically, place the runtime files in the mmce0:/ root, and copy the `POPSLOADER.ELF` renamed as `BOOT.ELF`

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -24,7 +24,7 @@ do
   end
 end
 local function resolvePreferredPath(relative_path)
-  local candidate = JoinPath(System.currentDirectory(), relative_path)
+  local candidate = JoinPath(BOOT_PATH or System.currentDirectory(), relative_path)
   if doesFileExist(candidate) then return candidate end
   return candidate
 end
@@ -45,11 +45,13 @@ local function canOpenDir(path)
   return ok and type(result) == "table"
 end
 
+local POPS_ROOT = BOOT_DEVICE_ROOT and (BOOT_DEVICE_ROOT.."POPS/") or "mmce0:/POPS/"
+
 PLDR = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
   POPSTARTER_PATH = resolvePreferredPath("POPSTARTER.ELF");
   CHECK_POPSTARTER_FILES = false;
-  GAMEPATH = ".";
+  GAMEPATH = POPS_ROOT;
   GAMES = {};
   HDDCACHE = nil;
   PROFILES = {};
@@ -65,10 +67,15 @@ PLDR = {
   };
 }
 
-function PLDR.FindPopsRoot(retries, delay)
-  local attempts = retries or 5
+function PLDR.FindPopsRoot(delay)
   local wait = delay or 1
-  for _ = 1, attempts do
+  if BOOT_DEVICE_ROOT then
+    local candidate = BOOT_DEVICE_ROOT.."POPS/"
+    if canOpenDir(candidate) then
+      return candidate
+    end
+  end
+  while true do
     for _, root in ipairs(POPS_DEVICE_ORDER) do
       if canOpenDir(root) then
         return root
@@ -76,7 +83,6 @@ function PLDR.FindPopsRoot(retries, delay)
     end
     System.sleep(wait)
   end
-  return nil
 end
 if BOOTPATH ~= nil then
   PLDR.HDD.LOADSTATE = 1

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -32,20 +32,23 @@ end
 ResolvePreferredPath = resolvePreferredPath
 
 local POPS_DEVICE_ORDER = {
-  "mmce1:/POPS/",
-  "mmce0:/POPS/",
   "mass0:/POPS/",
   "mass1:/POPS/",
   "mass2:/POPS/",
   "mass3:/POPS/"
 }
 
+if MMCE_AVAILABLE then
+  table.insert(POPS_DEVICE_ORDER, 1, "mmce1:/POPS/")
+  table.insert(POPS_DEVICE_ORDER, 2, "mmce0:/POPS/")
+end
+
 local function canOpenDir(path)
   local ok, result = pcall(System.listDirectory, path)
   return ok and type(result) == "table"
 end
 
-local POPS_ROOT = BOOT_DEVICE_ROOT and (BOOT_DEVICE_ROOT.."POPS/") or "mmce0:/POPS/"
+local POPS_ROOT = BOOT_DEVICE_ROOT and (BOOT_DEVICE_ROOT.."POPS/") or "mass0:/POPS/"
 
 PLDR = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -67,22 +67,19 @@ PLDR = {
   };
 }
 
-function PLDR.FindPopsRoot(delay)
-  local wait = delay or 1
+function PLDR.FindPopsRoot()
   if BOOT_DEVICE_ROOT then
     local candidate = BOOT_DEVICE_ROOT.."POPS/"
     if canOpenDir(candidate) then
       return candidate
     end
   end
-  while true do
-    for _, root in ipairs(POPS_DEVICE_ORDER) do
-      if canOpenDir(root) then
-        return root
-      end
+  for _, root in ipairs(POPS_DEVICE_ORDER) do
+    if canOpenDir(root) then
+      return root
     end
-    System.sleep(wait)
   end
+  return nil
 end
 if BOOTPATH ~= nil then
   PLDR.HDD.LOADSTATE = 1

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -59,13 +59,16 @@ IsValidRoot = isValidRoot
 
 local function detectPreferredDevice()
   local probe_roots = {
-    "mmce1:/",
-    "mmce0:/",
     "mass0:/",
     "mass1:/",
     "mass2:/",
     "mass3:/",
   }
+
+  if MMCE_AVAILABLE then
+    table.insert(probe_roots, 1, "mmce1:/")
+    table.insert(probe_roots, 2, "mmce0:/")
+  end
 
   while true do
     for _, root in ipairs(probe_roots) do

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -153,8 +153,6 @@ function RunScript(S)
   dofile(S)
 end
 
-RUNTIME_ROOT = System.currentDirectory()
-
 RUNTIME_ROOT = BOOT_PATH
 POPSTARTER_PATH = BOOT_PATH.."POPSTARTER.ELF"
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -58,13 +58,29 @@ JoinPath = joinPath
 IsValidRoot = isValidRoot
 
 local function detectPreferredDevice()
-  if safeDoesFolderExist("mmce0:/") then return "mmce0:/" end
-  if safeDoesFolderExist("mmce1:/") then return "mmce1:/" end
-  if safeDoesFolderExist("mass0:/") then return "mass0:/" end
-  if safeDoesFolderExist("mass1:/") then return "mass1:/" end
-  if safeDoesFolderExist("mass2:/") then return "mass2:/" end
-  if safeDoesFolderExist("mass3:/") then return "mass3:/" end
-  return "mmce0:/"
+  local probe_roots = {
+    "mmce1:/",
+    "mmce0:/",
+    "mass0:/",
+    "mass1:/",
+    "mass2:/",
+    "mass3:/",
+  }
+
+  while true do
+    for _, root in ipairs(probe_roots) do
+      if safeDoesFolderExist(root.."POPS/") then
+        return root
+      end
+    end
+    System.sleep(1)
+  end
+end
+
+BOOT_PATH = tostring(BOOT_PATH or System.currentDirectory() or "./")
+BOOT_PATH = BOOT_PATH:gsub("//+", "/")
+if BOOT_PATH:sub(-1) ~= "/" then
+  BOOT_PATH = BOOT_PATH.."/"
 end
 
 PREFERRED_DEVICE = normalizeRoot(detectPreferredDevice())
@@ -77,7 +93,7 @@ elseif not isValidRoot(BOOT_DEVICE_ROOT) then
   LOG("WARNING: invalid boot device root", BOOT_DEVICE_ROOT)
 end
 
-package.path = "./?.lua;mc0:/?.lua;mc1:/?.lua"
+package.path = string.format("%s?.lua", BOOT_PATH)
 
 POPSLDR_VER = "v1.0.0 - rev3"
 
@@ -139,8 +155,11 @@ end
 
 RUNTIME_ROOT = System.currentDirectory()
 
-if doesFileExist("system.lua") then
-	RunScript("system.lua");
+RUNTIME_ROOT = BOOT_PATH
+POPSTARTER_PATH = BOOT_PATH.."POPSTARTER.ELF"
+
+if doesFileExist(BOOT_PATH.."system.lua") then
+	RunScript(BOOT_PATH.."system.lua");
 else
   error("Cant access system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory())
 end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -146,9 +146,20 @@ if string.find(ARGV0, "^hdd0:") then
 end
 GPAD = 0
 Font.ftInit()
-BFONT = Font.LoadBuiltinFont()
-SFONT = Font.LoadBuiltinFont()
-LFONT = Font.LoadBuiltinFont()
+local function loadBuiltinFont()
+  local font = Font.LoadBuiltinFont()
+  if font == nil and doesFileExist(BOOT_PATH.."builtin_font.ttf") then
+    font = Font.ftLoad(BOOT_PATH.."builtin_font.ttf")
+  end
+  return font
+end
+
+BFONT = loadBuiltinFont()
+SFONT = loadBuiltinFont()
+LFONT = loadBuiltinFont()
+if BFONT == nil or SFONT == nil or LFONT == nil then
+  error("Failed to load builtin font (missing embedded font and builtin_font.ttf)")
+end
 Font.ftSetCharSize(BFONT, 800, 800)
 Font.ftSetCharSize(SFONT, 600, 600)
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -10,6 +10,7 @@ extern "C" {
 }
 
 extern char boot_path[255];
+extern int g_mmce_available;
 
 #ifdef DEBUG
 #define dbgprintf(args...) scr_printf(args)
@@ -41,4 +42,3 @@ extern void luaHDD_init(lua_State *L);
 extern void stackDump (lua_State *L);
 
 #endif
-

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -846,7 +846,8 @@ void luaSystem_init(lua_State *L) {
 	lua_pushinteger(L, 2);
 	lua_setglobal(L, "READ_WRITE");
 
-
+	lua_pushstring(L, boot_path);
+	lua_setglobal(L, "BOOT_PATH");
 
 	
 }

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -849,5 +849,8 @@ void luaSystem_init(lua_State *L) {
 	lua_pushstring(L, boot_path);
 	lua_setglobal(L, "BOOT_PATH");
 
+	lua_pushboolean(L, g_mmce_available != 0);
+	lua_setglobal(L, "MMCE_AVAILABLE");
+
 	
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,7 +281,9 @@ int main(int argc, char * argv[])
 
 	LOAD_IRX_NARG(sio2man_irx);
 	LOAD_IRX_NARG(mmceman_irx);
+#ifdef DEBUG
     logMmceDiagnostics();
+#endif
     LOAD_IRX_NARG(mcman_irx);
     LOAD_IRX_NARG(mcserv_irx);
     initMC();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,6 +118,23 @@ static int waitForDevice(const char *device, int retries)
     return ret;
 }
 
+static bool hasPopsDirectory(const char *root)
+{
+    if (root == NULL) {
+        return false;
+    }
+
+    char path[64];
+    snprintf(path, sizeof(path), "%sPOPS/", root);
+
+    struct stat buffer;
+    if (stat(path, &buffer) != 0) {
+        return false;
+    }
+
+    return S_ISDIR(buffer.st_mode);
+}
+
 static void logMmceDiagnostics(void)
 {
     bool any_ready = false;
@@ -142,12 +159,28 @@ static void logMmceDiagnostics(void)
 static const char *detectPreferredDevice(void)
 {
     for (size_t idx = 0; idx < (sizeof(kDeviceProbeOrder) / sizeof(kDeviceProbeOrder[0])); ++idx) {
-        if (waitForDevice(kDeviceProbeOrder[idx], kDeviceRetries) == 0) {
+        if (waitForDevice(kDeviceProbeOrder[idx], kDeviceRetries) == 0 &&
+            hasPopsDirectory(kDeviceProbeOrder[idx])) {
             return kDeviceProbeOrder[idx];
         }
     }
 
     return kDefaultDevice;
+}
+
+static void ensureBootPathSlash(void)
+{
+    size_t len = strlen(boot_path);
+    if (len == 0) {
+        return;
+    }
+
+    if (boot_path[len - 1] != '/') {
+        if (len + 1 < sizeof(boot_path)) {
+            boot_path[len] = '/';
+            boot_path[len + 1] = '\0';
+        }
+    }
 }
 
 void setLuaBootPath(int argc, char ** argv, int idx, const char *preferred_device)
@@ -184,6 +217,8 @@ void setLuaBootPath(int argc, char ** argv, int idx, const char *preferred_devic
     if (boot_path[0] == '\0' || !hasDevicePrefix(boot_path)) {
         snprintf(boot_path, sizeof(boot_path), "%s", normalized_root);
     }
+
+    ensureBootPathSlash();
     
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,9 @@ extern unsigned char mmceman_irx[];
 extern unsigned int size_mmceman_irx;
 
 char boot_path[255];
+int g_mmce_available = 0;
+static int g_mmce_probed = 0;
+static int g_mmce_disabled = 0;
 static const char *kMmceDevices[] = {"mmce0:/", "mmce1:/"};
 static const char *kDeviceProbeOrder[] = {
     "mmce1:/",
@@ -97,6 +100,7 @@ static const char *kDeviceProbeOrder[] = {
 };
 static const char *kDefaultDevice = "mmce0:/";
 static const int kDeviceRetries = 50;
+static const int kMmceProbeRetries = 2;
 
 static bool hasDevicePrefix(const char *path)
 {
@@ -116,6 +120,35 @@ static int waitForDevice(const char *device, int retries)
     }
 
     return ret;
+}
+
+static bool isMmceRoot(const char *root)
+{
+    return root != NULL && (strncmp(root, "mmce0:/", 7) == 0 || strncmp(root, "mmce1:/", 7) == 0);
+}
+
+static void probeMmceAvailability(void)
+{
+    if (g_mmce_probed) {
+        return;
+    }
+
+    g_mmce_probed = 1;
+    g_mmce_available = 0;
+
+    for (size_t idx = 0; idx < (sizeof(kMmceDevices) / sizeof(kMmceDevices[0])); ++idx) {
+        if (waitForDevice(kMmceDevices[idx], kMmceProbeRetries) == 0) {
+            g_mmce_available = 1;
+            break;
+        }
+    }
+
+    if (g_mmce_available) {
+        printf("MMCE: available\n");
+    } else {
+        g_mmce_disabled = 1;
+        printf("MMCE: probe failed (no ACK). Disabling mmce0:/ for this session.\n");
+    }
 }
 
 static bool hasPopsDirectory(const char *root)
@@ -158,7 +191,11 @@ static void logMmceDiagnostics(void)
 
 static const char *detectPreferredDevice(void)
 {
+    probeMmceAvailability();
     for (size_t idx = 0; idx < (sizeof(kDeviceProbeOrder) / sizeof(kDeviceProbeOrder[0])); ++idx) {
+        if (g_mmce_disabled && isMmceRoot(kDeviceProbeOrder[idx])) {
+            continue;
+        }
         if (waitForDevice(kDeviceProbeOrder[idx], kDeviceRetries) == 0 &&
             hasPopsDirectory(kDeviceProbeOrder[idx])) {
             return kDeviceProbeOrder[idx];


### PR DESCRIPTION
### Motivation
- Ensure POPSLoader always loads its runtime files from the same directory as `POPSLOADER.ELF` (no `POPSLDR/` subfolder) and resolve `POPSTARTER.ELF` next to the ELF.
- Make device selection strictly follow the required probe order and only succeed if `X:/POPS/` exists so game discovery is deterministic.
- Force embedding of repo-provided `sio2man.irx` variants and produce multiple build artifacts so variant testing does not require source edits.

### Description
- Exported the normalized boot directory to Lua as the global `BOOT_PATH` by adding `ensureBootPathSlash()` and preserving `boot_path` in `src/main.cpp` and pushing it into Lua in `src/luasystem.cpp` (registered as `BOOT_PATH`).
- Reworked device probing to require a `POPS/` directory: added `hasPopsDirectory()` and updated `detectPreferredDevice()` in `src/main.cpp`, and moved the repeat-until-found probe loop into `etc/boot.lua` using the exact order `mmce1:, mmce0:, mass0..mass3` checking `root.."POPS/"`.
- Updated Lua boot logic in `etc/boot.lua` and runtime `bin/system.lua` to load scripts from `BOOT_PATH`, set `POPSTARTER_PATH = BOOT_PATH .. "POPSTARTER.ELF"`, and make `GAMEPATH` use the discovered `X:/POPS/` root.
- Changed packaging in `Makefile` to flatten runtime files into a `bin/pkg/` staging area (no `bin/POPSLDR/`) and adjusted `variants` and `SIO2MAN_IRX` handling so the embedded `sio2man.irx` comes from a repo path and multiple variants can be enumerated and built.
- CI updated (`.github/workflows/compilation.yml`) to run a matrix over `sio2man` IRX paths, build each variant with `SIO2MAN_IRX=... ENABLE_USB_MASS=1`, rename outputs to `POPSLOADER_<variant>.ELF`, and upload them as artifacts.
- Documentation updates to `README.md` and `bin/README.md` to reflect the flattened layout and `X:/POPS/` requirement.

### Testing
- No automated tests were executed locally as part of this change; CI was updated to generate build artifacts per `sio2man` variant but the workflow was not run in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676dfaff3c8321a7a6a675a395b305)