### PR TITLE
Align POPS probe order, surface failed device in UI, and harden boot file loading

### DIFF
--- a/bin/system.lua
+++ b/bin/system.lua
@@ -32,16 +32,20 @@ end
 ResolvePreferredPath = resolvePreferredPath
 
 local POPS_DEVICE_ORDER = {
+  "mmce1:/POPS/",
+  "mmce0:/POPS/",
+  "mmce1:/POPS/",
+  "mmce0:/POPS/",
+  "mass:/POPS/",
   "mass0:/POPS/",
   "mass1:/POPS/",
   "mass2:/POPS/",
-  "mass3:/POPS/"
+  "mass3:/POPS/",
+  "mass:/POPS/",
+  "mass0:/POPS/"
 }
 
-if MMCE_AVAILABLE then
-  table.insert(POPS_DEVICE_ORDER, 1, "mmce1:/POPS/")
-  table.insert(POPS_DEVICE_ORDER, 2, "mmce0:/POPS/")
-end
+PLDR_LAST_POPS_DEVICE = nil
 
 local function canOpenDir(path)
   local ok, result = pcall(System.listDirectory, path)
@@ -73,11 +77,13 @@ PLDR = {
 function PLDR.FindPopsRoot()
   if BOOT_DEVICE_ROOT then
     local candidate = BOOT_DEVICE_ROOT.."POPS/"
+    PLDR_LAST_POPS_DEVICE = candidate
     if canOpenDir(candidate) then
       return candidate
     end
   end
   for _, root in ipairs(POPS_DEVICE_ORDER) do
+    PLDR_LAST_POPS_DEVICE = root
     if canOpenDir(root) then
       return root
     end

--- a/bin/ui.lua
+++ b/bin/ui.lua
@@ -179,7 +179,8 @@ UI = {
             PLDR.CleanupGameList()
             local root = PLDR.FindPopsRoot()
             if root == nil then
-              UI.Notif_queue.add("No POPS/ folder found on mmce/mass devices")
+              local last_device = PLDR_LAST_POPS_DEVICE or "unknown device"
+              UI.Notif_queue.add("No POPS Folder Found on "..last_device)
             else
               PLDR.GetPS1GameLists(root, true)
             end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -214,13 +214,46 @@ LOGF("system.lua stat ret: %d", system_stat_ret)
 if system_stat_ret ~= 0 then
   emit_fatal("Cant access system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_ret: "..tostring(system_stat_ret))
 end
+if system_size <= 0 then
+  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_size: "..tostring(system_size))
+end
 
 local system_fd, system_open_ret = open_with_retry(system_path, FREAD)
 if system_fd < 0 then
   emit_fatal("Cant open system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\topen_ret: "..tostring(system_open_ret))
 end
 
-local system_data, system_read_ret = System.fileXioRead(system_fd, system_size)
+local function read_filexio_all(fd, total_size)
+  if total_size <= 0 then
+    return nil, 0
+  end
+  local chunks = {}
+  local read_total = 0
+  local last_ret = 0
+  while read_total < total_size do
+    local remaining = total_size - read_total
+    local chunk_size = remaining
+    if chunk_size > 16384 then
+      chunk_size = 16384
+    end
+    local data, ret = System.fileXioRead(fd, chunk_size)
+    last_ret = ret
+    if data == nil then
+      return nil, ret
+    end
+    if ret <= 0 then
+      break
+    end
+    table.insert(chunks, data)
+    read_total = read_total + ret
+  end
+  if read_total ~= total_size then
+    return nil, last_ret
+  end
+  return table.concat(chunks), read_total
+end
+
+local system_data, system_read_ret = read_filexio_all(system_fd, system_size)
 LOGF("system.lua read ret: %d", system_read_ret)
 local system_close_ret = System.fileXioClose(system_fd)
 LOGF("system.lua close ret: %d", system_close_ret)

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -214,28 +214,17 @@ LOGF("system.lua stat ret: %d", system_stat_ret)
 if system_stat_ret ~= 0 then
   emit_fatal("Cant access system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_ret: "..tostring(system_stat_ret))
 end
-if system_size <= 0 then
-  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_size: "..tostring(system_size))
-end
-
 local system_fd, system_open_ret = open_with_retry(system_path, FREAD)
 if system_fd < 0 then
   emit_fatal("Cant open system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\topen_ret: "..tostring(system_open_ret))
 end
 
-local function read_filexio_all(fd, total_size)
-  if total_size <= 0 then
-    return nil, 0
-  end
+local function read_filexio_all(fd)
   local chunks = {}
   local read_total = 0
   local last_ret = 0
-  while read_total < total_size do
-    local remaining = total_size - read_total
-    local chunk_size = remaining
-    if chunk_size > 16384 then
-      chunk_size = 16384
-    end
+  while true do
+    local chunk_size = 16384
     local data, ret = System.fileXioRead(fd, chunk_size)
     last_ret = ret
     if data == nil then
@@ -247,14 +236,17 @@ local function read_filexio_all(fd, total_size)
     table.insert(chunks, data)
     read_total = read_total + ret
   end
-  if read_total ~= total_size then
+  if read_total == 0 then
     return nil, last_ret
   end
   return table.concat(chunks), read_total
 end
 
-local system_data, system_read_ret = read_filexio_all(system_fd, system_size)
+local system_data, system_read_ret = read_filexio_all(system_fd)
 LOGF("system.lua read ret: %d", system_read_ret)
+if system_size > 0 and system_read_ret ~= system_size then
+  LOG("WARNING: system.lua size mismatch. stat:"..tostring(system_size).." read:"..tostring(system_read_ret))
+end
 local system_close_ret = System.fileXioClose(system_fd)
 LOGF("system.lua close ret: %d", system_close_ret)
 if system_close_ret ~= 0 then

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -224,11 +224,18 @@ local system_data, system_read_ret = System.fileXioRead(system_fd, system_size)
 LOGF("system.lua read ret: %d", system_read_ret)
 local system_close_ret = System.fileXioClose(system_fd)
 LOGF("system.lua close ret: %d", system_close_ret)
+if system_close_ret ~= 0 then
+  LOG("WARNING: Failed to close system.lua, ret: "..tostring(system_close_ret))
+end
 if system_data == nil then
   emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tread_ret: "..tostring(system_read_ret))
 end
 
-local system_chunk, system_err = loadstring(system_data, "@"..system_path)
+local loader = loadstring or load
+if loader == nil then
+  emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: loader unavailable")
+end
+local system_chunk, system_err = loader(system_data, "@"..system_path)
 if system_chunk == nil then
   emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: "..tostring(system_err))
 end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -7,30 +7,6 @@ function LOGF(S, ...)
   print_uart(string.format(S, ...))
 end
 
-local function safeDoesFolderExist(path)
-  local ok, result = pcall(doesFolderExist, path)
-  return ok and result
-end
-
-local function normalizeRoot(devroot)
-  local dev = tostring(devroot or "")
-  local prefix = dev:match("^(.-):") or dev
-  prefix = string.lower(prefix)
-  if prefix ~= "mmce0" and prefix ~= "mmce1" and
-     prefix ~= "mass0" and prefix ~= "mass1" and
-     prefix ~= "mass2" and prefix ~= "mass3" then
-    prefix = "mmce0"
-  end
-  return prefix..":/"
-end
-
-local function isValidRoot(root)
-  if root == nil then return false end
-  if root == "mmce0:/" or root == "mmce1:/" then return true end
-  if root == "mass0:/" or root == "mass1:/" or root == "mass2:/" or root == "mass3:/" then return true end
-  return false
-end
-
 local function joinPath(root, rel)
   local base = tostring(root or "")
   local extra = tostring(rel or "")
@@ -53,48 +29,110 @@ local function joinPath(root, rel)
   return (base.."/"..extra):gsub("//+", "/"):gsub(":(/+)", ":/")
 end
 
-NormalizeRoot = normalizeRoot
 JoinPath = joinPath
-IsValidRoot = isValidRoot
 
-local function detectPreferredDevice()
-  local probe_roots = {
-    "mass0:/",
-    "mass1:/",
-    "mass2:/",
-    "mass3:/",
-  }
+local DEVICE_READY_TIMEOUT_MS = 2000
+local DEVICE_READY_SLEEP_MS = 100
+local OPEN_RETRY_COUNT = 3
+local OPEN_RETRY_SLEEP_MS = 100
 
-  if MMCE_AVAILABLE then
-    table.insert(probe_roots, 1, "mmce1:/")
-    table.insert(probe_roots, 2, "mmce0:/")
+local function emit_fatal(message)
+  LOG(message)
+  System.dprintf(message)
+  print(message)
+  if Screen and Screen.clear then
+    Screen.clear()
   end
-
+  pcall(function()
+    Font.ftInit()
+    Font.fmLoad()
+    Font.fmPrint(20, 20, 0.6, message)
+  end)
+  if Screen and Screen.flip then
+    Screen.flip()
+  end
   while true do
-    for _, root in ipairs(probe_roots) do
-      if safeDoesFolderExist(root.."POPS/") then
-        return root
-      end
-    end
     System.sleep(1)
   end
 end
 
-BOOT_PATH = tostring(BOOT_PATH or System.currentDirectory() or "./")
-BOOT_PATH = BOOT_PATH:gsub("//+", "/")
-if BOOT_PATH:sub(-1) ~= "/" then
-  BOOT_PATH = BOOT_PATH.."/"
+local function wait_for_ready(path, timeout_ms)
+  local elapsed = 0
+  local last_ret = nil
+  while elapsed <= timeout_ms do
+    local stat_ret = System.fileXioGetStat(path)
+    if stat_ret == 0 then
+      return true, 0
+    end
+    local dopen_ret = System.fileXioDopen(path)
+    if dopen_ret >= 0 then
+      System.fileXioDclose(dopen_ret)
+      return true, 0
+    end
+    last_ret = (dopen_ret < 0) and dopen_ret or stat_ret
+    System.sleepMs(DEVICE_READY_SLEEP_MS)
+    elapsed = elapsed + DEVICE_READY_SLEEP_MS
+  end
+  return false, last_ret
 end
 
-PREFERRED_DEVICE = normalizeRoot(detectPreferredDevice())
-BOOT_DEVICE_ROOT = PREFERRED_DEVICE
-
-LOGF("Boot device root: %s", BOOT_DEVICE_ROOT)
-if DEBUG_BUILD then
-  assert(isValidRoot(BOOT_DEVICE_ROOT), "Invalid boot device root: "..BOOT_DEVICE_ROOT)
-elseif not isValidRoot(BOOT_DEVICE_ROOT) then
-  LOG("WARNING: invalid boot device root", BOOT_DEVICE_ROOT)
+local function open_with_retry(path, flags)
+  local last_ret = nil
+  for attempt = 1, OPEN_RETRY_COUNT do
+    local fd = System.fileXioOpen(path, flags)
+    LOGF("fileXioOpen attempt %d ret: %d", attempt, fd)
+    if fd >= 0 then
+      return fd, 0
+    end
+    last_ret = fd
+    System.sleepMs(OPEN_RETRY_SLEEP_MS)
+  end
+  return -1, last_ret
 end
+
+local boot_path = tostring(System.GetArgv0() or System.currentDirectory() or "")
+local current_bootpath = boot_path
+local deps_base_dir = System.deriveBaseDir(current_bootpath)
+
+local ready_ok, ready_ret = wait_for_ready(deps_base_dir, DEVICE_READY_TIMEOUT_MS)
+if not ready_ok then
+  emit_fatal("FATAL: base_dir not ready\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tlast_ret: "..tostring(ready_ret))
+end
+
+local base_stat_ret, _ = System.fileXioGetStat(deps_base_dir)
+LOGF("base_dir stat ret: %d", base_stat_ret)
+
+BOOT_PATH = deps_base_dir
+
+local function find_pops_device()
+  local roots = {
+    "mmce1:/",
+    "mmce0:/",
+    "mmce1:/",
+    "mmce0:/",
+    "mass:/",
+    "mass0:/",
+    "mass1:/",
+    "mass2:/",
+    "mass3:/",
+    "mass:/",
+    "mass0:/"
+  }
+  for _, root in ipairs(roots) do
+    local path = root.."POPS/"
+    local ready_ok, _ = wait_for_ready(path, DEVICE_READY_TIMEOUT_MS)
+    if ready_ok then
+      local dopen_ret = System.fileXioDopen(path)
+      if dopen_ret >= 0 then
+        System.fileXioDclose(dopen_ret)
+        return root
+      end
+    end
+  end
+  return nil
+end
+
+BOOT_DEVICE_ROOT = find_pops_device()
 
 package.path = string.format("%s?.lua", BOOT_PATH)
 
@@ -170,8 +208,28 @@ end
 RUNTIME_ROOT = BOOT_PATH
 POPSTARTER_PATH = BOOT_PATH.."POPSTARTER.ELF"
 
-if doesFileExist(BOOT_PATH.."system.lua") then
-	RunScript(BOOT_PATH.."system.lua");
-else
-  error("Cant access system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory())
+local system_path = System.resolveLocal(deps_base_dir, "system.lua")
+local system_stat_ret, system_size = System.fileXioGetStat(system_path)
+LOGF("system.lua stat ret: %d", system_stat_ret)
+if system_stat_ret ~= 0 then
+  emit_fatal("Cant access system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_ret: "..tostring(system_stat_ret))
 end
+
+local system_fd, system_open_ret = open_with_retry(system_path, FREAD)
+if system_fd < 0 then
+  emit_fatal("Cant open system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\topen_ret: "..tostring(system_open_ret))
+end
+
+local system_data, system_read_ret = System.fileXioRead(system_fd, system_size)
+LOGF("system.lua read ret: %d", system_read_ret)
+local system_close_ret = System.fileXioClose(system_fd)
+LOGF("system.lua close ret: %d", system_close_ret)
+if system_data == nil then
+  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tread_ret: "..tostring(system_read_ret))
+end
+
+local system_chunk, system_err = loadstring(system_data, "@"..system_path)
+if system_chunk == nil then
+  emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: "..tostring(system_err))
+end
+system_chunk()

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -78,6 +78,8 @@ end
 
 local function open_with_retry(path, flags)
   local last_ret = nil
+  local last_read_ret = nil
+  local last_parse_err = nil
   for attempt = 1, OPEN_RETRY_COUNT do
     local fd = System.fileXioOpen(path, flags)
     LOGF("fileXioOpen attempt %d ret: %d", attempt, fd)
@@ -214,11 +216,6 @@ LOGF("system.lua stat ret: %d", system_stat_ret)
 if system_stat_ret ~= 0 then
   emit_fatal("Cant access system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_ret: "..tostring(system_stat_ret))
 end
-local system_fd, system_open_ret = open_with_retry(system_path, FREAD)
-if system_fd < 0 then
-  emit_fatal("Cant open system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\topen_ret: "..tostring(system_open_ret))
-end
-
 local function read_filexio_all(fd)
   local chunks = {}
   local read_total = 0
@@ -242,26 +239,48 @@ local function read_filexio_all(fd)
   return table.concat(chunks), read_total
 end
 
-local system_data, system_read_ret = read_filexio_all(system_fd)
-LOGF("system.lua read ret: %d", system_read_ret)
-if system_size > 0 and system_read_ret ~= system_size then
-  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_size: "..tostring(system_size).."\n\tread_size: "..tostring(system_read_ret))
-end
-local system_close_ret = System.fileXioClose(system_fd)
-LOGF("system.lua close ret: %d", system_close_ret)
-if system_close_ret ~= 0 then
-  LOG("WARNING: Failed to close system.lua, ret: "..tostring(system_close_ret))
-end
-if system_data == nil then
-  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tread_ret: "..tostring(system_read_ret))
+local function load_system_lua()
+  local loader = loadstring or load
+  if loader == nil then
+    emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: loader unavailable")
+  end
+
+  local last_read_ret = nil
+  local last_parse_err = nil
+  for attempt = 1, OPEN_RETRY_COUNT do
+    local system_fd, system_open_ret = open_with_retry(system_path, FREAD)
+    if system_fd < 0 then
+      emit_fatal("Cant open system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\topen_ret: "..tostring(system_open_ret))
+    end
+
+    local system_data, system_read_ret = read_filexio_all(system_fd)
+    last_read_ret = system_read_ret
+    LOGF("system.lua read ret: %d", system_read_ret)
+    if system_size > 0 and system_read_ret ~= system_size then
+      LOG("WARNING: system.lua size mismatch. stat:"..tostring(system_size).." read:"..tostring(system_read_ret))
+    end
+    local system_close_ret = System.fileXioClose(system_fd)
+    LOGF("system.lua close ret: %d", system_close_ret)
+    if system_close_ret ~= 0 then
+      LOG("WARNING: Failed to close system.lua, ret: "..tostring(system_close_ret))
+    end
+    if system_data == nil then
+      LOG("WARNING: system.lua read failed, retrying. ret:"..tostring(system_read_ret))
+      System.sleepMs(OPEN_RETRY_SLEEP_MS)
+    else
+      local system_chunk, system_err = loader(system_data, "@"..system_path)
+      if system_chunk == nil then
+        last_parse_err = system_err
+        LOG("WARNING: system.lua parse failed, retrying. err:"..tostring(system_err))
+        System.sleepMs(OPEN_RETRY_SLEEP_MS)
+      else
+        return system_chunk
+      end
+    end
+  end
+
+  emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tread_ret: "..tostring(last_read_ret).."\n\terr: "..tostring(last_parse_err))
 end
 
-local loader = loadstring or load
-if loader == nil then
-  emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: loader unavailable")
-end
-local system_chunk, system_err = loader(system_data, "@"..system_path)
-if system_chunk == nil then
-  emit_fatal("Cant load system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\terr: "..tostring(system_err))
-end
+local system_chunk = load_system_lua()
 system_chunk()

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -245,7 +245,7 @@ end
 local system_data, system_read_ret = read_filexio_all(system_fd)
 LOGF("system.lua read ret: %d", system_read_ret)
 if system_size > 0 and system_read_ret ~= system_size then
-  LOG("WARNING: system.lua size mismatch. stat:"..tostring(system_size).." read:"..tostring(system_read_ret))
+  emit_fatal("Cant read system.lua\n\n\tboot_path: "..current_bootpath.."\n\tdeps_base_dir: "..deps_base_dir.."\n\tsystem_path: "..system_path.."\n\tstat_size: "..tostring(system_size).."\n\tread_size: "..tostring(system_read_ret))
 end
 local system_close_ret = System.fileXioClose(system_fd)
 LOGF("system.lua close ret: %d", system_close_ret)

--- a/src/include/system.h
+++ b/src/include/system.h
@@ -22,6 +22,8 @@ extern bool normalize_root(const char *devroot, char *out, size_t outsz);
 extern bool join_path(char *out, size_t outsz, const char *root, const char *rel);
 extern bool is_valid_root(const char *root);
 extern void normalize_device_path(char *path);
+extern bool derive_base_dir(const char *boot_path, char *out, size_t out_sz);
+extern bool resolve_local(const char *base_dir, const char *filename, char *out, size_t out_sz);
 #define load_elf_NoIOPReset(ELF) load_elf(ELF, 0, NULL, 0);
 extern void load_elf(const char *elf_path, int reboot_iop, char** Cargs, int Cargc);
 extern size_t GetFreeSize(void);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -4,6 +4,9 @@
 #include <sys/fcntl.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <errno.h>
+#define NEWLIB_PORT_AWARE
+#include <fileXio_rpc.h>
 #include "include/luaplayer.h"
 #include "include/md5.h"
 #include "include/graphics.h"
@@ -345,6 +348,15 @@ static int lua_sleep(lua_State *L)
 	return 0;
 }
 
+static int lua_sleep_ms(lua_State *L)
+{
+	if (lua_gettop(L) != 1) return luaL_error(L, "milliseconds expected.");
+	int ms = luaL_checkinteger(L, 1);
+	if (ms < 0) ms = 0;
+	usleep((useconds_t)ms * 1000);
+	return 0;
+}
+
 static int lua_getFreeMemory(lua_State *L)
 {
 	if (lua_gettop(L) != 0) return luaL_error(L, "no arguments expected.");
@@ -364,6 +376,15 @@ static int lua_exit(lua_State *L)
             "syscall;"
             "nop;"
         );
+	return 0;
+}
+
+static int lua_dprintf(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "System.dprintf(text) expects one string");
+	const char *text = luaL_checkstring(L, 1);
+	dbgprintf("%s", text);
 	return 0;
 }
 
