### PR TITLE
Add documentation and roadmap links; update README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md (popsplay)
+
+## 1) Project identity
+POPSLoader is an open-source launcher for POPStarter, scripted in Lua and based on the Enceladus project.【F:README.md†L1-L4】
+
+## 2) Branch + scope notes
+- This guidance is written for branch: `popsplay`.
+- Do **not** assume behavior not found in code or repo text; label unknowns as **TODO: verify** and point to where to verify.
+
+## 3) Build + environment
+**Toolchain / assumptions (from repo):**
+- PS2DEV/ps2sdk toolchain is required; build uses `PS2SDK`, `PS2DEV`, `ps2-packer`, and `bin2c`.【F:Makefile†L30-L48】【F:Makefile†L41-L49】
+
+**Build commands / targets:**
+- `make all` → builds `bin/POPSLOADER.ELF`.【F:Makefile†L61-L69】
+- `make elfloader` → builds `src/elf_loader/libcustom-elf-loader.a`.【F:Makefile†L107-L112】
+- `make package` → creates `POPSLoader.7z` with runtime assets and docs.【F:Makefile†L132-L135】
+- CI uses: `make clean elfloader all package`.【F:.github/workflows/compilation.yml†L23-L28】
+
+**Output artifacts:**
+- `bin/enceladus.elf` (intermediate).【F:Makefile†L30-L33】
+- `bin/POPSLOADER.ELF` (packed release).【F:Makefile†L66-L69】
+- `POPSLoader.7z` (packaged archive).【F:Makefile†L132-L135】
+
+## 4) Repository map
+- `src/` — C/C++ source, including entrypoint `main.cpp` and Lua/graphics/pad subsystems.【F:src/main.cpp†L1-L22】
+- `modules/` — external modules (e.g., `ds34bt`, `ds34usb`) built as libs and IOP modules.【F:Makefile†L51-L60】【F:Makefile†L94-L106】
+- `etc/` — build-time Lua boot script (`boot.lua`) embedded into the ELF via bin2c.【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L60】
+- `docs/` — project docs site content (Jekyll config + index).【F:docs/index.md†L1-L40】【F:docs/_config.yml†L1-L1】
+- `iop/embed/` — embedded IOP module(s), e.g., `mmceman.irx`.【F:iop/embed/mmceman.irx†L1-L1】
+- `EMBED/` — PNG/TTF assets embedded into the binary at build time.【F:Makefile†L75-L79】
+- `bin/` — packaged runtime assets and POPSLDR scripts (`bin/POPSLDR/*`), plus `bin/changelog`.【F:Makefile†L132-L135】【F:bin/POPSLDR/system.lua†L1-L11】
+- `samples/` — sample Lua content (e.g., `fractal.lua`, `helloworld.lua`).【F:samples/fractal.lua†L1-L1】
+- `.github/workflows/` — CI build definition for packaging artifacts.【F:.github/workflows/compilation.yml†L1-L35】
+
+## 5) Runtime invariants (critical)
+**Device path rules (as evidenced in code):**
+- Lua search paths include `mass:/POPSLDR/?.lua`, `mc0:/POPSLDR/?.lua`, and `mc1:/POPSLDR/?.lua`.【F:etc/boot.lua†L1-L1】
+- `main.cpp` patches `mass:/` paths by removing an extra slash (`mass:/X` → `mass:X`).【F:src/main.cpp†L88-L96】
+- Memory card paths (`mc0:`/`mc1:`) are treated specially in directory listing logic.【F:src/luasystem.cpp†L64-L123】
+- TODO: verify `mmce0:/` usage. `mmceman.irx` is embedded, but device path usage is not shown in the reviewed code; inspect other Lua scripts or C/C++ modules for explicit usage.【F:iop/embed/mmceman.irx†L1-L1】
+
+**POPS folder expectations (only when present in code/docs):**
+- Default POPStarter path is `mass:/POPS/POPSTARTER.ELF` in `system.lua`.【F:bin/POPSLDR/system.lua†L25-L27】
+- POPStarter dependencies are checked under `mass:/POPS/` for USB and `pfs1:/POPS/` for HDD when enabled.【F:bin/POPSLDR/system.lua†L63-L74】
+- Usage docs instruct placing `POPSLOADER.ELF` and the `POPSLDR/` folder at USB or internal HDD root.【F:README.md†L6-L7】
+
+**Asset layout expectations (current):**
+- Runtime scripts are expected under `POPSLDR/` (e.g., `POPSLDR/system.lua`).【F:etc/boot.lua†L55-L60】
+- Packaged runtime assets live under `bin/POPSLDR/` in the repo/package.【F:Makefile†L132-L135】【F:bin/POPSLDR/system.lua†L1-L11】
+
+### Roadmap / active refactor goal
+- **No subfolder dependencies: assets should load from ELF directory first.**
+- **Keep compatibility fallback for legacy installs.**
+- Future changes must preserve fallback behavior unless it is intentionally removed and documented.
+
+## 6) Change discipline
+- Prefer a **central path helper** for device/path normalization (avoid re-implementing `mass:/` fixes or directory resolution in multiple places).【F:src/main.cpp†L65-L96】
+- Avoid scattering hardcoded paths; reference a single, testable source of truth (e.g., Lua config or a shared helper).【F:etc/boot.lua†L1-L60】
+- Logging/debugging: use existing debug output patterns (e.g., `DPRINTF` in C/C++ and `LOG/LOGF` in Lua) instead of introducing new styles.【F:src/main.cpp†L112-L126】【F:etc/boot.lua†L2-L7】
+- Keep diffs tight and testable: isolate functional changes, avoid unrelated reformatting, and update docs when runtime paths change.【F:README.md†L6-L10】
+
+## 7) Definition of done for PRs
+- Build succeeds in CI (target: `make clean elfloader all package`).【F:.github/workflows/compilation.yml†L23-L28】
+- Basic runtime smoke checks (without hardware):
+  - TODO: verify available emulator/scripted checks. Inspect `bin/POPSLDR/system.lua` and the sample Lua scripts for any lightweight runtime validations that can be run on a host or in PCSX2.【F:bin/POPSLDR/system.lua†L1-L200】【F:samples/fractal.lua†L1-L1】
+- Docs updated if runtime layout changes (e.g., `POPSLDR/` layout, POPStarter paths, or device path rules).【F:README.md†L6-L10】【F:etc/boot.lua†L1-L60】

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Branches and pull requests
+Use the standard GitHub fork/branch workflow described in the project documentation:
+1. Fork the project.
+2. Create your feature branch (`git checkout -b feature/MyChange`).
+3. Commit your changes.
+4. Push the branch and open a PR.【F:docs/index.md†L123-L131】
+
+## Style expectations (C/C++/Lua)
+- Match the existing style in the file you are editing (indentation, brace placement, naming, and logging conventions). For C/C++, see the formatting and `DPRINTF` usage in `src/main.cpp`.【F:src/main.cpp†L108-L126】
+- For Lua scripts, follow the conventions in `etc/boot.lua` and `bin/POPSLDR/system.lua` (indentation, function naming, and logging via `LOG`/`LOGF`).【F:etc/boot.lua†L2-L7】【F:bin/POPSLDR/system.lua†L1-L14】
+
+## What to include in PR descriptions
+Please include:
+- The build command you ran (e.g., `make all`, `make package`, or `make clean elfloader all package`) and any relevant output or errors.【F:Makefile†L61-L146】【F:.github/workflows/compilation.yml†L23-L28】
+- Any runtime checks you performed (device/emulator), including device type and logs. **TODO: verify preferred log format/location.**
+- If your change affects runtime layout, note the old vs. new layout and any compatibility fallbacks you preserved.【F:README.md†L6-L10】【F:etc/boot.lua†L1-L1】
+
+## How to run builds locally
+- Standard build: `make all` (produces `bin/POPSLOADER.ELF`).【F:Makefile†L61-L69】
+- Build with the ELF loader: `make elfloader` (builds `src/elf_loader/libcustom-elf-loader.a`).【F:Makefile†L107-L112】
+- Package release archive: `make package` (creates `POPSLoader.7z`).【F:Makefile†L132-L135】

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,26 @@
+# Development
+
+## Build prerequisites
+- PS2DEV/ps2sdk toolchain with `PS2SDK` and `PS2DEV` configured, and tools such as `ps2-packer` and `bin2c` available in the toolchain path.【F:Makefile†L30-L49】
+- Packaging requires `7z` (CI installs `p7zip`).【F:Makefile†L132-L135】【F:.github/workflows/compilation.yml†L12-L14】
+
+## Build instructions
+- Release build (packed ELF): `make all` → `bin/POPSLOADER.ELF`.【F:Makefile†L61-L69】
+- Build ELF loader: `make elfloader` → `src/elf_loader/libcustom-elf-loader.a`.【F:Makefile†L107-L112】
+- Package archive: `make package` → `POPSLoader.7z`.【F:Makefile†L132-L135】
+- Debug build: set `DEBUG=1` (enables `-DDEBUG`), then build normally. Example: `make DEBUG=1 all`.【F:Makefile†L16-L27】
+
+## Where artifacts go
+- `bin/enceladus.elf` (intermediate build output).【F:Makefile†L30-L33】
+- `bin/POPSLOADER.ELF` (packed release).【F:Makefile†L66-L69】
+- `POPSLoader.7z` (packaged release archive).【F:Makefile†L132-L135】
+
+## Packaging and running on device
+- Place `POPSLOADER.ELF` and the `POPSLDR/` folder on a USB device or internal HDD (root).【F:README.md†L6-L7】
+- Lua boot script expects `POPSLDR/system.lua` in the current directory, and uses `POPSLDR/` on `mass:/` and `mc0:/mc1:/` as fallbacks for Lua modules.【F:etc/boot.lua†L1-L1】【F:etc/boot.lua†L55-L60】
+- Default POPStarter path is `mass:/POPS/POPSTARTER.ELF` (see runtime script).【F:bin/POPSLDR/system.lua†L25-L27】
+
+## Troubleshooting (common build issues)
+- **Missing PS2DEV/PS2SDK**: Ensure `PS2SDK`/`PS2DEV` are set and toolchain binaries are on `PATH` (Makefile uses both).【F:Makefile†L30-L49】
+- **Packaging fails**: `make package` uses `7z`; install p7zip/7z on your host if missing.【F:Makefile†L132-L135】【F:.github/workflows/compilation.yml†L12-L14】
+- **ELF not found**: `make package` depends on the packed ELF (`bin/POPSLOADER.ELF`). Run `make all` first if needed.【F:Makefile†L61-L69】【F:Makefile†L132-L135】

