### PR TITLE
Add mmceman load logging and debug-only IOP module dump

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -92,6 +92,24 @@ if BOOTPATH ~= nil then
   PLDR.HDD.STATUS = HDD.GetHDDStatus()
 end
 
+if MMCE_SLOT0_READY ~= nil and MMCE_SLOT0_READY >= 0 then
+  PLDR.MMCE.PROBED = true
+  PLDR.MMCE.SLOTS = {}
+  PLDR.MMCE.INDEX = 1
+  if MMCE_SLOT0_READY == 1 then
+    table.insert(PLDR.MMCE.SLOTS, "mmce0:/")
+  end
+  if MMCE_SLOT1_READY == 1 then
+    table.insert(PLDR.MMCE.SLOTS, "mmce1:/")
+  end
+  if #PLDR.MMCE.SLOTS > 0 then
+    PLDR.MMCE.PREFIX = PLDR.MMCE.SLOTS[PLDR.MMCE.INDEX]
+    LOG("MMCE slot selected: "..PLDR.MMCE.PREFIX)
+  else
+    LOG("MMCE not found")
+  end
+end
+
 require("pops_profiles")
 require("ui")
 require("images")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -191,17 +191,25 @@ UI = {
         if Pads.check(GPAD, PAD_LEFT)  then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT-1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_START) then UI.SceneChange(UI.SCENES.MPROFILE) end
         if Pads.check(GPAD, PAD_SELECT)then UI.SceneChange(UI.SCENES.CREDITS) end
-        if Pads.check(GPAD, PAD_CROSS) then
+          if Pads.check(GPAD, PAD_CROSS) then
           if UI.MainMenu.OPT == 1 then
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
             UI.SceneChange(UI.MainMenu.OPT)
           elseif UI.MainMenu.OPT == 2 then
-            local mmce_prefix = PLDR.DetectMMCESlot()
-            if mmce_prefix == nil then
+            local slots = PLDR.GetMMCESlots()
+            if #slots < 1 then
               UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
             else
-              mmce_prefix = PLDR.SetMMCESlot(1)
+              if PLDR.MMCE.PREFIX == nil then
+                PLDR.SetMMCESlot(1)
+              end
+              local mmce_prefix = PLDR.MMCE.PREFIX or PLDR.SetMMCESlot(1)
+              if mmce_prefix == nil then
+                UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
+                GPAD = 0
+                return
+              end
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
               UI.SceneChange(UI.MainMenu.OPT)

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -594,6 +594,8 @@ static int lua_getDiscType(lua_State *L)
 }
 
 extern void *_gp;
+extern int mmce_slot0_ready;
+extern int mmce_slot1_ready;
 
 #define BUFSIZE (64*1024)
 
