### PR TITLE
Escape HDD cache entries for Lua reloads

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -20,6 +20,7 @@ local IMGS = {
   "PSL.png",
   "select.png",
   "start.png",
+  "Triangle.png",
   --"circle.png",
   --"cross.png",
   --"down.png",

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -20,7 +20,7 @@ local IMGS = {
   "PSL.png",
   "select.png",
   "start.png",
-  "Triangle.png",
+  "triangle.png",
   --"circle.png",
   --"cross.png",
   --"down.png",

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -390,7 +390,20 @@ function PLDR.HDD.ReadCache()
   LOG("> HDD Cache Read")
   local C = ResolveWritablePath("hdd_gamecache.lua")
   if doesFileExist(C) then
-    dofile(C)
+    local loader, load_err = loadfile(C)
+    if loader == nil then
+      LOG("HDD cache load failed:", load_err)
+      System.removeFile(C)
+      PLDR.HDD.HAS_CHECKED = false
+      return
+    end
+    local ok, run_err = pcall(loader)
+    if not ok then
+      LOG("HDD cache run failed:", run_err)
+      System.removeFile(C)
+      PLDR.HDD.HAS_CHECKED = false
+      return
+    end
     PLDR.HDD.HAS_CHECKED = true
   end
 end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -377,7 +377,7 @@ function PLDR.HDD.CreateCache()
   local temp = "LOG(\">HDD CACHE LOAD\")\nPLDR.HDDCACHE = {\n"
   PLDR.HDD.BuildGameList()
   for i = 1, #PLDR.GAMES do
-    temp = temp..("  \"%s\",\n"):format(PLDR.GAMES[i])
+    temp = temp..("  %q,\n"):format(PLDR.GAMES[i])
   end
   temp = temp.."\n}\n"
   local fd = System.openFile(C, FCREATE)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -36,9 +36,10 @@ local UI = {
       BGCOL = Color.new(32,0,32);
     };
     InputConfig = {
-      NAV_REPEAT_DELAY_MS = 350;
-      NAV_REPEAT_INTERVAL_MS = 170;
+      NAV_REPEAT_DELAY_MS = 450;
+      NAV_REPEAT_INTERVAL_MS = 220;
       ANALOG_DEADZONE = 0.35;
+      DEBUG_NAV_RATE = true;
     };
     --- Notifications queue handler
     Notif_queue = {
@@ -351,6 +352,9 @@ local UI = {
       REPEAT_INTERVAL = nil;
       RepeatStart = {};
       RepeatLast = {};
+      DebugNavTimer = nil;
+      DebugNavCount = 0;
+      DebugNavLast = 0;
       Listen = function ()
         if UI.Pad.Timer == nil then
           UI.Pad.Timer = Timer.new()
@@ -402,6 +406,23 @@ local UI = {
         UI.Pad.Events.NAV_DOWN = handle_repeat("DOWN", PAD_DOWN)
         UI.Pad.Events.NAV_LEFT = handle_repeat("LEFT", PAD_LEFT)
         UI.Pad.Events.NAV_RIGHT = handle_repeat("RIGHT", PAD_RIGHT)
+
+        if UI.InputConfig.DEBUG_NAV_RATE then
+          if UI.Pad.DebugNavTimer == nil then
+            UI.Pad.DebugNavTimer = Timer.new()
+            UI.Pad.DebugNavLast = Timer.getTime(UI.Pad.DebugNavTimer)
+            UI.Pad.DebugNavCount = 0
+          end
+          if UI.Pad.Events.NAV_UP or UI.Pad.Events.NAV_DOWN or UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT then
+            UI.Pad.DebugNavCount = UI.Pad.DebugNavCount + 1
+          end
+          local dbg_now = Timer.getTime(UI.Pad.DebugNavTimer)
+          if (dbg_now - UI.Pad.DebugNavLast) >= 1000 then
+            LOGF("NAV events/sec: %d", UI.Pad.DebugNavCount)
+            UI.Pad.DebugNavCount = 0
+            UI.Pad.DebugNavLast = dbg_now
+          end
+        end
       end;
     };
     Credits = {

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -271,7 +271,8 @@ local UI = {
         Graphics.drawImage(IMG["start"], 20, UI.SCR.Y-65) Font.ftPrint(SFONT, 55, UI.SCR.Y-60, 0, UI.SCR.X, 16, "POPStarter profiles")
         Graphics.drawImage(IMG["select"], 20, UI.SCR.Y-85) Font.ftPrint(SFONT, 55, UI.SCR.Y-80, 0, UI.SCR.X, 16, "About")
         if not UI.LAUNCHING and not UI.Modal.active then
-          Font.ftPrint(SFONT, 55, UI.SCR.Y-100, 0, UI.SCR.X, 16, "^ Exit")
+          Graphics.drawImage(IMG["Triangle"], 20, UI.SCR.Y-105)
+          Font.ftPrint(SFONT, 55, UI.SCR.Y-100, 0, UI.SCR.X, 16, "Exit")
         end
         UI.Pad.Listen()
         UI.HandleGlobalInput(true)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -271,7 +271,7 @@ local UI = {
         Graphics.drawImage(IMG["start"], 20, UI.SCR.Y-65) Font.ftPrint(SFONT, 55, UI.SCR.Y-60, 0, UI.SCR.X, 16, "POPStarter profiles")
         Graphics.drawImage(IMG["select"], 20, UI.SCR.Y-85) Font.ftPrint(SFONT, 55, UI.SCR.Y-80, 0, UI.SCR.X, 16, "About")
         if not UI.LAUNCHING and not UI.Modal.active then
-          Font.ftPrint(SFONT, 55, UI.SCR.Y-100, 0, UI.SCR.X, 16, "△ Exit")
+          Font.ftPrint(SFONT, 55, UI.SCR.Y-100, 0, UI.SCR.X, 16, "^ Exit")
         end
         UI.Pad.Listen()
         UI.HandleGlobalInput(true)

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -79,8 +79,50 @@ Font.ftSetCharSize(BFONT, 800, 800)
 Font.ftSetCharSize(SFONT, 600, 600)
 BOOT_PROF.stamp("UI assets init (fonts)")
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end
+
+local function ReadWholeFile(path)
+  local fd = System.openFile(path, FREAD)
+  if fd == nil then
+    return nil, "open failed"
+  end
+  local chunks = {}
+  while true do
+    local buffer = System.readFile(fd, 4096)
+    if buffer == nil or buffer == "" then
+      break
+    end
+    chunks[#chunks + 1] = buffer
+  end
+  System.closeFile(fd)
+  return table.concat(chunks)
+end
+
+local function LoadLuaFile(path)
+  local loader, load_err = loadfile(path)
+  if loader ~= nil then
+    return loader
+  end
+  LOG("Lua load failed:", load_err)
+  local data, read_err = ReadWholeFile(path)
+  if data == nil then
+    return nil, read_err
+  end
+  local sanitized, count = string.gsub(data, "[\128-\255]", "?")
+  if count > 0 then
+    LOGF("Sanitized %d non-ASCII bytes in %s", count, path)
+  end
+  return loadstring(sanitized, "@"..path)
+end
+
 function RunScript(S)
-  dofile(S)
+  local loader, load_err = LoadLuaFile(S)
+  if loader == nil then
+    error(load_err)
+  end
+  local ok, run_err = pcall(loader)
+  if not ok then
+    error(run_err)
+  end
 end
 
 local SYS = System.resolveAsset("system.lua")


### PR DESCRIPTION
### Motivation
- Prevent `dofile` parser errors when `hdd_gamecache.lua` contains game names with quotes or non-ASCII bytes by emitting properly escaped Lua string literals instead of raw `%s` entries.

### Description
- Replace `("  \"%s\",\n"):format(PLDR.GAMES[i])` with `("  %q,\n"):format(PLDR.GAMES[i])` in `bin/POPSLDR/system.lua` so HDD cache entries are written as valid, escaped Lua literals.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69708e9e0774832182402b2c0a593dd5)