### PR TITLE
Fix ELF loading when rebooting the IOP

### DIFF
--- a/bin/system.lua
+++ b/bin/system.lua
@@ -12,56 +12,23 @@
   Licensed under GNU General public license v3.0
 --]]
 LOG(System.currentDirectory())
-do
-  local IRXDIR = System.listDirectory(".")
+if doesFolderExist("POPSLDR/IRX/") then
+  local IRXDIR = System.listDirectory("POPSLDR/IRX/")
   if IRXDIR ~= nil then
+    LOG("Found IRX folder")
     for x=1, #IRXDIR do
-      if string.lower(string.sub(IRXDIR[x].name, -4)) == ".irx" then
-        local ID, RET = IOP.loadModule(IRXDIR[x].name)
-        LOG(IRXDIR[x].name, ID, RET)
+      if string.lower(string.sub(IRXDIR[i].name,-4)) == ".irx" then
+        local ID, RET = IOP.loadModule(IRXDIR[x])
+        LOG(IRXDIR[x], ID, RET)
       end
     end
   end
 end
-local function resolvePreferredPath(relative_path)
-  local candidate = JoinPath(BOOT_PATH or System.currentDirectory(), relative_path)
-  if doesFileExist(candidate) then return candidate end
-  return candidate
-end
-
-ResolvePreferredPath = resolvePreferredPath
-
-local POPS_DEVICE_ORDER = {}
-local mmce_devices = {"mmce1:/POPS/", "mmce0:/POPS/"}
-local mass_devices = {"mass:/POPS/", "mass0:/POPS/", "mass1:/POPS/", "mass2:/POPS/", "mass3:/POPS/"}
-local mass_retry_devices = {"mass:/POPS/", "mass0:/POPS/"}
-
-for _ = 1, 2 do
-  for _, dev in ipairs(mmce_devices) do
-    table.insert(POPS_DEVICE_ORDER, dev)
-  end
-end
-for _, dev in ipairs(mass_devices) do
-  table.insert(POPS_DEVICE_ORDER, dev)
-end
-for _, dev in ipairs(mass_retry_devices) do
-  table.insert(POPS_DEVICE_ORDER, dev)
-end
-
-PLDR_LAST_POPS_DEVICE = nil
-
-local function canOpenDir(path)
-  local ok, result = pcall(System.listDirectory, path)
-  return ok and type(result) == "table"
-end
-
-local POPS_ROOT = BOOT_DEVICE_ROOT and (BOOT_DEVICE_ROOT.."POPS/") or "mass0:/POPS/"
-
 PLDR = {
-  REBOOT_IOP_WHILE_LOADING_POPSTARTER = 1;
-  POPSTARTER_PATH = resolvePreferredPath("POPSTARTER.ELF");
+  REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
+  POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
   CHECK_POPSTARTER_FILES = false;
-  GAMEPATH = POPS_ROOT;
+  GAMEPATH = ".";
   GAMES = {};
   HDDCACHE = nil;
   PROFILES = {};
@@ -75,24 +42,10 @@ PLDR = {
     HAS_CHECKED_DEPS = false;
     STATUS = 3
   };
+  USB = {
+    MASSINDX = 0
+  }
 }
-
-function PLDR.FindPopsRoot()
-  if BOOT_DEVICE_ROOT then
-    local candidate = BOOT_DEVICE_ROOT.."POPS/"
-    PLDR_LAST_POPS_DEVICE = candidate
-    if canOpenDir(candidate) then
-      return candidate
-    end
-  end
-  for _, root in ipairs(POPS_DEVICE_ORDER) do
-    PLDR_LAST_POPS_DEVICE = root
-    if canOpenDir(root) then
-      return root
-    end
-  end
-  return nil
-end
 if BOOTPATH ~= nil then
   PLDR.HDD.LOADSTATE = 1
   PLDR.HDD.STATUS = HDD.GetHDDStatus()
@@ -128,11 +81,7 @@ end
 function PLDR.CheckPOPStarterDEPS(device)
   if not PLDR.CHECK_POPSTARTER_FILES then return true, true, true end
   if device == UI.SCENES.GUSB then
-    local root = PLDR.FindPopsRoot()
-    if root == nil then
-      return false, false, false
-    end
-    return doesFileExist(JoinPath(root, "POPS_IOX.PAK"))
+    return doesFileExist("mass:/POPS/POPS_IOX.PAK")
   elseif device == UI.SCENES.GHDD then
     local a = HDD.MountPartition("hdd0:__common", 1, FIO_MT_RDONLY)
     if a then
