### PR TITLE
Document local PopStarter layout and default to APP_DIR-relative POPSTARTER.ELF; add MMCE probing and robust IOP loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ POPSLoader was created by [El_isra](https://www.github.com/israpps), and this re
 Put `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required):  
 - `system.lua`, `ui.lua`, `images.lua`, `pops_profiles.lua`, `PATCH_5.BIN`  
 - UI images (`*.png`) and optional external IRX modules (`*.irx`)  
+Recommended layout: place `POPSTARTER.ELF` next to `POPSLOADER.ELF` in the same folder.  
+Profiles can override the PopStarter path if needed; legacy locations are fallback-only.  
 Legacy `POPSLDR/` folder layout is still supported as a fallback.  
 See [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md) for layout details and compatibility notes.
 

--- a/bin/POPSLDR/pops_profiles.lua
+++ b/bin/POPSLDR/pops_profiles.lua
@@ -6,9 +6,9 @@
   Licensed under GNU General public license v3.0
 --]]
 LOG("Registering POPStarter profiles...")
-local DEFAULT_PROFILE = 1 -- change this for a different default profile. default package points to classic popstarter path
+local DEFAULT_PROFILE = 1 -- change this for a different default profile. default package points to local popstarter path
 -- to register an ELF that is stored on the same folder than POPSLOADER, please do it this way:
--- System.currentDirectory().."/POPSLDR/PROFILES/YOUR_CUSTOM_PROFILE/POPSTARTER.ELF"
+-- System.currentDirectory().."/POPSTARTER.ELF"
 
 local APP_DIR_LOCAL = APP_DIR or System.currentDirectory()
 if string.sub(APP_DIR_LOCAL, -1) ~= "/" then APP_DIR_LOCAL = APP_DIR_LOCAL.."/" end
@@ -18,6 +18,10 @@ local function ResolveProfilePath(rel)
 end
 
 PLDR.PROFILES = {
+  {
+    ELF="POPSTARTER.ELF";
+    DESC="PopStarter located next to POPSLOADER.ELF";
+  },
   {
     ELF=ResolveProfilePath("PROFILES/MAIN/POPSTARTER.ELF");
     DESC="Latest popstarter without any modifications";

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -28,6 +28,27 @@ local function ResolveWritablePath(rel)
   return modern
 end
 
+local function IsAbsoluteDevicePath(path)
+  return path ~= nil and string.match(path, "^[%a]+%d*:/") ~= nil
+end
+
+local function ResolvePopstarterPath(path)
+  local fallback = "mass:/POPS/POPSTARTER.ELF"
+  local chosen = path
+  if chosen == nil or chosen == "" then
+    chosen = APP_DIR_LOCAL.."POPSTARTER.ELF"
+  elseif not IsAbsoluteDevicePath(chosen) then
+    chosen = APP_DIR_LOCAL..chosen
+  end
+  if doesFileExist(chosen) then
+    return chosen
+  end
+  if chosen ~= fallback and doesFileExist(fallback) then
+    return fallback
+  end
+  return chosen
+end
+
 local function ResolveIrx(name)
   return System.resolveAssetType(name, ASSET_IRX) or (APP_DIR_LOCAL..name)
 end
@@ -90,6 +111,24 @@ PLDR = {
 if BOOTPATH ~= nil then
   PLDR.HDD.LOADSTATE = 1
   PLDR.HDD.STATUS = HDD.GetHDDStatus()
+end
+
+if MMCE_SLOT0_READY ~= nil and MMCE_SLOT0_READY >= 0 then
+  PLDR.MMCE.PROBED = true
+  PLDR.MMCE.SLOTS = {}
+  PLDR.MMCE.INDEX = 1
+  if MMCE_SLOT0_READY == 1 then
+    table.insert(PLDR.MMCE.SLOTS, "mmce0:/")
+  end
+  if MMCE_SLOT1_READY == 1 then
+    table.insert(PLDR.MMCE.SLOTS, "mmce1:/")
+  end
+  if #PLDR.MMCE.SLOTS > 0 then
+    PLDR.MMCE.PREFIX = PLDR.MMCE.SLOTS[PLDR.MMCE.INDEX]
+    LOG("MMCE slot selected: "..PLDR.MMCE.PREFIX)
+  else
+    LOG("MMCE not found")
+  end
 end
 
 require("pops_profiles")
@@ -368,6 +407,7 @@ end
 function PLDR.RunPOPStarterGame(gamelocation, game)
   local source_mode = GetLaunchSourceMode(gamelocation)
   local vcd_path = gamelocation..game
+  local popstarter = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
 
   local BOOTPARAM
   if UI.CURSCENE == UI.SCENES.GSMB then
@@ -377,11 +417,13 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     BOOTPARAM = BuildXXUsageArgs(gamelocation, game, source_mode)
   end
 
-  LOG("PopStarter:", PLDR.POPSTARTER_PATH, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", 2, "args:", BOOTPARAM, "--nr")
-  System.loadELF(PLDR.POPSTARTER_PATH,
+  LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
+  LOG("PopStarter selected: "..popstarter)
+  LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", 2, "args:", BOOTPARAM, "--nr")
+  System.loadELF(popstarter,
     PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER,
     BOOTPARAM, "--nr")
-    LOG(">>> UNHANDLED ERROR at Launching game '", game, " via ", PLDR.POPSTARTER_PATH, " Failed")
+    LOG(">>> UNHANDLED ERROR at Launching game '", game, " via ", popstarter, " Failed")
   error("ERROR: ELF loading failure")
 end
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -191,17 +191,25 @@ UI = {
         if Pads.check(GPAD, PAD_LEFT)  then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT-1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_START) then UI.SceneChange(UI.SCENES.MPROFILE) end
         if Pads.check(GPAD, PAD_SELECT)then UI.SceneChange(UI.SCENES.CREDITS) end
-        if Pads.check(GPAD, PAD_CROSS) then
+          if Pads.check(GPAD, PAD_CROSS) then
           if UI.MainMenu.OPT == 1 then
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
             UI.SceneChange(UI.MainMenu.OPT)
           elseif UI.MainMenu.OPT == 2 then
-            local mmce_prefix = PLDR.DetectMMCESlot()
-            if mmce_prefix == nil then
+            local slots = PLDR.GetMMCESlots()
+            if #slots < 1 then
               UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
             else
-              mmce_prefix = PLDR.SetMMCESlot(1)
+              if PLDR.MMCE.PREFIX == nil then
+                PLDR.SetMMCESlot(1)
+              end
+              local mmce_prefix = PLDR.MMCE.PREFIX or PLDR.SetMMCESlot(1)
+              if mmce_prefix == nil then
+                UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
+                GPAD = 0
+                return
+              end
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
               UI.SceneChange(UI.MainMenu.OPT)

--- a/docs/RUNTIME_LAYOUT.md
+++ b/docs/RUNTIME_LAYOUT.md
@@ -3,6 +3,7 @@
 ## Current expected runtime folder structure (today)
 From README and boot scripts:
 - Place `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required).【F:README.md†L17-L21】