--- a/README.md
+++ b/README.md
@@ -3,7 +3,19 @@ An open source Launcher for POPStarter scripted in lua.
 
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
+## Documentation
+- [AGENTS.md](AGENTS.md)
+- [DEVELOPMENT.md](DEVELOPMENT.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md)
+
+## Status / Roadmap
+- No subfolder dependencies (assets load from ELF directory first).
+- Legacy `POPSLDR/` layout kept as fallback.
+- Treat mmce as USB (XX.) for POPSTARTER.
+
 ## Usage
+**Current layout** (see [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md) for the upcoming layout change).
 move the POPSLOADER.ELF and the `POPSLDR/` folder into a USB device or internal HDD
 
 ### Tips

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# Architecture
+
+## High-level flow (UI → profile selection → POPStarter handoff)
+- The Lua entrypoint is `etc/boot.lua`, embedded into the ELF at build time and executed at startup; it sets `package.path` and runs `POPSLDR/system.lua`.【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L1】【F:etc/boot.lua†L55-L60】
+- `bin/POPSLDR/system.lua` initializes UI state and executes a main loop that drives scenes (main menu, profile query, game list, credits).【F:bin/POPSLDR/system.lua†L277-L296】
+- POPStarter handoff is performed by `PLDR.RunPOPStarterGame`, which builds a boot parameter and calls `System.loadELF(POPSLDR.POPSTARTER_PATH, ...)`.【F:bin/POPSLDR/system.lua†L262-L279】
+
+## Key modules / files and responsibilities
+- `src/main.cpp`: EE entrypoint; sets up IOP modules, device readiness, and boot path from argv, then executes embedded Lua boot script.【F:src/main.cpp†L65-L126】
+- `etc/boot.lua`: boot script; sets Lua search paths, handles HDD boot path setup, and loads `POPSLDR/system.lua`.【F:etc/boot.lua†L1-L60】
+- `bin/POPSLDR/system.lua`: core runtime logic for POPSLoader UI, game list handling, and POPStarter handoff (calls `System.loadELF`).【F:bin/POPSLDR/system.lua†L25-L31】【F:bin/POPSLDR/system.lua†L262-L296】
+- `bin/POPSLDR/ui.lua`, `bin/POPSLDR/images.lua`, `bin/POPSLDR/pops_profiles.lua`: UI and profile data loaded via `require(...)` from `system.lua`.【F:bin/POPSLDR/system.lua†L55-L58】
+- `src/luasystem.cpp`: provides Lua bindings such as `System.loadELF` for POPStarter handoff.【F:src/luasystem.cpp†L496-L526】【F:src/luasystem.cpp†L720-L735】
+
+## Where Lua lives and how it’s invoked
+- Lua boot code is embedded from `etc/boot.lua` into the ELF during the build (via `bin2c`).【F:Makefile†L71-L73】
+- Runtime Lua scripts are expected under `POPSLDR/` (e.g., `POPSLDR/system.lua`) and are loaded using `dofile`/`require`.【F:etc/boot.lua†L55-L60】【F:bin/POPSLDR/system.lua†L55-L58】