@@ -284,7 +233,7 @@ end
 function PLDR.HDD.CreateCache()
   if not PLDR.HDD.USECACHE then return end
   LOG("> HDD Cache Create")
-  local C = "hdd_gamecache.lua"
+  local C = "POPSLDR/hdd_gamecache.lua"
   local temp = "LOG(\">HDD CACHE LOAD\")\nPLDR.HDDCACHE = {\n"
   PLDR.HDD.BuildGameList()
   for i = 1, #PLDR.GAMES do
@@ -299,7 +248,7 @@ end
 
 function PLDR.HDD.ReadCache()
   LOG("> HDD Cache Read")
-  local C = "hdd_gamecache.lua"
+  local C = "POPSLDR/hdd_gamecache.lua"
   if doesFileExist(C) then
     dofile(C)
     PLDR.HDD.HAS_CHECKED = true
@@ -308,7 +257,7 @@ end
 
 function PLDR.HDD.WipeCache(CACHE)
   LOG("> HDD Cache Wipe")
-  local C = "hdd_gamecache.lua"
+  local C = "POPSLDR/hdd_gamecache.lua"
   if doesFileExist(C) then
     System.removeFile(C)
     PLDR.HDD.HAS_CHECKED = false
@@ -341,7 +290,7 @@ end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 UI.WelcomeDraw.Play()
-if Touch(".pldrs") then
+if Touch("POPSLDR/.pldrs") then
   UI.CURSCENE = UI.SCENES.CREDITS
 end
 

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -14,11 +14,20 @@
 LOG(System.currentDirectory())
 do
   local IRXDIR = System.listDirectory(".")
+  local has_irx = false
   if IRXDIR ~= nil then
     for x=1, #IRXDIR do
       if string.lower(string.sub(IRXDIR[x].name, -4)) == ".irx" then
-        local ID, RET = IOP.loadModule(IRXDIR[x].name)
-        LOG(IRXDIR[x].name, ID, RET)
+        has_irx = true
+        break
+      end
+    end
+    if has_irx then
+      for x=1, #IRXDIR do
+        if string.lower(string.sub(IRXDIR[x].name, -4)) == ".irx" then
+          local ID, RET = IOP.loadModule(IRXDIR[x].name)
+          LOG(IRXDIR[x].name, ID, RET)
+        end
       end
     end
   end

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -12,23 +12,55 @@
   Licensed under GNU General public license v3.0
 --]]
 LOG(System.currentDirectory())
-if doesFolderExist("POPSLDR/IRX/") then
-  local IRXDIR = System.listDirectory("POPSLDR/IRX/")
+do
+  local IRXDIR = System.listDirectory(".")
   if IRXDIR ~= nil then
-    LOG("Found IRX folder")
     for x=1, #IRXDIR do
-      if string.lower(string.sub(IRXDIR[i].name,-4)) == ".irx" then
-        local ID, RET = IOP.loadModule(IRXDIR[x])
-        LOG(IRXDIR[x], ID, RET)
+      if string.lower(string.sub(IRXDIR[x].name, -4)) == ".irx" then
+        local ID, RET = IOP.loadModule(IRXDIR[x].name)
+        LOG(IRXDIR[x].name, ID, RET)
       end
     end
   end
 end
+local function resolvePreferredPath(relative_path)
+  local candidate = JoinPath(BOOT_PATH or System.currentDirectory(), relative_path)
+  if doesFileExist(candidate) then return candidate end
+  return candidate
+end
+
+ResolvePreferredPath = resolvePreferredPath
+
+local POPS_DEVICE_ORDER = {}
+local mmce_devices = {"mmce1:/POPS/", "mmce0:/POPS/"}
+local mass_devices = {"mass:/POPS/", "mass0:/POPS/", "mass1:/POPS/", "mass2:/POPS/", "mass3:/POPS/"}
+local mass_retry_devices = {"mass:/POPS/", "mass0:/POPS/"}
+
+for _ = 1, 2 do
+  for _, dev in ipairs(mmce_devices) do
+    table.insert(POPS_DEVICE_ORDER, dev)
+  end
+end
+for _, dev in ipairs(mass_devices) do
+  table.insert(POPS_DEVICE_ORDER, dev)
+end
+for _, dev in ipairs(mass_retry_devices) do
+  table.insert(POPS_DEVICE_ORDER, dev)
+end
+
+PLDR_LAST_POPS_DEVICE = nil
+
+local function canOpenDir(path)
+  local ok, result = pcall(System.listDirectory, path)
+  return ok and type(result) == "table"
+end
+
+local POPS_ROOT = BOOT_DEVICE_ROOT and (BOOT_DEVICE_ROOT.."POPS/") or "mass0:/POPS/"
 PLDR = {
-  REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
-  POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
+  REBOOT_IOP_WHILE_LOADING_POPSTARTER = 1;
+  POPSTARTER_PATH = resolvePreferredPath("POPSTARTER.ELF");
   CHECK_POPSTARTER_FILES = false;
-  GAMEPATH = ".";
+  GAMEPATH = POPS_ROOT;
   GAMES = {};
   HDDCACHE = nil;
   PROFILES = {};
@@ -42,10 +74,24 @@ PLDR = {
     HAS_CHECKED_DEPS = false;
     STATUS = 3
   };
-  USB = {
-    MASSINDX = 0
-  }
 }