+- Recommended: place `POPSTARTER.ELF` next to `POPSLOADER.ELF`; profiles can override this path, while legacy locations are fallback-only.【F:README.md†L22-L28】
 - `boot.lua` executes the resolved `system.lua` via `System.resolveAsset` and prefers APP_DIR paths first, with legacy `POPSLDR/` fallbacks preserved.【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
 
 Example layout (USB root, no subfolder):
@@ -44,7 +45,7 @@ When resolving Lua scripts/modules:
 |---|---|---|---|
 | Lua entrypoint | `system.lua` | `System.resolveAsset("system.lua")` (APP_DIR first, `POPSLDR/` fallback) | `etc/boot.lua` |【F:etc/boot.lua†L72-L81】【F:src/system.cpp†L80-L107】
 | Lua modules | `ui.lua`, `images.lua`, `pops_profiles.lua` | `package.path` includes `APP_DIR/?.lua` plus legacy `POPSLDR/?.lua` locations | `etc/boot.lua` |【F:etc/boot.lua†L1-L11】
-| POPStarter ELF | `mass:/POPS/POPSTARTER.ELF` | Used as `PLDR.POPSTARTER_PATH` when launching games | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L25-L27】
+| POPStarter ELF | `APP_DIR/POPSTARTER.ELF` (preferred), `mass:/POPS/POPSTARTER.ELF` (fallback) | Resolved at launch from `PLDR.POPSTARTER_PATH` with APP_DIR-first behavior | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L31-L50】【F:bin/POPSLDR/system.lua†L407-L427】
 | POPStarter dependencies (USB/HDD) | `POPS_IOX.PAK`, `POPS.ELF`, `IOPRP252.IMG` | Checked under `mass:/POPS/` or `pfs1:/POPS/` if enabled | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L63-L74】
 | Optional IGR textures | `PATCH_5.BIN` | Documented as replaceable in `POPS/` for POPStarter IGR | `bin/README.md` |【F:bin/README.md†L9-L10】
 

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -594,6 +594,8 @@ static int lua_getDiscType(lua_State *L)
 }
 
 extern void *_gp;