@@ -417,6 +438,19 @@ static int lua_openfile(lua_State *L){
 	if (fileHandle < 0) return luaL_error(L, "cannot open '%s'\n\tfd:%d.", file_tbo, fileHandle);
 	lua_pushinteger(L,fileHandle);
 	return 1;
+}
+
+static int lua_openfile_raw(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 2) return luaL_error(L, "wrong number of arguments");
+	const char *file_tbo = luaL_checkstring(L, 1);
+	int type = luaL_checkinteger(L, 2);
+	errno = 0;
+	int fileHandle = open(file_tbo, type, 0644);
+	int err = errno;
+	lua_pushinteger(L, fileHandle);
+	lua_pushinteger(L, err);
+	return 2;
 }
 
 
@@ -486,6 +520,117 @@ static int lua_checkexist(lua_State *L){
 		close(fileHandle);
 		lua_pushboolean(L,true);
 	}
+	return 1;
+}
+
+static int lua_filexio_getstat(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
+	const char *path = luaL_checkstring(L, 1);
+	iox_stat_t stat;
+	memset(&stat, 0, sizeof(stat));
+	int ret = fileXioGetStat(path, &stat);
+	lua_pushinteger(L, ret);
+	lua_pushinteger(L, (ret == 0) ? (lua_Integer)stat.size : 0);
+	return 2;
+}
+
+static int lua_filexio_dopen(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
+	const char *path = luaL_checkstring(L, 1);
+	int fd = fileXioDopen(path);
+	lua_pushinteger(L, fd);
+	return 1;
+}
+
+static int lua_filexio_dclose(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
+	int fd = luaL_checkinteger(L, 1);
+	int ret = fileXioDclose(fd);
+	lua_pushinteger(L, ret);
+	return 1;
+}
+
+static int lua_filexio_open(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 2 && argc != 3) return luaL_error(L, "wrong number of arguments");
+	const char *path = luaL_checkstring(L, 1);
+	int flags = luaL_checkinteger(L, 2);
+	int mode = 0;
+	if (argc == 3) {
+		mode = luaL_checkinteger(L, 3);
+	}
+	int fd = fileXioOpen(path, flags, mode);
+	lua_pushinteger(L, fd);
+	return 1;
+}
+
+static int lua_filexio_read(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 2) return luaL_error(L, "wrong number of arguments");
+	int fd = luaL_checkinteger(L, 1);
+	int size = luaL_checkinteger(L, 2);
+	if (size < 0) size = 0;
+	uint8_t *buffer = (uint8_t*)malloc((size_t)size + 1);
+	if (buffer == NULL) return luaL_error(L, "out of memory");
+	int len = fileXioRead(fd, buffer, size);
+	if (len < 0) {
+		free(buffer);
+		lua_pushnil(L);
+		lua_pushinteger(L, len);
+		return 2;
+	}
+	buffer[len] = 0;
+	lua_pushlstring(L, (const char*)buffer, len);
+	free(buffer);
+	lua_pushinteger(L, len);
+	return 2;
+}
+
+static int lua_filexio_close(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
+	int fd = luaL_checkinteger(L, 1);
+	int ret = fileXioClose(fd);
+	lua_pushinteger(L, ret);
+	return 1;
+}
+
+static int lua_derive_base_dir(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
+	size_t path_len = 0;
+	const char *path = luaL_checklstring(L, 1, &path_len);
+	size_t out_sz = path_len + 3;
+	char *out = (char*)malloc(out_sz);
+	if (out == NULL) return luaL_error(L, "out of memory");
+	if (!derive_base_dir(path, out, out_sz)) {
+		free(out);
+		return luaL_error(L, "derive_base_dir failed for '%s'", path);
+	}
+	lua_pushstring(L, out);
+	free(out);
+	return 1;
+}
+
+static int lua_resolve_local(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc != 2) return luaL_error(L, "wrong number of arguments");
+	size_t base_len = 0;
+	size_t file_len = 0;
+	const char *base_dir = luaL_checklstring(L, 1, &base_len);
+	const char *filename = luaL_checklstring(L, 2, &file_len);
+	size_t out_sz = base_len + file_len + 1;
+	char *out = (char*)malloc(out_sz);
+	if (out == NULL) return luaL_error(L, "out of memory");
+	if (!resolve_local(base_dir, filename, out, out_sz)) {
+		free(out);
+		return luaL_error(L, "resolve_local failed for '%s' + '%s'", base_dir, filename);
+	}
+	lua_pushstring(L, out);
+	free(out);
 	return 1;
 }
 extern "C" {
@@ -705,11 +850,20 @@ static int lua_popargv0(lua_State *L) {
 
 static const luaL_Reg System_functions[] = {
 	{"openFile",                   lua_openfile},
+	{"openFileRaw",                lua_openfile_raw},
 	{"readFile",                   lua_readfile},
 	{"writeFile",                 lua_writefile},
 	{"closeFile",                 lua_closefile},  
 	{"seekFile",                   lua_seekfile},  
 	{"sizeFile",                   lua_sizefile},
+	{"fileXioGetStat",             lua_filexio_getstat},
+	{"fileXioDopen",               lua_filexio_dopen},
+	{"fileXioDclose",              lua_filexio_dclose},
+	{"fileXioOpen",                lua_filexio_open},
+	{"fileXioRead",                lua_filexio_read},
+	{"fileXioClose",               lua_filexio_close},
+	{"deriveBaseDir",              lua_derive_base_dir},
+	{"resolveLocal",               lua_resolve_local},
 	//{"doesFileExist",            lua_checkexist}, BREAKS ERROR HANDLING IF DECLARED INSIDE TABLE. DONT ASK ME WHY
 	{"currentDirectory",             lua_curdir},
 	{"listDirectory",           	    lua_dir},
@@ -723,8 +877,10 @@ static const luaL_Reg System_functions[] = {
 	{"rename",                       lua_rename},
 	{"md5sum",                       lua_md5sum},
 	{"sleep",                         lua_sleep},
+	{"sleepMs",                     lua_sleep_ms},
 	{"getFreeMemory",         lua_getFreeMemory},
 	{"exitToBrowser",                  lua_exit},
+	{"dprintf",                     lua_dprintf},
 	{"getMCInfo",                 lua_getmcinfo},
 	{"loadELF",                 	lua_loadELF},
 	{"checkValidDisc",       lua_checkValidDisc},

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -185,6 +185,79 @@ bool join_path(char *out, size_t outsz, const char *root, const char *rel)
 	return true;
 }
 
+bool derive_base_dir(const char *boot_path, char *out, size_t out_sz)
+{
+	if (out == NULL || out_sz == 0) {
+		return false;
+	}
+	out[0] = '\0';
+
+	if (boot_path == NULL || boot_path[0] == '\0') {
+		return false;
+	}
+
+	const char *colon = strchr(boot_path, ':');
+	const char *last_slash = strrchr(boot_path, '/');
+
+	if (colon == NULL) {
+		if (last_slash == NULL) {
+			return false;
+		}
+		size_t len = (size_t)(last_slash - boot_path + 1);
+		if (len >= out_sz) {
+			len = out_sz - 1;
+		}
+		memcpy(out, boot_path, len);
+		out[len] = '\0';
+		return true;
+	}
+
+	size_t dev_len = (size_t)(colon - boot_path);
+	if (dev_len + 2 >= out_sz) {
+		return false;
+	}
+
+	memcpy(out, boot_path, dev_len);
+	out[dev_len] = ':';
+	out[dev_len + 1] = '/';
+	size_t written = dev_len + 2;
+
+	const char *rest_start = (colon[1] == '/') ? colon + 2 : colon + 1;
+	if (last_slash == NULL || last_slash < rest_start) {
+		out[written] = '\0';
+		return true;
+	}
+
+	size_t rest_len = (size_t)(last_slash - rest_start + 1);
+	if (written + rest_len >= out_sz) {
+		rest_len = out_sz - written - 1;
+	}
+
+	memcpy(out + written, rest_start, rest_len);
+	written += rest_len;
+	out[written] = '\0';
+	return true;
+}
+
+bool resolve_local(const char *base_dir, const char *filename, char *out, size_t out_sz)
+{
+	if (out == NULL || out_sz == 0) {
+		return false;
+	}
+	out[0] = '\0';
+
+	if (base_dir == NULL || filename == NULL) {
+		return false;
+	}
+
+	int written = snprintf(out, out_sz, "%s%s", base_dir, filename);
+	if (written < 0 || (size_t)written >= out_sz) {
+		out[0] = '\0';
+		return false;
+	}
+	return true;
+}
+
 
 void IOP_Reset(void)
 {


### PR DESCRIPTION
### Motivation
- Enforce the exact POPS probe sequence requested (`mmce1:/ -> mmce0:/ -> mmce1:/ -> mmce0:/ -> mass:/ -> mass0:/ -> mass1:/ -> mass2:/ -> mass3:/ -> mass:/ -> mass0:/`) so device scanning behaves deterministically. 
- Provide clearer diagnostics to the user by surfacing the specific device that was last probed when no `POPS/` folder is found. 
- Harden boot-time file operations against transient device readiness and I/O errors by adding readiness checks, retries, lower-level `fileXio` usage, and fatal diagnostics for unrecoverable failures. 

### Description
- Update `etc/boot.lua` to use `deriveBaseDir` for dependency base resolution, add `wait_for_ready`, `open_with_retry`, and `emit_fatal`, and replace ad-hoc device discovery with `find_pops_device` that probes the exact ordered sequence above and returns the selected root; boot now loads `system.lua` using `fileXio` reads and retries with fatal UI on failure. 
- Mirror the new probe sequence in `bin/system.lua` by setting `POPS_DEVICE_ORDER` to the requested order and add `PLDR_LAST_POPS_DEVICE` tracking so the last attempted candidate is recorded during `PLDR.FindPopsRoot`. 
- Update `bin/ui.lua` to show a targeted message `No POPS Folder Found on <device>` using `PLDR_LAST_POPS_DEVICE` when scanning fails. 
- Add/expand native helpers and Lua bindings included in the codebase: declare and implement `derive_base_dir` and `resolve_local` in `src/include/system.h`/`src/system.cpp`, and extend `src/luasystem.cpp` with `fileXio*` wrappers, `deriveBaseDir`/`resolveLocal`, `sleepMs`, `dprintf`, `openFileRaw`, and related helpers so Lua can reliably stat/open/read files via the lower-level API. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f2155ca48321beb1518d25350f8d)