+
+function PLDR.FindPopsRoot()
+  if BOOT_DEVICE_ROOT then
+    local candidate = BOOT_DEVICE_ROOT.."POPS/"
+    PLDR_LAST_POPS_DEVICE = candidate
+    if canOpenDir(candidate) then
+      return candidate
+    end
+  end
+  for _, root in ipairs(POPS_DEVICE_ORDER) do
+    PLDR_LAST_POPS_DEVICE = root
+    if canOpenDir(root) then
+      return root
+    end
+  end
+  return nil
+end
 if BOOTPATH ~= nil then
   PLDR.HDD.LOADSTATE = 1
   PLDR.HDD.STATUS = HDD.GetHDDStatus()
@@ -81,7 +127,11 @@ end
 function PLDR.CheckPOPStarterDEPS(device)
   if not PLDR.CHECK_POPSTARTER_FILES then return true, true, true end
   if device == UI.SCENES.GUSB then
-    return doesFileExist("mass:/POPS/POPS_IOX.PAK")
+    local root = PLDR.FindPopsRoot()
+    if root == nil then
+      return false, false, false
+    end
+    return doesFileExist(JoinPath(root, "POPS_IOX.PAK"))
   elseif device == UI.SCENES.GHDD then
     local a = HDD.MountPartition("hdd0:__common", 1, FIO_MT_RDONLY)
     if a then
@@ -233,7 +283,7 @@ end
 function PLDR.HDD.CreateCache()
   if not PLDR.HDD.USECACHE then return end
   LOG("> HDD Cache Create")
-  local C = "POPSLDR/hdd_gamecache.lua"
+  local C = "hdd_gamecache.lua"
   local temp = "LOG(\">HDD CACHE LOAD\")\nPLDR.HDDCACHE = {\n"
   PLDR.HDD.BuildGameList()
   for i = 1, #PLDR.GAMES do
@@ -248,7 +298,7 @@ end
 
 function PLDR.HDD.ReadCache()
   LOG("> HDD Cache Read")
-  local C = "POPSLDR/hdd_gamecache.lua"
+  local C = "hdd_gamecache.lua"
   if doesFileExist(C) then
     dofile(C)
     PLDR.HDD.HAS_CHECKED = true
@@ -257,7 +307,7 @@ end
 
 function PLDR.HDD.WipeCache(CACHE)
   LOG("> HDD Cache Wipe")
-  local C = "POPSLDR/hdd_gamecache.lua"
+  local C = "hdd_gamecache.lua"
   if doesFileExist(C) then
     System.removeFile(C)
     PLDR.HDD.HAS_CHECKED = false
@@ -290,7 +340,7 @@ end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 UI.WelcomeDraw.Play()
-if Touch("POPSLDR/.pldrs") then
+if Touch(".pldrs") then
   UI.CURSCENE = UI.SCENES.CREDITS
 end
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -32,6 +32,7 @@ end
 JoinPath = joinPath
 
 local DEVICE_READY_TIMEOUT_MS = 2000
+local POPS_SCAN_TIMEOUT_MS = 250
 local DEVICE_READY_SLEEP_MS = 100
 
 local function emit_fatal(message)
@@ -109,7 +110,7 @@ local function find_pops_device()
   end
   for _, root in ipairs(roots) do
     local path = root.."POPS/"
-    local ready_ok, _ = wait_for_ready(path, DEVICE_READY_TIMEOUT_MS)
+    local ready_ok, _ = wait_for_ready(path, POPS_SCAN_TIMEOUT_MS)
     if ready_ok then
       local dopen_ret = System.fileXioDopen(path)
       if dopen_ret >= 0 then

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -27,7 +27,7 @@ int getBootDevice(void);
 
 extern size_t GetFreeSize(void);
 
