### PR TITLE
Trigger IOP reset before loading ELF

### DIFF
--- a/src/include/system.h
+++ b/src/include/system.h
@@ -24,6 +24,7 @@ extern bool is_valid_root(const char *root);
 extern void normalize_device_path(char *path);
 extern bool derive_base_dir(const char *boot_path, char *out, size_t out_sz);
 extern bool resolve_local(const char *base_dir, const char *filename, char *out, size_t out_sz);
+extern void CleanUp(int iop_reset);
 #define load_elf_NoIOPReset(ELF) load_elf(ELF, 0, NULL, 0);
 extern void load_elf(const char *elf_path, int reboot_iop, char** Cargs, int Cargc);
 extern size_t GetFreeSize(void);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -664,6 +664,8 @@ static int lua_loadELF(lua_State *L)
 	}
 	if (rebootIOP) {
 		CleanUp(rebootIOP);
+		SifInitRpc(0);
+		SifLoadFileInit();
 	}
 	//load_elf(elftoload, rebootIOP, p, (argc-1));
 	LoadELFFromFile(elftoload, argc-2, p);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -662,6 +662,9 @@ static int lua_loadELF(lua_State *L)
 		printf("#  argv[%d] = '%s'\n", (x-3), luaL_checkstring(L, x));
 		p[x-3] = (char*)luaL_checkstring(L, x);
 	}
+	if (rebootIOP) {
+		CleanUp(rebootIOP);
+	}
 	//load_elf(elftoload, rebootIOP, p, (argc-1));
 	LoadELFFromFile(elftoload, argc-2, p);
 	return 1;


### PR DESCRIPTION
### Motivation
- Ensure an IOP reboot is performed when GUI-triggered ELF/file executions request it to avoid stale IOP state before launching payloads.

### Description
- Call `CleanUp(rebootIOP)` in `lua_loadELF` before invoking `LoadELFFromFile`, and export `CleanUp` in `src/include/system.h` so the Lua binding can request the IOP reset.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685443b1f48321a621721da791dd24)