--- a/docs/RUNTIME_LAYOUT.md
+++ b/docs/RUNTIME_LAYOUT.md
@@ -1,0 +1,44 @@
+# Runtime layout
+
+## Current expected runtime folder structure (today)
+From README and boot scripts:
+- Place `POPSLOADER.ELF` and the `POPSLDR/` folder at the USB or HDD root.【F:README.md†L6-L7】
+- `boot.lua` executes `POPSLDR/system.lua` from the current directory, and adds `POPSLDR/` search paths for `mass:/`, `mc0:/`, and `mc1:/`.【F:etc/boot.lua†L1-L1】【F:etc/boot.lua†L55-L60】
+
+Example layout (USB root):
+```
+/mass:/
+  POPSLOADER.ELF
+  POPSLDR/
+    system.lua
+    ui.lua
+    images.lua
+    pops_profiles.lua
+    PATCH_5.BIN
+```
+(See packaged assets under `bin/POPSLDR/` in the repo.)【F:bin/POPSLDR/system.lua†L1-L11】
+
+## Target layout (goal)
+**Goal:** assets should load from the ELF directory first (no subfolder dependency). This is an active refactor goal and must preserve legacy fallback behavior unless intentionally removed and documented. (See `AGENTS.md` for the explicit roadmap statement.)【F:AGENTS.md†L41-L50】
+
+## Compatibility strategy (fallback order)
+When resolving Lua scripts/modules:
+1. `./POPSLDR/?.lua`
+2. `./?.lua`
+3. `mass:/POPSLDR/?.lua`
+4. `mc0:/POPSLDR/?.lua`
+5. `mc1:/POPSLDR/?.lua`【F:etc/boot.lua†L1-L1】
+
+`boot.lua` expects `POPSLDR/system.lua` to be accessible in the current working directory and will error if it is missing.【F:etc/boot.lua†L55-L60】
+
+## Runtime assets and search locations
+| Asset type | Example(s) | Search / usage location | Evidence |
+|---|---|---|---|
+| Lua entrypoint | `POPSLDR/system.lua` | `dofile("POPSLDR/system.lua")` from current directory | `etc/boot.lua` |【F:etc/boot.lua†L55-L60】
+| Lua modules (POPSLDR) | `ui.lua`, `images.lua`, `pops_profiles.lua` | `package.path` includes `mass:/POPSLDR/?.lua`, `mc0:/POPSLDR/?.lua`, `mc1:/POPSLDR/?.lua` | `etc/boot.lua` |【F:etc/boot.lua†L1-L1】
+| POPStarter ELF | `mass:/POPS/POPSTARTER.ELF` | Used as `PLDR.POPSTARTER_PATH` when launching games | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L25-L27】
+| POPStarter dependencies (USB/HDD) | `POPS_IOX.PAK`, `POPS.ELF`, `IOPRP252.IMG` | Checked under `mass:/POPS/` or `pfs1:/POPS/` if enabled | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L63-L74】
+| Optional IGR textures | `PATCH_5.BIN` | Documented as replaceable in `POPS/` for POPStarter IGR | `bin/README.md` |【F:bin/README.md†L9-L10】
+
+## TODOs / unknowns (verify in code)
+- `mmce0:/` usage is not visible in the reviewed files. The module `mmceman.irx` is embedded, but no explicit device path references were found. **TODO: verify** in other Lua scripts or C/C++ modules.【F:iop/embed/mmceman.irx†L1-L1】