-extern const char * runScript(const char* script, bool isStringBuffer);
+extern const char * runScript(const char* script, bool isStringBuffer, size_t buffer_len);
 extern void luaC_collectgarbage (lua_State *L);
 
 //extern void luaSound_init(lua_State *L);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -81,7 +81,7 @@ int test_error(lua_State * L) {
     return 0;
 }
 
-const char * runScript(const char* script, bool isStringBuffer )
+const char * runScript(const char* script, bool isStringBuffer, size_t buffer_len)
 {	
     DPRINTF("Creating luaVM... \n");
 
@@ -113,10 +113,11 @@ const char * runScript(const char* script, bool isStringBuffer )
 	int s = 0;
 	static char errMsg[512];
 
-	if(!isStringBuffer) s = luaL_loadfile(L, script);
-	else {
-    s = luaL_loadbuffer(L, script, strlen(script), NULL);
-  }
+	if(!isStringBuffer) {
+		s = luaL_loadfile(L, script);
+	} else {
+		s = luaL_loadbuffer(L, script, buffer_len, NULL);
+	}
 
 		
 	if (s == 0) s = lua_pcall(L, 0, LUA_MULTRET, 0);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -111,7 +111,7 @@ const char * runScript(const char* script, bool isStringBuffer )
 	}
 
 	int s = 0;
-	const char * errMsg =(const char*)malloc(sizeof(char)*512);
+	static char errMsg[512];
 
 	if(!isStringBuffer) s = luaL_loadfile(L, script);
 	else {
@@ -122,11 +122,11 @@ const char * runScript(const char* script, bool isStringBuffer )
 	if (s == 0) s = lua_pcall(L, 0, LUA_MULTRET, 0);
 
 	if (s) {
-		sprintf((char*)errMsg, "%s\n", lua_tostring(L, -1));
-    DPRINTF("%s\n", lua_tostring(L, -1));
+		snprintf(errMsg, sizeof(errMsg), "%s\n", lua_tostring(L, -1));
+		DPRINTF("%s\n", lua_tostring(L, -1));
 		lua_pop(L, 1); // remove error message
 	}
 	lua_close(L);
-	
-	return errMsg;
+
+	return s ? errMsg : NULL;
 }

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1062,7 +1062,8 @@ void luaSystem_init(lua_State *L) {
 	lua_pushboolean(L, g_mmce_available != 0);
 	lua_setglobal(L, "MMCE_AVAILABLE");
 
-	lua_pushlstring(L, (const char *)systemString, (size_t)size_systemString);
+	size_t system_len = strnlen((const char *)systemString, (size_t)size_systemString);
+	lua_pushlstring(L, (const char *)systemString, system_len);
 	lua_setglobal(L, "SYSTEM_LUA");
 
 	

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -672,38 +672,12 @@ static int lua_loadELF(lua_State *L)
 		printf("#  argv[%d] = '%s'\n", x, luaL_checkstring(L, lua_index));
 		p[x] = (char*)luaL_checkstring(L, lua_index);
 	}
-	if (rebootIOP) {
-		int loader_argc = extra_argc + 1;
-		char **loader_argv = (char**)malloc(loader_argc * sizeof(char*));
-		if (loader_argv == NULL) {
-			free(p);
-			return luaL_error(L, "out of memory");
-		}
-		loader_argv[0] = (char*)elftoload;
-		for (int i = 0; i < extra_argc; i++) {
-			loader_argv[i + 1] = p[i];
-		}
-		load_elf(elftoload, rebootIOP, loader_argv, loader_argc);
-		free(loader_argv);
-		// If load_elf returns, attempt to restore services for error reporting.
-		CleanUp(rebootIOP);
-		SifInitRpc(0);
-		sbv_patch_fileio();
-		int ret = 0;
-		SifExecModuleBuffer(iomanX_irx, size_iomanX_irx, 0, NULL, &ret);
-		SifExecModuleBuffer(fileXio_irx, size_fileXio_irx, 0, NULL, &ret);
-		fileXioInit();
-		SifLoadFileInit();
-		free(p);
-		return luaL_error(L, "load_elf returned unexpectedly");
-	} else {
-		int load_result = LoadELFFromFile(elftoload, extra_argc, p);
-		free(p);
-		if (load_result < 0) {
-			return luaL_error(L, "LoadELFFromFile failed: %d", load_result);
-		}
-		return 1;
+	int load_result = LoadELFFromFile(elftoload, extra_argc, p);
+	free(p);
+	if (load_result < 0) {
+		return luaL_error(L, "LoadELFFromFile failed: %d", load_result);
 	}
+	return 1;
 }
 
 DiscType DiscTypes[] = {

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -685,10 +685,7 @@ static int lua_loadELF(lua_State *L)
 		}
 		load_elf(elftoload, rebootIOP, loader_argv, loader_argc);
 		free(loader_argv);
