### PR TITLE
Normalize MMCE PopStarter handoff and add handoff logging; lazy textures, boot stamps, and UI/input fixes

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -6,7 +6,7 @@
   Licensed under GNU General public license v3.0
 --]]
 
-LOG("Loading images")
+LOG("Registering images")
 local function ResolveImage(name)
   return System.resolveAssetType(name, ASSET_IMG) or name
 end
@@ -35,12 +35,26 @@ local IMGS = {
   --"triangle.png",
   --"up.png",
 }
-IMG = {}
-LOGF("%d images registered", #IMGS)
+local IMG_SOURCES = {}
 for x=1, #IMGS do
-  local INDX = IMGS[x]:match("(.+)%..+$")
-  local PATH = ResolveImage(IMGS[x])
-  IMG[INDX] = Graphics.loadImage(PATH)
-  if IMG[INDX] == nil then error("Could not load '"..PATH.."'") end
-  Graphics.setImageFilters(IMG[INDX], LINEAR)
+  local key = IMGS[x]:match("(.+)%..+$")
+  IMG_SOURCES[key] = IMGS[x]
 end
+
+IMG = setmetatable({}, {
+  __index = function (tbl, key)
+    local source = IMG_SOURCES[key]
+    if source == nil then return nil end
+    if BOOT_PROF and BOOT_PROF.stamp and not BOOT_PROF.textures_ready then
+      BOOT_PROF.textures_ready = true
+      BOOT_PROF.stamp("UI assets init (textures)")
+    end
+    local path = ResolveImage(source)
+    local img = Graphics.loadImage(path)
+    if img == nil then error("Could not load '"..path.."'") end
+    Graphics.setImageFilters(img, LINEAR)
+    rawset(tbl, key, img)
+    return img
+  end
+})
+LOGF("%d images registered (lazy)", #IMGS)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -132,7 +132,24 @@ if MMCE_SLOT0_READY ~= nil and MMCE_SLOT0_READY >= 0 then
 end
 
 require("pops_profiles")
-require("ui")
+local ok_ui, ui_or_err = pcall(require, "ui")
+if not ok_ui then
+  LOG("UI load failed")
+  LOG("APP_DIR:", APP_DIR_LOCAL)
+  LOG("Boot cwd:", System.currentDirectory())
+  LOG("package.path:", package.path)
+  error("UI module failed to load: "..tostring(ui_or_err))
+end
+if ui_or_err ~= nil and ui_or_err ~= true then
+  UI = ui_or_err
+end
+if UI == nil then
+  LOG("UI global is nil after require('ui')")
+  LOG("APP_DIR:", APP_DIR_LOCAL)
+  LOG("Boot cwd:", System.currentDirectory())
+  LOG("package.path:", package.path)
+  error("UI global not initialized (module returned nil or did not set UI)")
+end
 require("images")
 
 function PLDR.DetectMMCESlot()
@@ -408,9 +425,16 @@ local function TranslateMMCEPathForPopStarter(gamelocation)
   return string.gsub(gamelocation, "^mmce%d:/", "mass:/")
 end
 
+local function LogPopstarterArgs(args)
+  for i = 1, #args do
+    LOG("PopStarter argv["..(i - 1).."]:", args[i])
+  end
+end
+
 function PLDR.RunPOPStarterGame(gamelocation, game)
   local is_mmce = string.match(gamelocation, "^mmce") ~= nil
   local source_mode = GetLaunchSourceMode(gamelocation)
+  local raw_source_mode = source_mode
   if is_mmce then
     source_mode = "isra"
   end
@@ -428,10 +452,11 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   else
     BOOTPARAM = BuildXXUsageArgs(handoff_gamelocation, game, source_mode)
   end
+  local argv = {BOOTPARAM, "--nr"}
 
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
   LOG("PopStarter selected: "..popstarter)
-  LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", 2, "args:", BOOTPARAM, "--nr")
+  LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", #argv)
   local device_page = "unknown"
   if string.match(gamelocation, "^mass") then
     device_page = "USB"
@@ -449,15 +474,15 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     end
   end
   LOG("PopStarter handoff device page:", device_page, "UI scene:", UI and UI.CURSCENE or "unknown")
-  LOG("PopStarter handoff source mode:", source_mode)
+  LOG("PopStarter handoff source mode:", source_mode, "raw_source:", raw_source_mode)
+  LOG("PopStarter reboot_iop flag:", PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER)
   LOG("PopStarter handoff path:", popstarter)
   LOG("PopStarter handoff game path (raw):", gamelocation, "translated:", handoff_gamelocation, "game:", game, "vcd_path:", vcd_path)
-  LOG("PopStarter argv[0]:", BOOTPARAM)
-  LOG("PopStarter argv[1]:", "--nr")
+  LogPopstarterArgs(argv)
   UI.LAUNCHING = true
   System.loadELF(popstarter,
     PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER,
-    BOOTPARAM, "--nr")
+    argv[1], argv[2])
     LOG(">>> UNHANDLED ERROR at Launching game '", game, " via ", popstarter, " Failed")
   error("ERROR: ELF loading failure")
 end
@@ -490,4 +515,8 @@ while true do
     UI.Credits.Play()
   end
   UI.flip()
+  if BOOT_PROF and not BOOT_PROF.first_main_menu and UI.CURSCENE == UI.SCENES.MMAIN then
+    BOOT_PROF.first_main_menu = true
+    BOOT_PROF.stamp("first frame / main menu visible")
+  end
 end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -7,7 +7,7 @@
 --]]
 
 LOG("Registering POPSLoader UI")