@@ -867,6 +869,12 @@ void luaSystem_init(lua_State *L) {
 
 	lua_pushinteger(L, ASSET_IRX);
 	lua_setglobal(L, "ASSET_IRX");
+
+	lua_pushinteger(L, mmce_slot0_ready);
+	lua_setglobal(L, "MMCE_SLOT0_READY");
+
+	lua_pushinteger(L, mmce_slot1_ready);
+	lua_setglobal(L, "MMCE_SLOT1_READY");
 
 	lua_pushinteger(L, O_RDONLY);
 	lua_setglobal(L, "FREAD");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,8 @@ extern unsigned int size_mmceman_irx;
 
 char boot_path[255];
 char app_dir[255];
+int mmce_slot0_ready = -1;
+int mmce_slot1_ready = -1;
 
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
@@ -182,6 +184,75 @@ char* GetArgv0(void) {
     printf("%s: id:%d, ret:%d\n", #_irx, ID, RET)
 #define LOAD_IRX_NARG(_irx) LOAD_IRX(_irx, 0, NULL)
 
+static bool LoadIrxChecked(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret)
+{
+    int id = -1;
+    int ret = -1;
+    id = SifExecModuleBuffer(irx, size, 0, NULL, &ret);
+    if (out_id) {
+        *out_id = id;
+    }
+    if (out_ret) {
+        *out_ret = ret;
+    }
+    if (id < 0 || ret < 0) {
+        DPRINTF("IOP module load failed: %s id=%d ret=%d\n", name, id, ret);
+        return false;
+    }
+    DPRINTF("IOP module load ok: %s id=%d ret=%d\n", name, id, ret);
+    return true;
+}
+
+#ifdef DEBUG
+static void DumpLoadedModules(void)
+{
+    smod_mod_info_t cur;
+    smod_mod_info_t next;
+    int ret = smod_get_next_mod(NULL, &cur);
+    if (ret < 0) {
+        DPRINTF("IOP module list unavailable: ret=%d\n", ret);
+        return;
+    }
+    for (;;) {
+        char name[32] = {0};
+        if (cur.name != NULL) {
+            smem_read(cur.name, name, sizeof(name) - 1);
+        } else {
+            snprintf(name, sizeof(name), "<noname>");
+        }
+        DPRINTF("IOP module: name=%s id=%d\n", name, cur.id);
+        ret = smod_get_next_mod(&cur, &next);
+        if (ret < 0) {
+            break;
+        }
+        cur = next;
+    }
+}
+#endif
+
+static bool ProbeDevicePath(const char *path)
+{
+    DIR *d = opendir(path);
+    if (d) {
+        closedir(d);
+        return true;
+    }
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return true;
+    }
+    return false;
+}
+
+static void ProbeMmceSlots(void)
+{
+    mmce_slot0_ready = ProbeDevicePath("mmce0:/") ? 1 : 0;
+    mmce_slot1_ready = ProbeDevicePath("mmce1:/") ? 1 : 0;
+    DPRINTF("MMCE probe: mmce0=%s mmce1=%s\n",
+            mmce_slot0_ready ? "OK" : "FAIL",
+            mmce_slot1_ready ? "OK" : "FAIL");
+}
+
 int main(int argc, char * argv[])
 {
     int ID, RET;
@@ -205,12 +276,49 @@ int main(int argc, char * argv[])
 	LOAD_IRX_NARG(ppctty_irx);
 #endif
 
-	LOAD_IRX_NARG(iomanX_irx);
-	LOAD_IRX_NARG(fileXio_irx);
-	fileXioInit();
+    bool ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
+    bool filexio_ok = false;
+    int filexio_ret = -1;
+    if (ioman_ok) {
+        filexio_ok = LoadIrxChecked("fileXio_irx", fileXio_irx, size_fileXio_irx, NULL, NULL);
+        if (filexio_ok) {
+            filexio_ret = fileXioInit();
+            if (filexio_ret < 0) {
+                DPRINTF("fileXioInit failed: ret=%d\n", filexio_ret);
+                filexio_ok = false;
+            }
+        }
+    } else {
+        DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
+    }
 
 	LOAD_IRX_NARG(sio2man_irx);
-	LOAD_IRX_NARG(mmceman_irx);
+    if (filexio_ok) {
+        int mmceman_id = -1;
+        int mmceman_ret = -1;
+        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+#ifdef DEBUG
+        if (mmceman_ok) {
+            smod_mod_info_t info;
+            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+            if (lookup_ret < 0) {
+                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                DumpLoadedModules();
+            }
+        }
+#endif
+        if (mmceman_ok) {
+            ProbeMmceSlots();
+        } else {
+            mmce_slot0_ready = 0;
+            mmce_slot1_ready = 0;
+        }
+    } else {
+        DPRINTF("Skipping mmceman init; fileXio not ready.\n");
+        mmce_slot0_ready = 0;
+        mmce_slot1_ready = 0;
+    }
     LOAD_IRX_NARG(mcman_irx);
     LOAD_IRX_NARG(mcserv_irx);
     initMC();


### PR DESCRIPTION
### Motivation
- Make IRX load failures easier to diagnose by recording the exact `SifExecModuleBuffer` id/return code for `mmceman` and by providing a debug-only fallback to enumerate IOP modules when a name lookup fails.
- Ensure the startup MMCE probe results are available to Lua so the UI can use a cached slot selection and avoid unnecessary re-probing on MMCE page entry.

### Description
- Changed `LoadIrxChecked` to accept optional output parameters `out_id` and `out_ret` and propagate the `SifExecModuleBuffer` `id` and `ret` values back to callers in `src/main.cpp`.
- Added a debug-only `DumpLoadedModules()` helper that enumerates IOP modules via `smod_get_next_mod` and reads module names via `smem_read`, and invoke it when a lookup for `mmceman` by name fails (wrapped in `#ifdef DEBUG`).
- Log an explicit line with `mmceman` load results (`id` and `ret`) after attempting to load it, and use the lookup+dump diagnostic to learn the real module name if necessary.
- Adjusted calls to the IRX loader to use the new `LoadIrxChecked` signature for `iomanX`, `fileXio`, and `mmceman`, and ensured `mmce_slot0_ready`/`mmce_slot1_ready` are set to 0 when `mmceman` or fileXio are unavailable.
- Exposed the startup MMCE probe state to Lua by pushing `MMCE_SLOT0_READY` and `MMCE_SLOT1_READY` in `luaSystem_init` and seeded `PLDR.MMCE` state in Lua so the UI can use the cached `PLDR.MMCE.PREFIX` when entering the MMCE page (see changes in `src/luasystem.cpp`, `bin/POPSLDR/system.lua`, and `bin/POPSLDR/ui.lua`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697059bd02088321a01d1b12a5b56fb1)