+extern int mmce_slot0_ready;
+extern int mmce_slot1_ready;
 
 #define BUFSIZE (64*1024)
 
@@ -867,6 +869,12 @@ void luaSystem_init(lua_State *L) {
 
 	lua_pushinteger(L, ASSET_IRX);
 	lua_setglobal(L, "ASSET_IRX");
+
+	lua_pushinteger(L, mmce_slot0_ready);
+	lua_setglobal(L, "MMCE_SLOT0_READY");
+
+	lua_pushinteger(L, mmce_slot1_ready);
+	lua_setglobal(L, "MMCE_SLOT1_READY");
 
 	lua_pushinteger(L, O_RDONLY);
 	lua_setglobal(L, "FREAD");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,8 @@ extern unsigned int size_mmceman_irx;
 
 char boot_path[255];
 char app_dir[255];
+int mmce_slot0_ready = -1;
+int mmce_slot1_ready = -1;
 
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
@@ -182,6 +184,75 @@ char* GetArgv0(void) {
     printf("%s: id:%d, ret:%d\n", #_irx, ID, RET)
 #define LOAD_IRX_NARG(_irx) LOAD_IRX(_irx, 0, NULL)
 
+static bool LoadIrxChecked(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret)
+{
+    int id = -1;
+    int ret = -1;
+    id = SifExecModuleBuffer(irx, size, 0, NULL, &ret);
+    if (out_id) {
+        *out_id = id;
+    }
+    if (out_ret) {
+        *out_ret = ret;
+    }
+    if (id < 0 || ret < 0) {
+        DPRINTF("IOP module load failed: %s id=%d ret=%d\n", name, id, ret);
+        return false;
+    }
+    DPRINTF("IOP module load ok: %s id=%d ret=%d\n", name, id, ret);
+    return true;
+}
+
+#ifdef DEBUG
+static void DumpLoadedModules(void)
+{
+    smod_mod_info_t cur;
+    smod_mod_info_t next;
+    int ret = smod_get_next_mod(NULL, &cur);
+    if (ret < 0) {
+        DPRINTF("IOP module list unavailable: ret=%d\n", ret);
+        return;
+    }
+    for (;;) {
+        char name[32] = {0};
+        if (cur.name != NULL) {
+            smem_read(cur.name, name, sizeof(name) - 1);
+        } else {
+            snprintf(name, sizeof(name), "<noname>");
+        }
+        DPRINTF("IOP module: name=%s id=%d\n", name, cur.id);
+        ret = smod_get_next_mod(&cur, &next);
+        if (ret < 0) {
+            break;
+        }
+        cur = next;
+    }
+}
+#endif
+
+static bool ProbeDevicePath(const char *path)
+{
+    DIR *d = opendir(path);
+    if (d) {
+        closedir(d);
+        return true;
+    }
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return true;
+    }
+    return false;
+}
+
+static void ProbeMmceSlots(void)
+{
+    mmce_slot0_ready = ProbeDevicePath("mmce0:/") ? 1 : 0;
+    mmce_slot1_ready = ProbeDevicePath("mmce1:/") ? 1 : 0;
+    DPRINTF("MMCE probe: mmce0=%s mmce1=%s\n",
+            mmce_slot0_ready ? "OK" : "FAIL",
+            mmce_slot1_ready ? "OK" : "FAIL");
+}
+
 int main(int argc, char * argv[])
 {
     int ID, RET;
@@ -205,12 +276,49 @@ int main(int argc, char * argv[])
 	LOAD_IRX_NARG(ppctty_irx);
 #endif
 
-	LOAD_IRX_NARG(iomanX_irx);
-	LOAD_IRX_NARG(fileXio_irx);
-	fileXioInit();
+    bool ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
+    bool filexio_ok = false;
+    int filexio_ret = -1;
+    if (ioman_ok) {
+        filexio_ok = LoadIrxChecked("fileXio_irx", fileXio_irx, size_fileXio_irx, NULL, NULL);
+        if (filexio_ok) {
+            filexio_ret = fileXioInit();
+            if (filexio_ret < 0) {
+                DPRINTF("fileXioInit failed: ret=%d\n", filexio_ret);
+                filexio_ok = false;
+            }
+        }
+    } else {
+        DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
+    }
 
 	LOAD_IRX_NARG(sio2man_irx);
-	LOAD_IRX_NARG(mmceman_irx);
+    if (filexio_ok) {
+        int mmceman_id = -1;
+        int mmceman_ret = -1;
+        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+#ifdef DEBUG
+        if (mmceman_ok) {
+            smod_mod_info_t info;
+            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+            if (lookup_ret < 0) {
+                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                DumpLoadedModules();
+            }
+        }
+#endif
+        if (mmceman_ok) {
+            ProbeMmceSlots();
+        } else {
+            mmce_slot0_ready = 0;
+            mmce_slot1_ready = 0;
+        }
+    } else {
+        DPRINTF("Skipping mmceman init; fileXio not ready.\n");
+        mmce_slot0_ready = 0;
+        mmce_slot1_ready = 0;
+    }
     LOAD_IRX_NARG(mcman_irx);
     LOAD_IRX_NARG(mcserv_irx);
     initMC();


### PR DESCRIPTION
### Motivation
- Make the shipped default profile prefer a PopStarter placed next to `POPSLOADER.ELF` by resolving relative paths to `APP_DIR/POPSTARTER.ELF` while preserving legacy fallbacks.
- Improve runtime robustness by probing MMCE slots early and exposing probe results to Lua so the UI and launcher can make informed decisions.
- Improve IOP module loading resiliency with checked loads and additional debug information to aid troubleshooting.

### Description
- Documentation: updated `README.md` and `docs/RUNTIME_LAYOUT.md` to recommend placing `POPSTARTER.ELF` next to `POPSLOADER.ELF`, note that profiles can override the PopStarter path, and document that legacy locations are fallback-only.
- Default profile: changed the shipped default profile in `bin/POPSLDR/pops_profiles.lua` to use a relative `"POPSTARTER.ELF"` entry so it resolves to `APP_DIR/POPSTARTER.ELF` at runtime.
- PopStarter resolution: added `IsAbsoluteDevicePath` and `ResolvePopstarterPath` in `bin/POPSLDR/system.lua` to treat relative profile paths as `APP_DIR`-relative, fall back to `mass:/POPS/POPSTARTER.ELF` when appropriate, and switched the chainload to use the resolved path with extra debug logs.
- MMCE support: added MMCE probe propagation from native into Lua by defining `mmce_slot0_ready`/`mmce_slot1_ready` in `src/main.cpp`, pushing `MMCE_SLOT0_READY`/`MMCE_SLOT1_READY` into Lua in `src/luasystem.cpp`, and updating `bin/POPSLDR/system.lua` and `bin/POPSLDR/ui.lua` to use probe results and a `PLDR.MMCE` structure for slot selection.
- IOP/IRX robustness: added `LoadIrxChecked`, `DumpLoadedModules` (debug), `ProbeMmceSlots`, and guarded IRX load/init sequences in `src/main.cpp` to record failures, skip dependent inits when prerequisites fail, and set safe defaults for MMCE probing when modules are unavailable.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697059bd02088321a01d1b12a5b56fb1)