### PR TITLE
Update architecture and runtime docs; add UI exit confirmation and launch state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,22 @@ POPSLoader was created by [El_isra](https://www.github.com/israpps), and this re
 ## Status / Roadmap
 - No subfolder dependencies (assets load from ELF directory first).
 - Legacy `POPSLDR/` layout kept as fallback.
-- Treat mmce as USB (XX.) for POPSTARTER.
 
 ## Usage
-Put `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required):  
+Place `POPSLOADER.ELF`, `POPSTARTER.ELF`, Lua scripts, images, and optional IRX modules in the same directory (no required subdirectories).  
 - `system.lua`, `ui.lua`, `images.lua`, `pops_profiles.lua`, `PATCH_5.BIN`  
 - UI images (`*.png`) and optional external IRX modules (`*.irx`)  
-Recommended layout: place `POPSTARTER.ELF` next to `POPSLOADER.ELF` in the same folder.  
-Profiles can override the PopStarter path if needed; legacy locations are fallback-only.  
-Legacy `POPSLDR/` folder layout is still supported as a fallback.  
+Legacy folders (`POPSLDR/`, `IMG/`, `IRX/`) are fallback-only.  
+Profiles can override the PopStarter path if needed.  
 See [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md) for layout details and compatibility notes.
+
+### Device pages
+- The SMB slot represents MMCE (no SMB networking support); `SMB.png` is reused as the icon.  
+- MMCE auto-detects `mmce0:/` and `mmce1:/`, with module load order: `iomanX` → `fileXio` → `mmceman`.  
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for implementation details.
+
+### Controls
+- Triangle: Exit to OSDSYS (with confirmation).
 
 ### Tips
 - (USB Only) if you want POPStarter IGR to go back to POPSLoader automatically, copy `POPSLOADER.ELF` renamed as `BOOT.ELF` (legacy `POPSLDR/` layout is still supported if you use it)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -420,6 +420,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
   LOG("PopStarter selected: "..popstarter)
   LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", 2, "args:", BOOTPARAM, "--nr")
+  UI.LAUNCHING = true
   System.loadELF(popstarter,
     PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER,
     BOOTPARAM, "--nr")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -11,6 +11,7 @@ UI = {
     LASTSCENE = 4;
     CURSCENE = 4;
     SCENES = {GUSB=1, GSMB=2, GHDD=3, MMAIN=4, MPROFILE=5, CREDITS=6};
+    LAUNCHING = false;
     SceneChange = function (SCENE)
       UI.LASTSCENE = UI.CURSCENE
       UI.CURSCENE = SCENE
@@ -64,6 +65,7 @@ UI = {
     --- wrapper for Screen.flip(), here you add UI draws that renders on top of everything (for example, error notifications)
     flip = function (notif)
       UI.Notif_queue.display()
+      UI.Modal.Draw()
       Screen.flip()
     end;
     WelcomeDraw = {
@@ -89,6 +91,82 @@ UI = {
           Graphics.drawRect(0, 20, UI.SCR.X, 398, UI.CCOL.TRANSP_BLACK)
       end;
     };
+    Modal = {
+      active = false;
+      title = "";
+      body = "";
+      options = {"Yes", "No"};
+      selected = 2;
+      OpenExit = function ()
+        LOG("Exit requested")
+        UI.Modal.active = true
+        UI.Modal.title = "Exit"
+        UI.Modal.body = "Return to OSDSYS?"
+        UI.Modal.options = {"Yes", "No"}
+        UI.Modal.selected = 2
+      end;
+      Close = function ()
+        UI.Modal.active = false
+      end;
+      Confirm = function ()
+        LOG("Exit confirmed")
+        UI.LAUNCHING = true
+        System.exitToBrowser()
+      end;
+      HandleInput = function ()
+        if not UI.Modal.active then return end
+        if Pads.check(GPAD, PAD_LEFT) or Pads.check(GPAD, PAD_RIGHT) then
+          if UI.Modal.selected == 1 then
+            UI.Modal.selected = 2
+          else
+            UI.Modal.selected = 1
+          end
+          GPAD = 0
+        elseif Pads.check(GPAD, PAD_CROSS) then
+          if UI.Modal.selected == 1 then
+            UI.Modal.Confirm()
+          else
+            UI.Modal.Close()
+          end
+          GPAD = 0
+        elseif Pads.check(GPAD, PAD_CIRCLE) then
+          UI.Modal.Close()
+          GPAD = 0
+        end
+      end;
+      Draw = function ()
+        if not UI.Modal.active then return end
+        local box_w = 320
+        local box_h = 140
+        local box_x = UI.SCR.X_MID - (box_w / 2)
+        local box_y = UI.SCR.Y_MID - (box_h / 2)
+        Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, 120))
+        Graphics.drawRect(box_x, box_y, box_w, box_h, Color.new(0, 0, 0, 200))
+        Graphics.drawRect(box_x, box_y, box_w, 2, UI.CCOL.GREY)
+        Graphics.drawRect(box_x, box_y + box_h - 2, box_w, 2, UI.CCOL.GREY)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 10, 8, UI.SCR.X, 16, UI.Modal.title, UI.CCOL.YELLOW)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 50, 8, UI.SCR.X, 16, UI.Modal.body, UI.CCOL.GREY)
+        local yes_col = UI.Modal.selected == 1 and UI.CCOL.YELLOW or UI.CCOL.GREY
+        local no_col = UI.Modal.selected == 2 and UI.CCOL.YELLOW or UI.CCOL.GREY
+        Font.ftPrint(BFONT, UI.SCR.X_MID - 60, box_y + 95, 0, UI.SCR.X, 16, UI.Modal.options[1], yes_col)
+        Font.ftPrint(BFONT, UI.SCR.X_MID + 20, box_y + 95, 0, UI.SCR.X, 16, UI.Modal.options[2], no_col)
+      end;
+    };
+    HandleGlobalInput = function (allow_exit)
+      if UI.Modal.active then
+        UI.Modal.HandleInput()
+        return true
+      end
+      if allow_exit == nil then allow_exit = true end
+      if not allow_exit then return false end
+      if UI.LAUNCHING then return false end
+      if Pads.check(GPAD, PAD_TRIANGLE) then
+        UI.Modal.OpenExit()
+        GPAD = 0
+        return true
+      end
+      return false
+    end;
     GameList = {
       MAXDRAW = 18;
       CURR = 1;
@@ -120,6 +198,12 @@ UI = {
           Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID+1, UI.SCR.Y_MID+1, 20, UI.SCR.X, 32, "No games found", UI.CCOL.TRANSP_BLACK)
         end
         UI.Pad.Listen()
+        if UI.CURSCENE == UI.SCENES.GSMB then
+          local slots = PLDR.GetMMCESlots()
+          UI.HandleGlobalInput(#slots <= 1)
+        else
+          UI.HandleGlobalInput(true)
+        end
         if Pads.check(GPAD, PAD_CIRCLE) then UI.SceneChange(UI.SCENES.MMAIN) end
         if UI.CURSCENE == UI.SCENES.GSMB then
           local slots = PLDR.GetMMCESlots()
@@ -160,6 +244,7 @@ UI = {
         Font.ftPrint(BFONT, UI.SCR.X_MID, 190, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].DESC, UI.CCOL.GREY)
         Font.ftPrint(BFONT, UI.SCR.X_MID, 280, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].ELF, Color.new(128,128,128, 110))
         UI.Pad.Listen()
+        UI.HandleGlobalInput(true)
         if Pads.check(GPAD, PAD_DOWN) then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_UP) then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_CIRCLE) then UI.SceneChange(UI.SCENES.MMAIN) end
@@ -185,7 +270,11 @@ UI = {
         end
         Graphics.drawImage(IMG["start"], 20, UI.SCR.Y-65) Font.ftPrint(SFONT, 55, UI.SCR.Y-60, 0, UI.SCR.X, 16, "POPStarter profiles")
         Graphics.drawImage(IMG["select"], 20, UI.SCR.Y-85) Font.ftPrint(SFONT, 55, UI.SCR.Y-80, 0, UI.SCR.X, 16, "About")
+        if not UI.LAUNCHING and not UI.Modal.active then
+          Font.ftPrint(SFONT, 55, UI.SCR.Y-100, 0, UI.SCR.X, 16, "△ Exit")
+        end
         UI.Pad.Listen()
+        UI.HandleGlobalInput(true)
         if Pads.check(GPAD, PAD_RIGHT) then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT+1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_LEFT)  then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT-1, 1, profcnt) GPAD = 0 end
         if Pads.check(GPAD, PAD_START) then UI.SceneChange(UI.SCENES.MPROFILE) end
@@ -280,6 +369,7 @@ UI = {
         Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, 120, 20, UI.SCR.X, UI.SCR.Y, "Based on Enceladus by Daniel santos\n\nSpecial thanks to:\nkrHACKen: for making POPStarter\nuyjulian, fjtrujy, HWC and others for always helping me\n\nThis program is free and open source\nif you bought it you've been scammed", currcol)
         Graphics.drawRect(0, UI.SCR.Y-60, UI.SCR.X, 2, currcol)
         UI.Pad.Listen()
+        UI.HandleGlobalInput(true)
         if GPAD ~= 0 then UI.Credits.INCR = 1 end
       end
     };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,17 +1,18 @@
 # Architecture
 
-## High-level flow (UI → profile selection → POPStarter handoff)
-- The Lua entrypoint is `etc/boot.lua`, embedded into the ELF at build time and executed at startup; it sets `package.path` and runs the resolved `system.lua` (APP_DIR first, legacy `POPSLDR/` fallback).【F:Makefile†L71-L73】【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
-- `bin/POPSLDR/system.lua` initializes UI state and executes a main loop that drives scenes (main menu, profile query, game list, credits).【F:bin/POPSLDR/system.lua†L277-L296】
-- POPStarter handoff is performed by `PLDR.RunPOPStarterGame`, which builds a boot parameter and calls `System.loadELF(POPSLDR.POPSTARTER_PATH, ...)`.【F:bin/POPSLDR/system.lua†L262-L279】
+This document reflects the current POPSLoader architecture as implemented in the codebase.
 
-## Key modules / files and responsibilities
-- `src/main.cpp`: EE entrypoint; sets up IOP modules, device readiness, and boot path from argv, then executes embedded Lua boot script.【F:src/main.cpp†L65-L126】
-- `etc/boot.lua`: boot script; sets Lua search paths, handles HDD boot path setup, and loads the resolved `system.lua` (flat-first).【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
-- `bin/POPSLDR/system.lua`: core runtime logic for POPSLoader UI, game list handling, and POPStarter handoff (calls `System.loadELF`).【F:bin/POPSLDR/system.lua†L25-L31】【F:bin/POPSLDR/system.lua†L262-L296】
-- `bin/POPSLDR/ui.lua`, `bin/POPSLDR/images.lua`, `bin/POPSLDR/pops_profiles.lua`: UI and profile data loaded via `require(...)` from `system.lua`.【F:bin/POPSLDR/system.lua†L55-L58】
-- `src/luasystem.cpp`: provides Lua bindings such as `System.loadELF` for POPStarter handoff.【F:src/luasystem.cpp†L496-L526】【F:src/luasystem.cpp†L720-L735】
+## Startup flow (EE entrypoint → Lua boot)
+- Optional IOP reset is performed only when `RESET_IOP` is defined (`SifIopReset`/`SifIopSync`).【F:src/main.cpp†L262-L267】
+- IOP module init order for MMCE support is: `iomanX` → `fileXio` (and `fileXioInit`) → `mmceman`; MMCE slots are probed after `mmceman` loads successfully.【F:src/main.cpp†L279-L313】
+- `APP_DIR` is derived from the launch path (`argv[0]`) via `setAppDirFromPath`, with `boot_path` fallback when no argv is provided.【F:src/main.cpp†L363-L368】
+- A USB readiness preflight probes `mass:/` (stat loop with retries).【F:src/main.cpp†L350-L361】
+- The embedded Lua boot script (`etc/boot.lua`) sets `package.path` and loads the resolved `system.lua` (APP_DIR first, legacy `POPSLDR/` fallback).【F:etc/boot.lua†L1-L11】【F:etc/boot.lua†L72-L81】
 
-## Where Lua lives and how it’s invoked
-- Lua boot code is embedded from `etc/boot.lua` into the ELF during the build (via `bin2c`).【F:Makefile†L71-L73】
-- Runtime Lua scripts are expected beside the ELF (flat layout) with `POPSLDR/` kept as a legacy fallback for `dofile`/`require`.【F:etc/boot.lua†L1-L11】【F:etc/boot.lua†L72-L81】
+## UI flow (scenes and device pages)
+- The main menu defines three device slots (`USB`, `SMB`, `HDD`); the `SMB` slot is wired to the MMCE device page and uses MMCE slot discovery/selection rather than SMB networking.【F:bin/POPSLDR/ui.lua†L261-L307】
+- MMCE slot detection is driven by `mmce0:/` and `mmce1:/` availability (populated into `PLDR.MMCE.SLOTS`).【F:bin/POPSLDR/system.lua†L116-L127】
+- POPStarter launches use a shared path builder: USB and MMCE both use the `XX.` boot parameter format, while the launch mode differs (`isra` for USB/mass, device string for MMCE).【F:bin/POPSLDR/system.lua†L390-L405】
+
+## Exit path (UI → OSDSYS)
+- Triangle opens an exit confirmation modal; confirming calls `System.exitToBrowser()` to return to OSDSYS.【F:bin/POPSLDR/ui.lua†L94-L168】

--- a/docs/RUNTIME_LAYOUT.md
+++ b/docs/RUNTIME_LAYOUT.md
@@ -1,53 +1,39 @@
-# Runtime layout
+# Runtime layout (single source of truth)
 
-## Current expected runtime folder structure (today)
-From README and boot scripts:
-- Place `POPSLOADER.ELF` and runtime assets in the same folder (no subfolder required).【F:README.md†L17-L21】
-- Recommended: place `POPSTARTER.ELF` next to `POPSLOADER.ELF`; profiles can override this path, while legacy locations are fallback-only.【F:README.md†L22-L28】
-- `boot.lua` executes the resolved `system.lua` via `System.resolveAsset` and prefers APP_DIR paths first, with legacy `POPSLDR/` fallbacks preserved.【F:etc/boot.lua†L1-L81】【F:src/system.cpp†L80-L107】
+This document describes how POPSLoader resolves runtime assets **today**, based on the current codebase. It is the authoritative layout reference; other docs should defer to this file.
 
-Example layout (USB root, no subfolder):
-```
-/mass:/
-  POPSLOADER.ELF
-  system.lua
-  ui.lua
-  images.lua
-  pops_profiles.lua
-  PATCH_5.BIN
-  USB.png
-  SMB.png
-  HDD.png
-  PSL.png
-  select.png
-  start.png
-  (optional) *.irx
-```
-(See packaged assets under `bin/POPSLDR/` in the repo; packaging flattens them beside the ELF.)【F:bin/POPSLDR/system.lua†L1-L11】【F:Makefile†L171-L179】
+## Flat layout (recommended)
+Place these files **next to** `POPSLOADER.ELF` in the same directory (no required subfolders):
+- `POPSLOADER.ELF`
+- `POPSTARTER.ELF`
+- Lua scripts (e.g., `system.lua`, `ui.lua`, `images.lua`, `pops_profiles.lua`)
+- UI images (`*.png`)
+- External modules (`*.irx`)
+- Profiles/configs if stored as external files
 
-## Target layout (goal)
-**Goal:** assets should load from the ELF directory first (no subfolder dependency). This is implemented in the resolver and must preserve legacy fallback behavior unless intentionally removed and documented. (See `AGENTS.md` for the explicit roadmap statement.)【F:AGENTS.md†L41-L50】【F:src/system.cpp†L80-L107】
+Legacy subfolders (`POPSLDR/`, `IMG/`, `IRX/`) are **fallback only** and should not be required for a correct install.
 
-## Compatibility strategy (fallback order)
-When resolving Lua scripts/modules:
+## Search order (explicit)
+### Lua scripts and modules
+`etc/boot.lua` sets the Lua search path so that assets are resolved in this order:
 1. `APP_DIR/?.lua`
 2. `APP_DIR/POPSLDR/?.lua` (legacy fallback)
 3. `./?.lua`
 4. `./POPSLDR/?.lua`
 5. `mass:/POPSLDR/?.lua`
 6. `mc0:/POPSLDR/?.lua`
-7. `mc1:/POPSLDR/?.lua`【F:etc/boot.lua†L1-L11】
+7. `mc1:/POPSLDR/?.lua`
 
-`boot.lua` resolves `system.lua` via `System.resolveAsset` before falling back to error handling.【F:etc/boot.lua†L72-L81】
+### Images and IRX modules
+`System.resolveAssetType` and runtime helpers attempt the flat layout first, then legacy folders:
+- Images: `APP_DIR/`, `APP_DIR/IMG/`, `APP_DIR/POPSLDR/IMG/`, `APP_DIR/POPSLDR/`
+- IRX: `APP_DIR/`, `APP_DIR/IRX/`, `APP_DIR/POPSLDR/IRX/`, `APP_DIR/POPSLDR/`
 
-## Runtime assets and search locations
-| Asset type | Example(s) | Search / usage location | Evidence |
-|---|---|---|---|
-| Lua entrypoint | `system.lua` | `System.resolveAsset("system.lua")` (APP_DIR first, `POPSLDR/` fallback) | `etc/boot.lua` |【F:etc/boot.lua†L72-L81】【F:src/system.cpp†L80-L107】
-| Lua modules | `ui.lua`, `images.lua`, `pops_profiles.lua` | `package.path` includes `APP_DIR/?.lua` plus legacy `POPSLDR/?.lua` locations | `etc/boot.lua` |【F:etc/boot.lua†L1-L11】
-| POPStarter ELF | `APP_DIR/POPSTARTER.ELF` (preferred), `mass:/POPS/POPSTARTER.ELF` (fallback) | Resolved at launch from `PLDR.POPSTARTER_PATH` with APP_DIR-first behavior | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L31-L50】【F:bin/POPSLDR/system.lua†L407-L427】
-| POPStarter dependencies (USB/HDD) | `POPS_IOX.PAK`, `POPS.ELF`, `IOPRP252.IMG` | Checked under `mass:/POPS/` or `pfs1:/POPS/` if enabled | `bin/POPSLDR/system.lua` |【F:bin/POPSLDR/system.lua†L63-L74】
-| Optional IGR textures | `PATCH_5.BIN` | Documented as replaceable in `POPS/` for POPStarter IGR | `bin/README.md` |【F:bin/README.md†L9-L10】
+## Device support (path prefixes used in code)
+POPSLoader uses these device prefixes in its runtime paths:
+- Memory card: `mc0:/`, `mc1:/`
+- USB mass storage: `mass:/` and `mass0:/`–`mass4:/` (the game list path is built as `mass{MASSINDX}:/`, default `MASSINDX = 0`)
+- MMCE: `mmce0:/`, `mmce1:/`
 
-## TODOs / unknowns (verify in code)
-- `mmce0:/` usage is not visible in the reviewed files. The module `mmceman.irx` is embedded, but no explicit device path references were found. **TODO: verify** in other Lua scripts or C/C++ modules.【F:iop/embed/mmceman.irx†L1-L1】
+## Not handled here
+This document does **not** define POPStarter’s own `POPS/` folder expectations (e.g., `mass:/POPS/` or `pfs1:/POPS/`). Those remain POPStarter responsibilities and are validated elsewhere in the runtime.


### PR DESCRIPTION
### Motivation
- Align documentation with the actual code paths for startup, device handling, and exit behavior by updating `docs/ARCHITECTURE.md` and `docs/RUNTIME_LAYOUT.md` to be authoritative references. 
- Make the startup sequence explicit in docs by reflecting implemented behavior such as optional IOP reset, the `iomanX` → `fileXio` → `mmceman` init order, `APP_DIR` derivation, and the `mass:/` preflight probe. 
- Improve UI robustness by adding an explicit exit confirmation flow and a `UI.LAUNCHING` state to prevent user input interference during game launch or exit transitions.

### Description
- Rewrote `docs/ARCHITECTURE.md` to document the actual startup flow (including optional `RESET_IOP` reset, `iomanX` → `fileXio` → `mmceman` ordering, `APP_DIR` detection from `argv[0]`, and the `mass:/` readiness probe), the UI/device page wiring, and the Triangle-driven exit path. 
- Revised `docs/RUNTIME_LAYOUT.md` into a single-source-of-truth layout doc that recommends a flat layout, enumerates the Lua search order, images/IRX lookup order, and device prefixes (`mc0:/`, `mc1:/`, `mass:/`, `mass0..mass4:/`, `mmce0:/`, `mmce1:/`). 
- Updated `bin/POPSLDR/ui.lua` to add `UI.LAUNCHING`, implement a modal (`UI.Modal`) with `OpenExit`, `Close`, `Confirm`, input handling and drawing, integrated `UI.Modal` into `UI.flip`, and wired `HandleGlobalInput` calls across scenes to block exits while launching. 
- Updated `bin/POPSLDR/system.lua` to set `UI.LAUNCHING = true` before invoking `System.loadELF` for POPStarter handoff to reflect the runtime launch state. 
- Minor `README.md` edits to document the MMCE/SMB device page behavior and the Triangle control mapping consistent with the implemented UI changes.

### Testing
- No automated tests were run for these changes. 
- Changes were limited to documentation and UI behavior code paths with no automated verification performed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69706bca0ee08321a965eef7b31bbd5d)