### PR TITLE
Translate MMCE handoff paths for PopStarter

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -404,22 +404,56 @@ local function GetLaunchSourceMode(gamelocation)
   return "isra"
 end
 
+local function TranslateMMCEPathForPopStarter(gamelocation)
+  return string.gsub(gamelocation, "^mmce%d:/", "mass:/")
+end
+
 function PLDR.RunPOPStarterGame(gamelocation, game)
+  local is_mmce = string.match(gamelocation, "^mmce") ~= nil
   local source_mode = GetLaunchSourceMode(gamelocation)
+  if is_mmce then
+    source_mode = "isra"
+  end
+  local handoff_gamelocation = gamelocation
+  if is_mmce then
+    handoff_gamelocation = TranslateMMCEPathForPopStarter(gamelocation)
+  end
   local vcd_path = gamelocation..game
   local popstarter = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
 
   local BOOTPARAM
-  if UI.CURSCENE == UI.SCENES.GSMB then
+  if UI.CURSCENE == UI.SCENES.GSMB and not is_mmce then
     -- SMB uses a distinct SB usage format when enabled.
-    BOOTPARAM = PLDR.replace_device(gamelocation, source_mode).."SB."..PLDR.replace_extension(game, "ELF")
+    BOOTPARAM = PLDR.replace_device(handoff_gamelocation, source_mode).."SB."..PLDR.replace_extension(game, "ELF")
   else
-    BOOTPARAM = BuildXXUsageArgs(gamelocation, game, source_mode)
+    BOOTPARAM = BuildXXUsageArgs(handoff_gamelocation, game, source_mode)
   end
 
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
   LOG("PopStarter selected: "..popstarter)
   LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", 2, "args:", BOOTPARAM, "--nr")
+  local device_page = "unknown"
+  if string.match(gamelocation, "^mass") then
+    device_page = "USB"
+  elseif string.match(gamelocation, "^mmce") then
+    device_page = "MMCE"
+  elseif string.match(gamelocation, "^pfs") then
+    device_page = "HDD"
+  elseif UI and UI.CURSCENE then
+    if UI.CURSCENE == UI.SCENES.GUSB then
+      device_page = "USB"
+    elseif UI.CURSCENE == UI.SCENES.GSMB then
+      device_page = "SMB/MMCE"
+    elseif UI.CURSCENE == UI.SCENES.GHDD then
+      device_page = "HDD"
+    end
+  end
+  LOG("PopStarter handoff device page:", device_page, "UI scene:", UI and UI.CURSCENE or "unknown")
+  LOG("PopStarter handoff source mode:", source_mode)
+  LOG("PopStarter handoff path:", popstarter)
+  LOG("PopStarter handoff game path (raw):", gamelocation, "translated:", handoff_gamelocation, "game:", game, "vcd_path:", vcd_path)
+  LOG("PopStarter argv[0]:", BOOTPARAM)
+  LOG("PopStarter argv[1]:", "--nr")
   UI.LAUNCHING = true
   System.loadELF(popstarter,
     PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER,


### PR DESCRIPTION
### Motivation
- Ensure MMCE launches use the same PopStarter parsing/init path as USB by handing PopStarter a `mass:/`-style path while keeping UI listings as `mmce0:/`/`mmce1:/`.
- Repository inspection showed PopStarter and related code expect `mass:/` device prefixes (examples: `POPSTARTER_PATH`, `boot.lua`, `elf-loader` and `main.cpp` checks), so translation to `mass:/` is needed for compatibility.

### Description
- Add `TranslateMMCEPathForPopStarter` which maps `mmce%d:/` prefixes to `mass:/` for handoff only and preserve original `gamelocation` for UI/storage.
- Use a `handoff_gamelocation` when building PopStarter argv via `BuildXXUsageArgs` and for the SMB `SB.` branch so PopStarter always receives the mass-style path for MMCE launches.
- Force the PopStarter source mode to `isra` for MMCE handoffs to follow USB/mass behavior and change the SMB branch to exclude MMCE (`and not is_mmce`).
- Improve runtime logging to print device page, source mode, PopStarter path, original and translated game paths, and each `argv` entry before calling `System.loadELF`.

### Testing
- No automated tests or CI were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697075136bf483219f3f5897a10bb514)