### PR TITLE
Add MMCE slot detection and integrate into MMCE page

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -82,7 +82,9 @@ PLDR = {
   },
   MMCE = {
     PROBED = false,
-    PREFIX = nil
+    PREFIX = nil,
+    SLOTS = {},
+    INDEX = 1
   }
 }
 if BOOTPATH ~= nil then
@@ -99,17 +101,42 @@ function PLDR.DetectMMCESlot()
     return PLDR.MMCE.PREFIX
   end
   PLDR.MMCE.PROBED = true
+  PLDR.MMCE.SLOTS = {}
+  PLDR.MMCE.INDEX = 1
   local candidates = {"mmce0:/", "mmce1:/"}
   for i = 1, #candidates do
     local candidate = candidates[i]
     if doesFolderExist(candidate) then
-      PLDR.MMCE.PREFIX = candidate
-      LOG("MMCE slot selected: "..candidate)
-      return candidate
+      table.insert(PLDR.MMCE.SLOTS, candidate)
     end
+  end
+  if #PLDR.MMCE.SLOTS > 0 then
+    PLDR.MMCE.PREFIX = PLDR.MMCE.SLOTS[PLDR.MMCE.INDEX]
+    LOG("MMCE slot selected: "..PLDR.MMCE.PREFIX)
+    return PLDR.MMCE.PREFIX
   end
   LOG("MMCE not found")
   return nil
+end
+
+function PLDR.GetMMCESlots()
+  if not PLDR.MMCE.PROBED then
+    PLDR.DetectMMCESlot()
+  end
+  return PLDR.MMCE.SLOTS
+end
+
+function PLDR.SetMMCESlot(index)
+  local slots = PLDR.GetMMCESlots()
+  if #slots < 1 then
+    return nil
+  end
+  if index < 1 then index = #slots end
+  if index > #slots then index = 1 end
+  PLDR.MMCE.INDEX = index
+  PLDR.MMCE.PREFIX = slots[index]
+  LOG("MMCE slot selected: "..PLDR.MMCE.PREFIX)
+  return PLDR.MMCE.PREFIX
 end
 
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -79,6 +79,10 @@ PLDR = {
   };
   USB = {
     MASSINDX = 0
+  },
+  MMCE = {
+    PROBED = false,
+    PREFIX = nil
   }
 }
 if BOOTPATH ~= nil then
@@ -89,6 +93,24 @@ end
 require("pops_profiles")
 require("ui")
 require("images")
+
+function PLDR.DetectMMCESlot()
+  if PLDR.MMCE.PROBED then
+    return PLDR.MMCE.PREFIX
+  end
+  PLDR.MMCE.PROBED = true
+  local candidates = {"mmce0:/", "mmce1:/"}
+  for i = 1, #candidates do
+    local candidate = candidates[i]
+    if doesFolderExist(candidate) then
+      PLDR.MMCE.PREFIX = candidate
+      LOG("MMCE slot selected: "..candidate)
+      return candidate
+    end
+  end
+  LOG("MMCE not found")
+  return nil
+end
 
 
 function CLAMP(a, MIN, MAX)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -177,6 +177,16 @@ UI = {
           if UI.MainMenu.OPT == 1 then
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
+            UI.SceneChange(UI.MainMenu.OPT)
+          elseif UI.MainMenu.OPT == 2 then
+            local mmce_prefix = PLDR.DetectMMCESlot()
+            if mmce_prefix == nil then
+              UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
+            else
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
+              UI.SceneChange(UI.MainMenu.OPT)
+            end
           elseif UI.MainMenu.OPT == 3 then
             PLDR.LoadHDDModules()
             if UI.LASTSCENE == UI.SCENES.GHDD then
@@ -199,8 +209,8 @@ UI = {
             else
               UI.Notif_queue.add("ERROR: Cant detect usable HDD ("..PLDR.HDD.STATUS..")")
             end
+            UI.SceneChange(UI.MainMenu.OPT)
           end --because we still dont support SMB
-          if UI.MainMenu.OPT ~= 2 then UI.SceneChange(UI.MainMenu.OPT) end
           GPAD = 0
         end
       end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -98,6 +98,13 @@ UI = {
       end;
       Play = function()
         local ammount = #PLDR.GAMES
+        if UI.CURSCENE == UI.SCENES.GSMB then
+          local slots = PLDR.GetMMCESlots()
+          if #slots > 1 then
+            Font.ftPrint(SFONT, 30, 2, 0, UI.SCR.X, 16, "Slot: "..PLDR.MMCE.PREFIX, UI.CCOL.GREY)
+            Font.ftPrint(SFONT, 30, 12, 0, UI.SCR.X, 16, "Triangle: switch slot", UI.CCOL.GREY)
+          end
+        end
         if (UI.GameList.CURR > (UI.GameList.STARTUP+(UI.GameList.MAXDRAW-1))) then
           UI.GameList.STARTUP = (UI.GameList.CURR-UI.GameList.MAXDRAW+1)
         elseif (UI.GameList.CURR < UI.GameList.STARTUP) then
@@ -114,6 +121,17 @@ UI = {
         end
         UI.Pad.Listen()
         if Pads.check(GPAD, PAD_CIRCLE) then UI.SceneChange(UI.SCENES.MMAIN) end
+        if UI.CURSCENE == UI.SCENES.GSMB then
+          local slots = PLDR.GetMMCESlots()
+          if #slots > 1 and Pads.check(GPAD, PAD_TRIANGLE) then
+            local next_prefix = PLDR.SetMMCESlot(PLDR.MMCE.INDEX + 1)
+            if next_prefix ~= nil then
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(next_prefix.."POPS/", true)
+            end
+            GPAD = 0
+          end
+        end
         if Pads.check(GPAD, PAD_DOWN) then UI.GameList.CURR = CLAMP(UI.GameList.CURR+1, 1, ammount) GPAD = 0 end
         if Pads.check(GPAD, PAD_RIGHT) then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) GPAD = 0 end
         if Pads.check(GPAD, PAD_UP) then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) GPAD = 0 end
@@ -183,6 +201,7 @@ UI = {
             if mmce_prefix == nil then
               UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
             else
+              mmce_prefix = PLDR.SetMMCESlot(1)
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
               UI.SceneChange(UI.MainMenu.OPT)


### PR DESCRIPTION
### Motivation
- Detect which MMCE slot is active at runtime so the MMCE page can list and launch games from the correct device instead of assuming a fixed prefix.
- Fail gracefully and inform the user when no MMCE device is present.

### Description
- Add a cached helper `PLDR.DetectMMCESlot()` that probes `mmce0:/` then `mmce1:/` using `doesFolderExist(...)` and returns the selected prefix or `nil` if none found, while caching the result in `PLDR.MMCE`.
- Add `PLDR.MMCE = { PROBED = false, PREFIX = nil }` to `system.lua` and log either `"MMCE slot selected: <prefix>"` or `"MMCE not found"` when probing.
- Integrate detection into the main menu flow in `ui.lua` so the SMB/MMCE menu option uses the detected prefix (e.g. `mmce0:/POPS/` or `mmce1:/POPS/`) to enumerate games, and show the notification `No MMCE device found (mmce0/mmce1).` if no slot is available.
- Keep behavior minimal and localized (tight diff, no broad refactor) and preserve existing SMB icon/routing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697055ef3b988321b5288236a8974550)