-	} else {
-		LoadELFFromFile(elftoload, extra_argc, p);
-	}
-	if (rebootIOP) {
+		// If load_elf returns, attempt to restore services for error reporting.
 		CleanUp(rebootIOP);
 		SifInitRpc(0);
 		sbv_patch_fileio();
@@ -697,14 +694,16 @@ static int lua_loadELF(lua_State *L)
 		SifExecModuleBuffer(fileXio_irx, size_fileXio_irx, 0, NULL, &ret);
 		fileXioInit();
 		SifLoadFileInit();
+		free(p);
+		return luaL_error(L, "load_elf returned unexpectedly");
+	} else {
+		int load_result = LoadELFFromFile(elftoload, extra_argc, p);
+		free(p);
+		if (load_result < 0) {
+			return luaL_error(L, "LoadELFFromFile failed: %d", load_result);
+		}
+		return 1;
 	}
-	//load_elf(elftoload, rebootIOP, p, (argc-1));
-	int load_result = LoadELFFromFile(elftoload, argc-2, p);
-	free(p);
-	if (load_result < 0) {
-		return luaL_error(L, "LoadELFFromFile failed: %d", load_result);
-	}
-	return 1;
 }
 
 DiscType DiscTypes[] = {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,7 +347,14 @@ int main(int argc, char * argv[])
 
     LOAD_IRX_NARG(audsrv_irx);
 
-    const char *preferred_device = detectPreferredDevice();
+    const char *preferred_device = kDefaultDevice;
+    bool needs_device_probe = true;
+    if (argc > 0 && argv[0] != NULL && hasDevicePrefix(argv[0])) {
+        needs_device_probe = false;
+    }
+    if (needs_device_probe) {
+        preferred_device = detectPreferredDevice();
+    }
     char normalized_root[16];
     normalize_root(preferred_device, normalized_root, sizeof(normalized_root));
     DPRINTF("Preferred device: %s\n", preferred_device);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,7 +380,7 @@ int main(int argc, char * argv[])
     
     while (1)
     {
-        errMsg = runScript(bootString, true);
+        errMsg = runScript(bootString, true, size_bootString);
 
         init_scr();
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -80,6 +80,12 @@ void normalize_device_path(char *path)
 		return;
 	}
 
+	if (!strncmp(path, "mc:", 3) && (path[3] == '0' || path[3] == '1')) {
+		char slot = path[3];
+		path[2] = slot;
+		path[3] = ':';
+	}
+
 	for (int i = 0; path[i] != '\0'; ++i) {
 		if (path[i] == '/' && path[i + 1] == '/') {
 			memmove(&path[i], &path[i + 1], strlen(&path[i + 1]) + 1);


### PR DESCRIPTION
### Motivation
- The IOP-reboot ELF launch path could return unexpectedly and leave file I/O / RPC services in an inconsistent state, which can manifest as a black screen when launching games.
- The previous flow risked double-loading or redundant cleanup and did not explicitly restore services only in the error case as required by the IOP lifecycle guidance.
- Make the initialization/cleanup ordering explicit and restore minimal services only when `load_elf` returns, to allow proper error reporting and avoid hidden breakages.

### Description
- Update `lua_loadELF` in `src/luasystem.cpp` to treat `load_elf` as a non-returning path and only reinitialize IOP/file I/O services if it returns unexpectedly, restoring `SifInitRpc`, `fileXio` modules and calling `CleanUp` before returning a Lua error via `luaL_error`.
- Change the non-reboot branch to call `LoadELFFromFile` directly and propagate failures immediately while ensuring allocated memory (`p`) is freed in all paths.
- Remove the previous duplicated service reinitialization that ran unconditionally after the `rebootIOP` branch to avoid redundant or out-of-order cleanup operations.

### Testing
- No automated tests were run for this change.
- Manual verification is recommended: build and exercise the reboot and non-reboot ELF launch paths and confirm that services are reinitialized only on error returns from `load_elf` and that Lua receives a clear error when `load_elf` returns unexpectedly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fdc9e1e48321af5831b06613b7c4)