--- a/truth_sheet.md
+++ b/truth_sheet.md
@@ -1,0 +1,66 @@
+# Truth Sheet (audit, ground-truth only)
+
+## What this project is
+POPSLoader is an open-source launcher for POPStarter, scripted in Lua and based on the Enceladus project.【F:README.md†L1-L4】
+
+## What it builds / outputs
+- Main EE binary is built as `bin/enceladus.elf`, then stripped and packed into `bin/POPSLOADER.ELF`.【F:Makefile†L30-L33】【F:Makefile†L66-L69】
+- `make package` creates `POPSLoader.7z` containing `POPSLOADER.ELF`, `bin/POPSLDR/*`, `bin/changelog`, plus `LICENSE` and `README.md`.【F:Makefile†L132-L135】
+- CI uploads `POPSLoader.7z` as the `POPSLDR` artifact in GitHub Actions.【F:.github/workflows/compilation.yml†L29-L35】
+
+## How it’s built (toolchain / make targets / env vars)
+- Build uses PS2DEV/ps2sdk toolchain and libraries (e.g., `PS2SDK`, `PS2DEV`, `ps2-packer`, `bin2c`).【F:Makefile†L30-L48】【F:Makefile†L41-L49】
+- Main targets: `all` (builds `bin/POPSLOADER.ELF`), `elfloader` (builds `src/elf_loader/libcustom-elf-loader.a`), `package`, `clean`, `rebuild`, `run`, `reset`.【F:Makefile†L61-L146】
+- CI uses `ps2dev/ps2dev:latest` container and runs `make clean elfloader all package`.【F:.github/workflows/compilation.yml†L8-L28】
+
+## Runtime file layout expectations (current)
+- Usage docs instruct placing `POPSLOADER.ELF` and `POPSLDR/` folder on USB device or internal HDD.【F:README.md†L6-L7】
+- Boot Lua prepends Lua module search paths for `POPSLDR/` on current dir, `mass:/`, and `mc0:/mc1:/`.【F:etc/boot.lua†L1-L1】
+- On startup, `boot.lua` tries to execute `POPSLDR/system.lua` relative to current working directory; it errors if not found.【F:etc/boot.lua†L55-L60】
+- Packaged `bin/POPSLDR/` contains `system.lua`, `ui.lua`, `images.lua`, `pops_profiles.lua`, and `PATCH_5.BIN` (used for POPStarter UI texture replacement).【F:bin/POPSLDR/system.lua†L1-L11】【F:bin/README.md†L9-L10】
+
+## Launching / boot path determination
+- `main.cpp` derives `boot_path` from argv (supports `/`, `\`, or `:` delimiters), and patches `mass:/` paths by removing an extra slash (`mass:/X` -> `mass:X`).【F:src/main.cpp†L65-L96】
+- `boot.lua` reads `System.GetArgv0()` and, if launched from `hdd0:`, parses mount data, initializes/mounts the HDD partition, and updates the current directory to the boot path.【F:etc/boot.lua†L32-L53】
+
+## Key folders and what they contain
+- `src/`: C/C++ source, including entrypoint `main.cpp` and Lua/graphics/pad subsystems.【F:src/main.cpp†L1-L22】
+- `etc/`: build-time Lua boot script (`boot.lua`) embedded into the ELF via bin2c.【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L60】
+- `bin/`: packaged runtime assets and POPSLDR scripts (`bin/POPSLDR/*`), plus `bin/changelog`.【F:Makefile†L132-L135】【F:bin/POPSLDR/system.lua†L1-L11】
+- `EMBED/`: PNG/TTF assets embedded into the binary at build time.【F:Makefile†L75-L79】
+- `iop/embed/`: embedded IOP module(s) (e.g., `mmceman.irx`).【F:iop/embed/mmceman.irx†L1-L1】
+- `modules/`: external modules such as `ds34bt` and `ds34usb` built as libs and IOP modules.【F:Makefile†L51-L60】【F:Makefile†L94-L106】
+- `samples/`: sample Lua content (e.g., `fractal.lua`, `helloworld.lua`, etc.).【F:samples/fractal.lua†L1-L1】
+
+## Gotchas / device-path rules (from code)
+- `boot_path` normalization patches `mass:/` paths by shifting the slash (likely to handle `mass:/` formatting quirks).【F:src/main.cpp†L88-L96】
+- Lua package path explicitly includes `mass:/POPSLDR/?.lua` and `mc0:/mc1:/POPSLDR/?.lua` for module discovery.【F:etc/boot.lua†L1-L1】
+- HDD boot path handling in `boot.lua` expects `hdd0:` format and requires mounting partitions before setting the current directory.【F:etc/boot.lua†L32-L53】
+- POPStarter paths used by default in `system.lua` point to `mass:/POPS/POPSTARTER.ELF` and dependencies under `mass:/POPS/` or HDD `pfs1:/POPS/` depending on device selection.【F:bin/POPSLDR/system.lua†L25-L27】【F:bin/POPSLDR/system.lua†L63-L74】
+
+## Audit commands used (traceability)
+- `ls`
+- `find .. -name AGENTS.md -print`
+- `sed -n '1,200p' README.md`
+- `sed -n '1,200p' Makefile`
+- `ls docs`
+- `find src -maxdepth 2 -type f -print`
+- `find .github -maxdepth 3 -type f -print`
+- `sed -n '1,200p' docs/index.md`
+- `sed -n '1,200p' docs/_config.yml`
+- `sed -n '1,200p' .github/workflows/compilation.yml`
+- `ls etc`
+- `sed -n '1,220p' src/main.cpp`
+- `sed -n '1,220p' src/system.cpp`
+- `sed -n '1,200p' etc/boot.lua`
+- `find bin -maxdepth 2 -type f -print`
+- `sed -n '1,200p' bin/README.md`
+- `sed -n '1,200p' bin/POPSLDR/system.lua`
+- `ls iop`
+- `ls iop/embed`
+- `ls modules`
+- `ls samples`
+- `sed -n '1,200p' src/elf_loader/Makefile`
+- `sed -n '1,200p' src/luasystem.cpp`
+- `rg -n "GetArgv0" -S src etc`
+- `sed -n '660,760p' src/luasystem.cpp`


### PR DESCRIPTION
### Motivation
- Provide repository-grounded developer and contributor guidance and capture runtime layout and invariants in-code. 
- Make the active refactor goal (load assets from the ELF directory first) and legacy fallback behavior explicit in top-level docs. 
- Surface links in `README.md` so new contributors can quickly find `AGENTS.md`, `DEVELOPMENT.md`, `docs/ARCHITECTURE.md`, and `docs/RUNTIME_LAYOUT.md`.

### Description
- Add `AGENTS.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `docs/ARCHITECTURE.md`, `docs/RUNTIME_LAYOUT.md`, and `truth_sheet.md` that document build targets, runtime layout, module responsibilities, and change discipline. 
- Update `README.md` to add a `Documentation` section linking to the new files and to add a `Status / Roadmap` list that includes the ELF-directory-first goal, legacy `POPSLDR/` fallback, and treating `mmce` as USB for POPSTARTER. 
- Annotate the existing `Usage` section as `Current layout` and point readers to `docs/RUNTIME_LAYOUT.md` for the upcoming layout change.

### Testing
- No automated tests or CI jobs were executed for these documentation-only changes. 
- Packaging/build CI targets were not modified and remain `make clean elfloader all package` in CI configuration. 
- The documentation files and `README.md` were added/updated in the repository (no runtime code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697041b713dc83218266ad9af83b5e37)