### PR TITLE
Flatten package layout for runtime assets and add flat-first asset resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,17 @@ reset:
 	ps2client -h $(PS2LINK_IP) reset   
 
 POPSLDR_PKG = POPSLoader.7z
+PKG_DIR = bin/package
 package: $(EE_BIN_PKD)
 	rm -f $(POPSLDR_PKG)
-	7z a $(POPSLDR_PKG) $(EE_BIN_PKD) bin/changelog LICENSE README.md
-	cd bin/POPSLDR; 7z a ../$(POPSLDR_PKG) .
+	rm -rf $(PKG_DIR)
+	mkdir -p $(PKG_DIR)
+	cp $(EE_BIN_PKD) $(PKG_DIR)/
+	cp bin/changelog LICENSE README.md $(PKG_DIR)/
+	find bin/POPSLDR -maxdepth 1 -type f -exec cp {} $(PKG_DIR)/ \;
+	@if ls bin/POPSLDR/IMG/*.png >/dev/null 2>&1; then cp bin/POPSLDR/IMG/*.png $(PKG_DIR)/; fi
+	@if ls bin/POPSLDR/IRX/*.irx >/dev/null 2>&1; then cp bin/POPSLDR/IRX/*.irx $(PKG_DIR)/; fi
+	cd $(PKG_DIR); 7z a ../$(POPSLDR_PKG) .
 
 dummys:
 	touch $(BINDIR)A.vcd

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 - Treat mmce as USB (XX.) for POPSTARTER.
 
 ## Usage
-Put `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required).  
+Put `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required):  
+- `system.lua`, `ui.lua`, `images.lua`, `pops_profiles.lua`, `PATCH_5.BIN`  
+- UI images (`*.png`) and optional external IRX modules (`*.irx`)  
 Legacy `POPSLDR/` folder layout is still supported as a fallback.  
 See [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md) for layout details and compatibility notes.
 

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -7,10 +7,11 @@
 --]]
 
 LOG("Loading images")
-local function ResolveAsset(rel)
-  return System.resolveAsset(rel) or rel
+local function ResolveImage(name)
+  return System.resolveAssetType(name, ASSET_IMG) or name
 end
---- Add your images to this table, just write the name of the file, all images go into POPSLDR/IMG/*
+--- Add your images to this table, just write the name of the file.
+--- Flat layout places images beside POPSLOADER.ELF; legacy installs can still use POPSLDR/IMG/*
 --- FILES MUST HAVE EXTENSION. filename is parsed to create the access key: USB.PNG will be accesed by typing `IMG["USB"]`
 local IMGS = {
   "USB.png",
@@ -38,7 +39,7 @@ IMG = {}
 LOGF("%d images registered", #IMGS)
 for x=1, #IMGS do
   local INDX = IMGS[x]:match("(.+)%..+$")
-  local PATH = ResolveAsset("IMG/"..IMGS[x])
+  local PATH = ResolveImage(IMGS[x])
   IMG[INDX] = Graphics.loadImage(PATH)
   if IMG[INDX] == nil then error("Could not load '"..PATH.."'") end
   Graphics.setImageFilters(IMG[INDX], LINEAR)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -27,18 +27,37 @@ local function ResolveWritablePath(rel)
   end
   return modern
 end
-local IRXPATH = System.resolveAsset("IRX/") or (APP_DIR_LOCAL.."IRX/")
-if doesFolderExist(IRXPATH) then
-  local IRXDIR = System.listDirectory(IRXPATH)
-  if IRXDIR ~= nil then
-    LOG("Found IRX folder")
-    for x=1, #IRXDIR do
-      if string.lower(string.sub(IRXDIR[i].name,-4)) == ".irx" then
-        local ID, RET = IOP.loadModule(IRXDIR[x])
-        LOG(IRXDIR[x], ID, RET)
+
+local function ResolveIrx(name)
+  return System.resolveAssetType(name, ASSET_IRX) or (APP_DIR_LOCAL..name)
+end
+
+local function LoadIrxFromDir(dir)
+  if not doesFolderExist(dir) then return false end
+  local IRXDIR = System.listDirectory(dir)
+  if IRXDIR == nil then return false end
+  local loaded = false
+  for x=1, #IRXDIR do
+    local entry = IRXDIR[x]
+    if entry ~= nil and not entry.directory then
+      local name = entry.name
+      if name ~= nil and string.lower(string.sub(name, -4)) == ".irx" then
+        local PATH = ResolveIrx(name) or (dir..name)
+        local ID, RET = IOP.loadModule(PATH)
+        LOG(PATH, ID, RET)
+        loaded = true
       end
     end
   end
+  return loaded
+end
+
+local loadedIrx = LoadIrxFromDir(APP_DIR_LOCAL)
+if not loadedIrx then
+  loadedIrx = LoadIrxFromDir(APP_DIR_LOCAL.."IRX/")
+end
+if not loadedIrx then
+  LoadIrxFromDir(APP_DIR_LOCAL.."POPSLDR/IRX/")
 end
 PLDR = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;

--- a/bin/README.md
+++ b/bin/README.md
@@ -4,10 +4,13 @@ An open source Launcher for POPStarter scripted in lua.
 Based on [Enceladus](https://github.com/DanielSant0s/Enceladus)
 
 ## Usage
-move the POPSLOADER.ELF and the `POPSLDR/` folder into a USB device or internal HDD
+move the POPSLOADER.ELF and runtime assets into a USB device or internal HDD (flat layout)
+  - system.lua, ui.lua, images.lua, pops_profiles.lua, PATCH_5.BIN
+  - UI images (*.png) and optional external IRX modules (*.irx)
+Legacy `POPSLDR/` folder layout is still supported as a fallback.
 
 ### Tips
-- (USB Only) if you want POPStarter IGR to go back to POPSLoader automatically, pasthe the `POPSLDR/` folder into the USB root, and copy the `POPSLOADER.ELF` renamed as `BOOT.ELF`
+- (USB Only) if you want POPStarter IGR to go back to POPSLoader automatically, copy the `POPSLOADER.ELF` renamed as `BOOT.ELF` (legacy `POPSLDR/` layout is still supported if you use it)
 - you can replace the POPStarter IGR textures with custom ones that looks like stock POPSLoader UI by pasting the `PATCH_5.BIN` found inside the `POPSLDR/` into the `POPS/` folder
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,17 +1,17 @@
 # Architecture
 
 ## High-level flow (UI → profile selection → POPStarter handoff)
-- The Lua entrypoint is `etc/boot.lua`, embedded into the ELF at build time and executed at startup; it sets `package.path` and runs `POPSLDR/system.lua`.【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L1】【F:etc/boot.lua†L55-L60】
+- The Lua entrypoint is `etc/boot.lua`, embedded into the ELF at build time and executed at startup; it sets `package.path` and runs the resolved `system.lua` (APP_DIR first, legacy `POPSLDR/` fallback).【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
 - `bin/POPSLDR/system.lua` initializes UI state and executes a main loop that drives scenes (main menu, profile query, game list, credits).【F:bin/POPSLDR/system.lua†L277-L296】
 - POPStarter handoff is performed by `PLDR.RunPOPStarterGame`, which builds a boot parameter and calls `System.loadELF(POPSLDR.POPSTARTER_PATH, ...)`.【F:bin/POPSLDR/system.lua†L262-L279】
 
 ## Key modules / files and responsibilities
 - `src/main.cpp`: EE entrypoint; sets up IOP modules, device readiness, and boot path from argv, then executes embedded Lua boot script.【F:src/main.cpp†L65-L126】
-- `etc/boot.lua`: boot script; sets Lua search paths, handles HDD boot path setup, and loads `POPSLDR/system.lua`.【F:etc/boot.lua†L1-L60】
+- `etc/boot.lua`: boot script; sets Lua search paths, handles HDD boot path setup, and loads the resolved `system.lua` (flat-first).【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
 - `bin/POPSLDR/system.lua`: core runtime logic for POPSLoader UI, game list handling, and POPStarter handoff (calls `System.loadELF`).【F:bin/POPSLDR/system.lua†L25-L31】【F:bin/POPSLDR/system.lua†L262-L296】
 - `bin/POPSLDR/ui.lua`, `bin/POPSLDR/images.lua`, `bin/POPSLDR/pops_profiles.lua`: UI and profile data loaded via `require(...)` from `system.lua`.【F:bin/POPSLDR/system.lua†L55-L58】
 - `src/luasystem.cpp`: provides Lua bindings such as `System.loadELF` for POPStarter handoff.【F:src/luasystem.cpp†L496-L526】【F:src/luasystem.cpp†L720-L735】
 
 ## Where Lua lives and how it’s invoked
 - Lua boot code is embedded from `etc/boot.lua` into the ELF during the build (via `bin2c`).【F:Makefile†L71-L73】
-- Runtime Lua scripts are expected under `POPSLDR/` (e.g., `POPSLDR/system.lua`) and are loaded using `dofile`/`require`.【F:etc/boot.lua†L55-L60】【F:bin/POPSLDR/system.lua†L55-L58】
+- Runtime Lua scripts are expected beside the ELF (flat layout) with `POPSLDR/` kept as a legacy fallback for `dofile`/`require`.【F:etc/boot.lua†L1-L11】【F:etc/boot.lua†L72-L81】

--- a/docs/RUNTIME_LAYOUT.md
+++ b/docs/RUNTIME_LAYOUT.md
@@ -14,15 +14,15 @@ Example layout (USB root, no subfolder):
   images.lua
   pops_profiles.lua
   PATCH_5.BIN
-  IMG/
-    USB.png
-    SMB.png
-    HDD.png
-    PSL.png
-    select.png
-    start.png
+  USB.png
+  SMB.png
+  HDD.png
+  PSL.png
+  select.png
+  start.png
+  (optional) *.irx
 ```
-(See packaged assets under `bin/POPSLDR/` in the repo; packaging flattens them beside the ELF.)【F:bin/POPSLDR/system.lua†L1-L11】【F:Makefile†L132-L135】
+(See packaged assets under `bin/POPSLDR/` in the repo; packaging flattens them beside the ELF.)【F:bin/POPSLDR/system.lua†L1-L11】【F:Makefile†L171-L179】
 
 ## Target layout (goal)
 **Goal:** assets should load from the ELF directory first (no subfolder dependency). This is implemented in the resolver and must preserve legacy fallback behavior unless intentionally removed and documented. (See `AGENTS.md` for the explicit roadmap statement.)【F:AGENTS.md†L41-L50】【F:src/system.cpp†L80-L107】
@@ -42,8 +42,8 @@ When resolving Lua scripts/modules:
 ## Runtime assets and search locations
 | Asset type | Example(s) | Search / usage location | Evidence |
 |---|---|---|---|
-| Lua entrypoint | `POPSLDR/system.lua` | `dofile("POPSLDR/system.lua")` from current directory | `etc/boot.lua` |【F:etc/boot.lua†L55-L60】
-| Lua modules (POPSLDR) | `ui.lua`, `images.lua`, `pops_profiles.lua` | `package.path` includes `mass:/POPSLDR/?.lua`, `mc0:/POPSLDR/?.lua`, `mc1:/POPSLDR/?.lua` | `etc/boot.lua` |【F:etc/boot.lua†L1-L1】
+| Lua entrypoint | `system.lua` | `System.resolveAsset("system.lua")` (APP_DIR first, `POPSLDR/` fallback) | `etc/boot.lua` |【F:etc/boot.lua†L72-L81】【F:src/system.cpp†L80-L107】
+| Lua modules | `ui.lua`, `images.lua`, `pops_profiles.lua` | `package.path` includes `APP_DIR/?.lua` plus legacy `POPSLDR/?.lua` locations | `etc/boot.lua` |【F:etc/boot.lua†L1-L11】
 | POPStarter ELF | `mass:/POPS/POPSTARTER.ELF` | Used as `PLDR.POPSTARTER_PATH` when launching games | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L25-L27】
 | POPStarter dependencies (USB/HDD) | `POPS_IOX.PAK`, `POPS.ELF`, `IOPRP252.IMG` | Checked under `mass:/POPS/` or `pfs1:/POPS/` if enabled | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L63-L74】
 | Optional IGR textures | `PATCH_5.BIN` | Documented as replaceable in `POPS/` for POPStarter IGR | `bin/README.md` |【F:bin/README.md†L9-L10】

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -13,7 +13,14 @@ extern "C" {
 extern char boot_path[255];
 extern char app_dir[255];
 
+typedef enum AssetKind {
+	ASSET_GENERIC = 0,
+	ASSET_IMG = 1,
+	ASSET_IRX = 2,
+} AssetKind;
+
 int ResolveAssetPath(char* out, size_t outsz, const char* relativeName);
+int ResolveAssetPathTyped(char* out, size_t outsz, const char* relativeName, AssetKind kind);
 
 #ifdef DEBUG
 #define dbgprintf(args...) scr_printf(args)

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -723,6 +723,20 @@ static int lua_resolveAsset(lua_State *L) {
 	return 1;
 }
 
+static int lua_resolveAssetType(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc != 2) return luaL_error(L, "Argument error: System.resolveAssetType(relativeName, kind) takes two arguments.");
+	const char *rel = luaL_checkstring(L, 1);
+	int kind = luaL_checkinteger(L, 2);
+	char out[255];
+	if (ResolveAssetPathTyped(out, sizeof(out), rel, (AssetKind)kind)) {
+		lua_pushstring(L, out);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 static const luaL_Reg System_functions[] = {
 	{"openFile",                   lua_openfile},
 	{"readFile",                   lua_readfile},
@@ -753,6 +767,7 @@ static const luaL_Reg System_functions[] = {
 	{"GetArgv0",                   lua_popargv0},
 	{"getAppDir",                 lua_getAppDir},
 	{"resolveAsset",           lua_resolveAsset},
+	{"resolveAssetType",   lua_resolveAssetType},
 	{0, 0}
 };
 
@@ -843,6 +858,15 @@ void luaSystem_init(lua_State *L) {
 
 	lua_pushstring(L, app_dir);
 	lua_setglobal(L, "APP_DIR");
+
+	lua_pushinteger(L, ASSET_GENERIC);
+	lua_setglobal(L, "ASSET_GENERIC");
+
+	lua_pushinteger(L, ASSET_IMG);
+	lua_setglobal(L, "ASSET_IMG");
+
+	lua_pushinteger(L, ASSET_IRX);
+	lua_setglobal(L, "ASSET_IRX");
 
 	lua_pushinteger(L, O_RDONLY);
 	lua_setglobal(L, "FREAD");

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -107,6 +107,64 @@ int ResolveAssetPath(char* out, size_t outsz, const char* relativeName)
 	return 0;
 }
 
+static int ResolveAssetCandidate(char* out, size_t outsz, const char* candidate)
+{
+	struct stat st;
+	if (stat(candidate, &st) == 0) {
+		DPRINTF("ResolveAssetPath: %s\n", candidate);
+		snprintf(out, outsz, "%s", candidate);
+		return 1;
+	}
+	return 0;
+}
+
+int ResolveAssetPathTyped(char* out, size_t outsz, const char* relativeName, AssetKind kind)
+{
+	if (!out || outsz == 0 || !relativeName) return 0;
+
+	if (strchr(relativeName, ':') != NULL) {
+		snprintf(out, outsz, "%s", relativeName);
+		struct stat st;
+		return (stat(out, &st) == 0);
+	}
+
+	char candidate[255];
+
+	if (kind == ASSET_IMG) {
+		snprintf(candidate, sizeof(candidate), "%s%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sIMG/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sPOPSLDR/IMG/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sPOPSLDR/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		return 0;
+	}
+
+	if (kind == ASSET_IRX) {
+		snprintf(candidate, sizeof(candidate), "%s%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sIRX/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sPOPSLDR/IRX/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		snprintf(candidate, sizeof(candidate), "%sPOPSLDR/%s", app_dir, relativeName);
+		if (ResolveAssetCandidate(out, outsz, candidate)) return 1;
+
+		return 0;
+	}
+
+	return ResolveAssetPath(out, outsz, relativeName);
+}
+
 
 void IOP_Reset(void)
 {


### PR DESCRIPTION
### Motivation
- Produce a flat runtime package so `POPSLOADER.ELF`, UI Lua scripts, PNG images and optional `.irx` modules are colocated for simpler installs and distribution. 
- Preserve backward compatibility by keeping legacy `POPSLDR/`, `POPSLDR/IMG/` and `POPSLDR/IRX/` fallbacks when flat files are not present. 
- Expose and use a typed resolver so image and IRX lookups prefer `APP_DIR` entries first and fall back to legacy subfolders.

### Description
- Updated the `package` target in `Makefile` to stage a flat package under `bin/package/`, copying `$(EE_BIN_PKD)` plus top-level runtime files and flattening any `bin/POPSLDR/IMG/*.png` and `bin/POPSLDR/IRX/*.irx` into the package before creating `POPSLoader.7z`.
- Added typed asset resolution APIs and enums in `src/include/luaplayer.h` (`AssetKind`, `ResolveAssetPathTyped`) and implemented `ResolveAssetPathTyped` plus `ResolveAssetCandidate` in `src/system.cpp` with flat-first search orders for `ASSET_IMG` and `ASSET_IRX`.
- Exposed the typed resolver to Lua via `System.resolveAssetType` in `src/luasystem.cpp` and exported `ASSET_GENERIC`, `ASSET_IMG`, and `ASSET_IRX` constants.
- Updated Lua call sites to use the new resolver: `bin/POPSLDR/images.lua` now calls `System.resolveAssetType(..., ASSET_IMG)` and `bin/POPSLDR/system.lua` uses `System.resolveAssetType(..., ASSET_IRX)` and the new `LoadIrxFromDir` helper to attempt loading IRX modules from the ELF directory first with legacy folder fallbacks.
- Updated documentation to reflect the new recommended flat runtime layout and preserved fallback behavior in `README.md`, `bin/README.md`, `docs/RUNTIME_LAYOUT.md`, and `docs/ARCHITECTURE.md`.

### Testing
- No automated tests were executed for these packaging and docs changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704c38ba108321a0abdf786b195363)