-UI = {
+local UI = {
     LASTSCENE = 4;
     CURSCENE = 4;
     SCENES = {GUSB=1, GSMB=2, GHDD=3, MMAIN=4, MPROFILE=5, CREDITS=6};
@@ -36,8 +36,9 @@ UI = {
       BGCOL = Color.new(32,0,32);
     };
     InputConfig = {
-      NAV_REPEAT_DELAY_MS = 300;
-      NAV_REPEAT_INTERVAL_MS = 150;
+      NAV_REPEAT_DELAY_MS = 350;
+      NAV_REPEAT_INTERVAL_MS = 170;
+      ANALOG_DEADZONE = 0.35;
     };
     --- Notifications queue handler
     Notif_queue = {
@@ -119,19 +120,19 @@ UI = {
       end;
       HandleInput = function ()
         if not UI.Modal.active then return end
-        if UI.Pad.Events.LEFT or UI.Pad.Events.RIGHT then
+        if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT then
           if UI.Modal.selected == 1 then
             UI.Modal.selected = 2
           else
             UI.Modal.selected = 1
           end
-        elseif UI.Pad.Events.CROSS then
+        elseif UI.Pad.Events.CONFIRM then
           if UI.Modal.selected == 1 then
             UI.Modal.Confirm()
           else
             UI.Modal.Close()
           end
-        elseif UI.Pad.Events.CIRCLE then
+        elseif UI.Pad.Events.BACK then
           UI.Modal.Close()
         end
       end;
@@ -161,7 +162,7 @@ UI = {
       if allow_exit == nil then allow_exit = true end
       if not allow_exit then return false end
       if UI.LAUNCHING then return false end
-      if UI.Pad.Events.TRIANGLE then
+      if UI.Pad.Events.EXIT then
         UI.Modal.OpenExit()
         return true
       end
@@ -204,10 +205,10 @@ UI = {
         else
           UI.HandleGlobalInput(true)
         end
-        if UI.Pad.Events.CIRCLE then UI.SceneChange(UI.SCENES.MMAIN) end
+        if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
         if UI.CURSCENE == UI.SCENES.GSMB then
           local slots = PLDR.GetMMCESlots()
-          if #slots > 1 and UI.Pad.Events.TRIANGLE then
+          if #slots > 1 and UI.Pad.Events.EXIT then
             local next_prefix = PLDR.SetMMCESlot(PLDR.MMCE.INDEX + 1)
             if next_prefix ~= nil then
               PLDR.CleanupGameList()
@@ -215,11 +216,11 @@ UI = {
             end
           end
         end
-        if UI.Pad.Events.DOWN then UI.GameList.CURR = CLAMP(UI.GameList.CURR+1, 1, ammount) end
-        if UI.Pad.Events.RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
-        if UI.Pad.Events.UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
-        if UI.Pad.Events.LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
-        if UI.Pad.Events.CROSS and ammount > 0 then
+        if UI.Pad.Events.NAV_DOWN then UI.GameList.CURR = CLAMP(UI.GameList.CURR+1, 1, ammount) end
+        if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
+        if UI.Pad.Events.NAV_UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
+        if UI.Pad.Events.NAV_LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
+        if UI.Pad.Events.CONFIRM and ammount > 0 then
           if not doesFileExist(PLDR.POPSTARTER_PATH) then
             UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..PLDR.POPSTARTER_PATH)
           else
@@ -244,10 +245,10 @@ UI = {
         Font.ftPrint(BFONT, UI.SCR.X_MID, 280, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].ELF, Color.new(128,128,128, 110))
         UI.Pad.Listen()
         UI.HandleGlobalInput(true)
-        if UI.Pad.Events.DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
-        if UI.Pad.Events.UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) end
-        if UI.Pad.Events.CIRCLE then UI.SceneChange(UI.SCENES.MMAIN) end
-        if UI.Pad.Events.CROSS then
+        if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
+        if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) end
+        if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
+        if UI.Pad.Events.CONFIRM then
           if not doesFileExist(PLDR.PROFILES[UI.ProfileQuery.curopt].ELF) then
             UI.Notif_queue.add("POPStarter ELF missing")
           else
@@ -274,11 +275,11 @@ UI = {
         end
         UI.Pad.Listen()
         UI.HandleGlobalInput(true)
-        if UI.Pad.Events.RIGHT then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT+1, 1, profcnt) end
-        if UI.Pad.Events.LEFT  then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT-1, 1, profcnt) end
+        if UI.Pad.Events.NAV_RIGHT then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT+1, 1, profcnt) end
+        if UI.Pad.Events.NAV_LEFT  then UI.MainMenu.OPT = CLAMP(UI.MainMenu.OPT-1, 1, profcnt) end
         if UI.Pad.Events.START then UI.SceneChange(UI.SCENES.MPROFILE) end
         if UI.Pad.Events.SELECT then UI.SceneChange(UI.SCENES.CREDITS) end
-          if UI.Pad.Events.CROSS then
+          if UI.Pad.Events.CONFIRM then
           if UI.MainMenu.OPT == 1 then
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
@@ -335,19 +336,18 @@ UI = {
       GPAD = 0;
       Timer = nil;
       Events = {
-        UP = false,
-        DOWN = false,
-        LEFT = false,
-        RIGHT = false,
-        CROSS = false,
-        CIRCLE = false,
-        TRIANGLE = false,
-        SQUARE = false,
+        NAV_UP = false,
+        NAV_DOWN = false,
+        NAV_LEFT = false,
+        NAV_RIGHT = false,
+        CONFIRM = false,
+        BACK = false,
+        EXIT = false,
         START = false,
         SELECT = false,
       };
-      REPEAT_DELAY = UI.InputConfig.NAV_REPEAT_DELAY_MS;
-      REPEAT_INTERVAL = UI.InputConfig.NAV_REPEAT_INTERVAL_MS;
+      REPEAT_DELAY = nil;
+      REPEAT_INTERVAL = nil;
       RepeatStart = {};
       RepeatLast = {};
       Listen = function ()
@@ -364,14 +364,13 @@ UI = {
         local pressed = UI.Pad.GPAD & ~UI.Pad.OLDPAD
         local released = ~UI.Pad.GPAD & UI.Pad.OLDPAD
 
-        UI.Pad.Events.UP = false
-        UI.Pad.Events.DOWN = false
-        UI.Pad.Events.LEFT = false
-        UI.Pad.Events.RIGHT = false
-        UI.Pad.Events.CROSS = (pressed & PAD_CROSS) ~= 0
-        UI.Pad.Events.CIRCLE = (pressed & PAD_CIRCLE) ~= 0
-        UI.Pad.Events.TRIANGLE = (pressed & PAD_TRIANGLE) ~= 0
-        UI.Pad.Events.SQUARE = (pressed & PAD_SQUARE) ~= 0
+        UI.Pad.Events.NAV_UP = false
+        UI.Pad.Events.NAV_DOWN = false
+        UI.Pad.Events.NAV_LEFT = false
+        UI.Pad.Events.NAV_RIGHT = false
+        UI.Pad.Events.CONFIRM = (pressed & PAD_CROSS) ~= 0
+        UI.Pad.Events.BACK = (pressed & PAD_CIRCLE) ~= 0
+        UI.Pad.Events.EXIT = (pressed & PAD_TRIANGLE) ~= 0
         UI.Pad.Events.START = (pressed & PAD_START) ~= 0
         UI.Pad.Events.SELECT = (pressed & PAD_SELECT) ~= 0
 
@@ -398,10 +397,10 @@ UI = {
           return false
         end
 
-        UI.Pad.Events.UP = handle_repeat("UP", PAD_UP)
-        UI.Pad.Events.DOWN = handle_repeat("DOWN", PAD_DOWN)
-        UI.Pad.Events.LEFT = handle_repeat("LEFT", PAD_LEFT)
-        UI.Pad.Events.RIGHT = handle_repeat("RIGHT", PAD_RIGHT)
+        UI.Pad.Events.NAV_UP = handle_repeat("UP", PAD_UP)
+        UI.Pad.Events.NAV_DOWN = handle_repeat("DOWN", PAD_DOWN)
+        UI.Pad.Events.NAV_LEFT = handle_repeat("LEFT", PAD_LEFT)
+        UI.Pad.Events.NAV_RIGHT = handle_repeat("RIGHT", PAD_RIGHT)
       end;
     };
     Credits = {
@@ -427,3 +426,7 @@ UI = {
       end
     };
   }
+UI.Pad.REPEAT_DELAY = UI.InputConfig.NAV_REPEAT_DELAY_MS
+UI.Pad.REPEAT_INTERVAL = UI.InputConfig.NAV_REPEAT_INTERVAL_MS
+_G.UI = UI
+return UI

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -7,13 +7,22 @@ local function ensure_dir(path)
 end
 
 local BASE_DIR = ensure_dir(APP_DIR or System.currentDirectory())
-package.path = BASE_DIR.."?.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
 function LOG(...)
   print_uart(...)
 end
 function LOGF(S, ...)
   print_uart(string.format(S, ...))
 end
+
+BOOT_PROF = {
+  timer = Timer.new(),
+  stamp = function (label)
+    local now = Timer.getTime(BOOT_PROF.timer)
+    LOGF("BOOT: %s %d", label, now)
+  end
+}
+BOOT_PROF.stamp("Lua init start")
 
 POPSLDR_VER = "v1.0.0 - rev3"
 
@@ -68,6 +77,7 @@ SFONT = Font.LoadBuiltinFont()
 LFONT = Font.LoadBuiltinFont()
 Font.ftSetCharSize(BFONT, 800, 800)
 Font.ftSetCharSize(SFONT, 600, 600)
+BOOT_PROF.stamp("UI assets init (fonts)")
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end
 function RunScript(S)
   dofile(S)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <smod.h>
 #include <audsrv.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include <dirent.h>
 
@@ -87,6 +88,20 @@ char boot_path[255];
 char app_dir[255];
 int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
+static clock_t boot_start = 0;
+
+static unsigned int boot_ms(void)
+{
+    if (boot_start == 0) {
+        return 0;
+    }
+    return (unsigned int)(((clock() - boot_start) * 1000) / CLOCKS_PER_SEC);
+}
+
+static void BootStamp(const char *stage)
+{
+    DPRINTF("BOOT: %s %u\n", stage, boot_ms());
+}
 
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
@@ -230,40 +245,20 @@ static void DumpLoadedModules(void)
 }
 #endif
 
-static bool ProbeDevicePath(const char *path)
-{
-    DIR *d = opendir(path);
-    if (d) {
-        closedir(d);
-        return true;
-    }
-    struct stat st;
-    if (stat(path, &st) == 0) {
-        return true;
-    }
-    return false;
-}
-
-static void ProbeMmceSlots(void)
-{
-    mmce_slot0_ready = ProbeDevicePath("mmce0:/") ? 1 : 0;
-    mmce_slot1_ready = ProbeDevicePath("mmce1:/") ? 1 : 0;
-    DPRINTF("MMCE probe: mmce0=%s mmce1=%s\n",
-            mmce_slot0_ready ? "OK" : "FAIL",
-            mmce_slot1_ready ? "OK" : "FAIL");
-}
-
 int main(int argc, char * argv[])
 {
     int ID, RET;
     if (argc > 0) ARGV0 = argv[0];
     const char * errMsg;
+    boot_start = clock();
+    BootStamp("EE init start");
 
 #ifdef RESET_IOP  
     SifInitRpc(0);
     while (!SifIopReset("", 0)){};
     while (!SifIopSync()){};
     SifInitRpc(0);
+    BootStamp("IOP reset");
 #endif
     
     // install sbv patch fix
@@ -277,6 +272,7 @@ int main(int argc, char * argv[])
 #endif
 
     bool ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
+    BootStamp("iomanX load");
     bool filexio_ok = false;
     int filexio_ret = -1;
     if (ioman_ok) {
@@ -291,6 +287,7 @@ int main(int argc, char * argv[])
     } else {
         DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
     }
+    BootStamp("fileXio load/init");
 
 	LOAD_IRX_NARG(sio2man_irx);
     if (filexio_ok) {
@@ -308,8 +305,11 @@ int main(int argc, char * argv[])
             }
         }
 #endif
+        BootStamp("mmceman load/init");
         if (mmceman_ok) {
-            ProbeMmceSlots();
+            mmce_slot0_ready = -1;
+            mmce_slot1_ready = -1;
+            DPRINTF("MMCE probe deferred until MMCE page entry.\n");
         } else {
             mmce_slot0_ready = 0;
             mmce_slot1_ready = 0;
@@ -318,6 +318,7 @@ int main(int argc, char * argv[])
         DPRINTF("Skipping mmceman init; fileXio not ready.\n");
         mmce_slot0_ready = 0;
         mmce_slot1_ready = 0;
+        BootStamp("mmceman load/init (skipped)");
     }
     LOAD_IRX_NARG(mcman_irx);
     LOAD_IRX_NARG(mcserv_irx);
@@ -382,6 +383,7 @@ int main(int argc, char * argv[])
     DPRINTF("app dir : %s\n", app_dir);
 	dbgprintf("app dir : %s\n", app_dir);
     
+    BootStamp("Lua init start");
     while (1)
     {
         errMsg = runScript(bootString, true);


### PR DESCRIPTION
### Motivation
- Make MMCE launches behave identically to USB/mass handoffs so PopStarter receives the same argv/mode shape it expects and to surface why MMCE launches were hanging. 
- Reduce startup work and make boot stages observable with low-overhead stamps. 
- Improve UI robustness and predictable navigation by hardening input handling and making textures lazy-loaded.

### Description
- PopStarter handoff instrumentation and normalization: `bin/POPSLDR/system.lua` now logs launcher page, PopStarter path, `reboot_iop` flag, raw vs handoff `source_mode`, and prints the full indexed `argv` list immediately before `System.loadELF`; MMCE launches are translated to USB-style handoff paths (`mmceN:/` → `mass:/`) and forced to the same `isra` source mode so the argv shape matches USB (handed as `{ BOOTPARAM, "--nr" }`).
- MMCE probe and boot stamps: `src/main.cpp` defers active MMCE probing by setting `mmce_slot0_ready`/`mmce_slot1_ready = -1` when `mmceman` is present, and adds simple EE-side boot profiling (`BootStamp`, `boot_ms`) with stamps for key stages; `etc/boot.lua` adds a Lua-side `BOOT_PROF` and stamps for `Lua init start` and font init.
- Lazy UI textures and one-time texture boot stamp: `bin/POPSLDR/images.lua` registers image sources and provides `IMG` as a metatable-backed table that loads textures on first access and emits a one-time `BOOT_PROF.stamp("UI assets init (textures)")` when textures are initialized.
- Safer UI load and MMCE slot detection: `bin/POPSLDR/system.lua` now `pcall(require, "ui")` with improved diagnostics and explicit failure errors, and provides `PLDR.DetectMMCESlot()` to probe MMCE on demand.
- UI/input hardening: `bin/POPSLDR/ui.lua` centralizes pad input into discrete events (`NAV_*`, `CONFIRM`, `BACK`, `EXIT`, `START`, `SELECT`), switches to edge-only action buttons, introduces configurable repeat timing (`NAV_REPEAT_DELAY_MS = 350`, `NAV_REPEAT_INTERVAL_MS = 170`, `ANALOG_DEADZONE = 0.35`), and wires the new events through menus.

### Testing
- No automated tests were executed for these changes. 
- Changes were committed after local code edits and inspection, but no build or runtime test harness was run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707eea1d64832195e696dcc84f20c9)