### PR TITLE
Add launch pipeline SOT, debugging guide, sanity-check report, and agent guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
 ## Branches and pull requests
-Use the standard GitHub fork/branch workflow described in the project documentation:
+Use the standard GitHub fork/branch workflow described in the repository README:
 1. Fork the project.
 2. Create your feature branch (`git checkout -b feature/MyChange`).
 3. Commit your changes.
-4. Push the branch and open a PR.【F:docs/index.md†L123-L131】
+4. Push the branch and open a PR.
 
 ## Style expectations (C/C++/Lua)
 - Match the existing style in the file you are editing (indentation, brace placement, naming, and logging conventions). For C/C++, see the formatting and `DPRINTF` usage in `src/main.cpp`.【F:src/main.cpp†L108-L126】

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ POPSLoader is an open-source launcher for POPStarter that is scripted in Lua and
 POPSLoader was created by [El_isra](https://www.github.com/israpps), and this repository is a fork of his work. Endless thanks to Isra for his contributions and open-source projects gifted to the community.
 
 > **Project lineage**: This project is derived from the [Enceladus](https://github.com/DanielSant0s/Enceladus) Lua environment and retains its GPLv3 licensing.
+
 ## Documentation
 - [AGENTS.md](AGENTS.md)
 - [DEVELOPMENT.md](DEVELOPMENT.md)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md)
+- [docs/LAUNCH_PIPELINE.md](docs/LAUNCH_PIPELINE.md) (canonical launch behavior + device rules)
+- [docs/DEBUGGING.md](docs/DEBUGGING.md)
+- [docs/DOC_AUDIT.md](docs/DOC_AUDIT.md)
 
 ## Status / Roadmap
 - No subfolder dependencies (assets load from ELF directory first).
@@ -25,6 +29,9 @@ Place `POPSLOADER.ELF`, `POPSTARTER.ELF`, Lua scripts, images, and optional IRX 
 Legacy folders (`POPSLDR/`, `IMG/`, `IRX/`) are fallback-only.  
 Profiles can override the PopStarter path if needed.  
 See [docs/RUNTIME_LAYOUT.md](docs/RUNTIME_LAYOUT.md) for layout details and compatibility notes.
+
+## Launch behavior (canonical)
+Launch behavior, device rules, and POPStarter handoff are documented in [docs/LAUNCH_PIPELINE.md](docs/LAUNCH_PIPELINE.md). This repo does **not** contain POPStarter’s argument parsing, so POPStarter’s argv index must be verified in POPStarter’s own sources or documentation.
 
 ### Device pages
 - The SMB slot represents MMCE (no SMB networking support); `SMB.png` is reused as the icon.  

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,18 @@
+# Agent Guidance (POPSLoader)
+
+## Non-negotiables
+- **DO NOT invent rules.** If a rule is not found in code or repo docs, mark it **TODO: verify** and cite where it should be verified.
+- **Search first, quote exact code, then propose a diff.** Use precise file/line references when describing behavior.
+- **Never change prefix rules:**
+  - HDD: **no prefix**
+  - SMB: `SB.`
+  - MASS/MMCE/USB: `XX.`
+
+## When confused
+- Produce a **short decision table** (source → pops root → prefix → argv example) and cite code locations.
+- If behavior is still unclear, add **TODO: verify** and list the file(s) to inspect next.
+
+## Change discipline
+- Prefer small, isolated diffs.
+- Do not refactor unrelated code.
+- Only add logs if they are throttled or change-detected (never per-frame).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,9 @@ This document reflects the current POPSLoader architecture as implemented in the
 ## UI flow (scenes and device pages)
 - The main menu defines three device slots (`USB`, `SMB`, `HDD`); the `SMB` slot is wired to the MMCE device page and uses MMCE slot discovery/selection rather than SMB networking.【F:bin/POPSLDR/ui.lua†L261-L307】
 - MMCE slot detection is driven by `mmce0:/` and `mmce1:/` availability (populated into `PLDR.MMCE.SLOTS`).【F:bin/POPSLDR/system.lua†L116-L127】
-- POPStarter launches use a shared path builder: USB and MMCE both use the `XX.` boot parameter format, while the launch mode differs (`isra` for USB/mass, device string for MMCE).【F:bin/POPSLDR/system.lua†L390-L405】
+
+## Launch pipeline reference
+- POPStarter launch rules (device detection, prefix rules, argv handoff) are documented in `docs/LAUNCH_PIPELINE.md` and should be treated as canonical.
 
 ## Exit path (UI → OSDSYS)
 - Triangle opens an exit confirmation modal; confirming calls `System.exitToBrowser()` to return to OSDSYS.【F:bin/POPSLDR/ui.lua†L94-L168】

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,55 @@
+# Debugging POPSLoader Launch Issues
+
+This document describes **how to capture meaningful logs** without creating per-frame spam, and how to reproduce and diagnose a black screen during POPStarter handoff.
+
+## Minimal logging guidelines
+
+- **Log on state changes** (e.g., launch phase transitions) rather than every frame.
+- **Use existing logging helpers**:
+  - Lua: `LOG(...)` / `LOGF(...)`
+  - Launch tracing: `LaunchLog(...)` (writes to `launch.log` as well as console)
+- **Avoid per-frame UI spam**. If you must log input activity, prefer throttled counters or `DEBUG_INPUT_LOG` guards.
+
+## Where to enable debug logging
+
+- **Lua launch tracing** is already always available via `LaunchLog(...)` and `LOG(...)`.
+- **ELF loader logs** (`LAUNCH: ...`) are printed from the ELF loader itself and are visible on the console when the loader executes.
+- **TODO: verify** whether any build flags or runtime toggles exist to enable/disable Lua log output globally.
+
+## Reproducing black screen on handoff (log checklist)
+
+When a black screen occurs after selecting a game, collect the following:
+
+1. `launch.log` from the writable path (written by `LaunchLog(...)`).
+2. Console output around the handoff, especially the loader’s `LAUNCH:` lines.
+
+### Required log lines (minimum viable set)
+
+From POPSLoader (Lua):
+- `LAUNCH: boot source: ...`
+- `LAUNCH: pops root: ...`
+- `LAUNCH: vcd basename: ...`
+- `LAUNCH: bootparam: ...`
+- `LAUNCH: exec argv[0]: ...`
+- `LAUNCH: exec argv[1]: ...`
+- `LAUNCH RETURNED rc=...`
+
+From ELF loader (C):
+- `LAUNCH: popstarter path: ...`
+- `LAUNCH: argv[0]: ...`
+- `LAUNCH: argv[1]: ...`
+- `LAUNCH: argv[2]: ...` (if present)
+- `LAUNCH: RETURNED rc=...`
+
+## What to check first (triage)
+
+1. **Does argv[1] contain the full boot string?**
+   - It must include the correct POPS root and required prefix.
+2. **Does the prefix match the device rules?**
+   - HDD: none
+   - SMB: `SB.`
+   - MASS/MMCE/USB: `XX.`
+3. **Does the POPStarter ELF resolve successfully?**
+   - `LAUNCH: popstarter path: ...` and `open rc` should show success.
+4. **Does the launch phase stall before `LAUNCH_EXEC`?**
+   - If so, note the last phase and review `launch.log`.

--- a/docs/DOC_AUDIT.md
+++ b/docs/DOC_AUDIT.md
@@ -1,0 +1,48 @@
+# Documentation Audit (Launch Behavior + Device Rules)
+
+This report reconciles documentation against **current code behavior**. It is the canonical audit record and should be updated whenever launch logic changes.
+
+## 1) Truth map (from current code)
+
+**Source mode selection**
+- `ResolveLaunchPolicy(gamelocation)` chooses the device policy based on `gamelocation` prefix (`mass`, `mmce`, `pfs`) or UI scene fallback.
+
+**POPS root selection**
+- In `PLDR.RunPOPStarterGame(...)`, `pops_root` is chosen as:
+  - `pfs*:/` (normalized gamelocation) when `source_mode` is `pfs`.
+  - `smb:/POPS/` when device page is `SMB/MMCE`.
+  - `mass:/POPS/` otherwise.
+
+**Prefix rules**
+- `BuildPopstarterBootString(...)` sets prefixes as:
+  - HDD (`pfs`) → **no prefix**
+  - SMB (`smb`) → `SB.`
+  - MASS/MMCE/USB → `XX.`
+
+**ELF loader argv handoff**
+- Lua passes the boot string as the first extra argument to `System.loadELF(...)`.
+- The ELF loader injects the resolved POPStarter path as `argv[0]`, shifting extras to `argv[1]`, `argv[2]`.
+- **POPStarter’s own argv parsing is not in this repo** and remains **TODO: verify**.
+
+## 2) Documentation inventory and status
+
+| File | Launch/device claims | Status | Action |
+| --- | --- | --- | --- |
+| `README.md` | Links to canonical launch pipeline + notes POPStarter arg parsing not in repo. | VERIFIED | Keep canonical references. |
+| `docs/LAUNCH_PIPELINE.md` | Canonical device rules, POPS roots, argv handoff, TODO for POPStarter parsing. | VERIFIED | Canonical reference. |
+| `docs/DEBUGGING.md` | Launch log checklist, argv logging references. | VERIFIED | Keep; no conflicting rules. |
+| `docs/ARCHITECTURE.md` | Defers launch rules to `docs/LAUNCH_PIPELINE.md`. | VERIFIED | Updated to avoid conflicting launch rules. |
+| `docs/RUNTIME_LAYOUT.md` | Runtime asset layout only; does not define POPStarter rules. | UNSPECIFIED | No change needed. |
+| `docs/SANITY_CHECK_REPORT.md` | Reports current vs expected launch rules. | VERIFIED | Keep as audit context. |
+| `docs/index.md` | Legacy Enceladus content (includes non-POPSLoader details). | STALE/CONTRADICTS | Deprecated banner added; refer to README/LAUNCH_PIPELINE. |
+| `truth_sheet.md` | Legacy audit notes with outdated layout statements. | STALE/CONTRADICTS | Deprecated banner added; refer to canonical docs. |
+| `DEVELOPMENT.md` | Build instructions only; no launch rules. | UNSPECIFIED | No change needed. |
+| `CONTRIBUTING.md` | Contribution workflow; removed link to deprecated `docs/index.md`. | VERIFIED | Updated reference. |
+| `bin/README.md` | Runtime asset placement; no launch rules. | UNSPECIFIED | No change needed. |
+| `AGENTS.md` / `agents.md` | Contributor guidance; no launch rules. | UNSPECIFIED | No change needed. |
+
+## 3) Canonical references
+
+- Launch behavior, device rules, and POPStarter handoff: `docs/LAUNCH_PIPELINE.md`.
+- Runtime asset layout: `docs/RUNTIME_LAYOUT.md`.
+- Debug logging and launch issue triage: `docs/DEBUGGING.md`.

--- a/docs/LAUNCH_PIPELINE.md
+++ b/docs/LAUNCH_PIPELINE.md
@@ -1,6 +1,6 @@
 # POPSLoader Launch Pipeline (Single Source of Truth)
 
-This document describes **how POPSLoader constructs and hands off the POPStarter boot string**, based on the current codebase. It is meant to be the definitive, unambiguous reference for launch behavior. If behavior is unknown or outside this repo, it is explicitly marked as **TODO: verify**.
+This document describes **how POPSLoader constructs and hands off the POPStarter boot string**, based on the current codebase. It is the definitive reference for launch behavior. If behavior is unknown or outside this repo, it is explicitly marked as **TODO: verify**.
 
 ## 1) Terminology and invariants
 
@@ -12,7 +12,7 @@ This document describes **how POPSLoader constructs and hands off the POPStarter
 
 **POPS root**
 - The directory that POPStarter expects to contain VCDs (e.g., `mass:/POPS/`, `smb:/POPS/`, or a mounted `pfs` path).
-- POPSLoader **must** provide a fully qualified VCD path to POPStarter, built from this root.
+- POPSLoader **must** build a fully qualified VCD path from this root and pass it to POPStarter.
 
 **VCD basename**
 - The filename portion of the VCD (e.g., `SLUS_012.34.VCD` or `XX.SLUS_012.34.VCD`).
@@ -20,7 +20,7 @@ This document describes **how POPSLoader constructs and hands off the POPStarter
 
 **VCD full path / boot string**
 - The concatenation of the POPS root and the normalized VCD basename (including any required prefix).
-- This is the boot string passed to POPStarter as part of the argument list.
+- This is the boot string passed to the ELF loader as an argument.
 
 **Source mode**
 - The source of the game/VCD, used to determine POPS root and prefix rules.
@@ -30,13 +30,13 @@ This document describes **how POPSLoader constructs and hands off the POPStarter
   - `pfs` for HDD if path begins with `pfs` or UI scene is HDD.
   - **TODO: verify** other device prefixes if present elsewhere.
 
-## 2) Device rules table (prefix + root + example argv)
+## 2) Device rules table (prefix + root + boot string)
 
-> **Invariant:** POPStarter must receive the **full VCD boot string** (including prefix when required) in the argument list. POPSLoader currently passes the boot string as the **first extra argument** (argv[1]) and `--nr` as argv[2].
+> **Invariant:** POPSLoader constructs the **full VCD boot string** (including prefix when required) and passes it to the ELF loader as the first extra argument. **Do not assume which argv index POPStarter itself reads** until verified from POPStarter source/docs.
 
-| Source mode | POPS root | Required prefix | Example argv[1] (boot string) |
+| Source mode | POPS root | Required prefix | Example boot string |
 | --- | --- | --- | --- |
-| HDD (`pfs`) | **pfs mount**, e.g. `pfs0:/` or `pfs1:/` (mounted `__.POPS` partition) | *(none)* | `pfs1:/SLUS_012.34.VCD` |
+| HDD (`pfs`) | `pfs*:/` mount of the `__.POPS` partition (e.g., `pfs1:/`) | *(none)* | `pfs1:/SLUS_012.34.VCD` |
 | SMB | `smb:/POPS/` | `SB.` | `smb:/POPS/SB.SLUS_012.34.VCD` |
 | MASS/USB/MMCE | `mass:/POPS/` | `XX.` | `mass:/POPS/XX.SLUS_012.34.VCD` |
 
@@ -56,20 +56,20 @@ These prefix rules are implemented in `BuildPopstarterBootString()`.
    - `NormalizeIsraPath()` translates `isra:` paths into device-specific `mass:`/`pfs:` equivalents.
    - MMCE paths are translated to `mass:/` for POPStarter handoff.
 4. **Compute `pops_root`**:
-   - `pfs` → use the normalized gamelocation directly.
-   - `SMB/MMCE` page → use `smb:/POPS/`.
-   - Otherwise → use `mass:/POPS/`.
+   - If `source_mode` matches `^pfs`, use the normalized `pfs*:/` gamelocation.
+   - If UI device page is `SMB/MMCE`, force `pops_root = "smb:/POPS/"`.
+   - Otherwise use `pops_root = "mass:/POPS/"`.
 5. **Build the boot string** with `BuildPopstarterBootString(source_mode, pops_root, basename)`:
    - Applies the correct prefix and ensures `pops_root` is slash-terminated.
-6. **Build argv list**:
+6. **Build argv list** (Lua side):
    - `argv[1] = boot string` (first extra arg)
    - `argv[2] = "--nr"`
 7. **Exec POPStarter** via `System.loadELF(popstarter, reboot_iop, argv[1], argv[2])`.
-   - The underlying ELF loader inserts POPStarter’s path as `argv[0]` and shifts the extra args.
+   - The ELF loader inserts POPStarter’s path as `argv[0]` and shifts the extra args.
 
-## 4) Argument list and POPStarter handoff (verified)
+## 4) Argument list and POPStarter handoff (verified vs unknown)
 
-### What POPSLoader passes to POPStarter
+### What POPSLoader passes to the ELF loader (verified)
 POPSLoader’s Lua side passes the boot string and `--nr` as extra args to `System.loadELF()`. The loader then constructs the final `ExecPS2()` argv list as:
 
 ```
@@ -83,7 +83,7 @@ This is verified by:
 - `lua_loadELF` printing extra args as `argv[0]`, `argv[1]`, etc.
 - `LoadELFFromFileWithPartition` inserting POPStarter path into `launch_argv[0]` and shifting extras.
 
-### Where POPStarter parses argv
+### Where POPStarter parses argv (unknown in this repo)
 **TODO: verify.** POPStarter argument parsing is **not** present in this repository. To confirm which argv index POPStarter reads for the VCD boot string, locate POPStarter’s source (or official docs) and cite the exact file/function/line.
 
 ## 5) Expected log lines (validation)

--- a/docs/LAUNCH_PIPELINE.md
+++ b/docs/LAUNCH_PIPELINE.md
@@ -1,0 +1,110 @@
+# POPSLoader Launch Pipeline (Single Source of Truth)
+
+This document describes **how POPSLoader constructs and hands off the POPStarter boot string**, based on the current codebase. It is meant to be the definitive, unambiguous reference for launch behavior. If behavior is unknown or outside this repo, it is explicitly marked as **TODO: verify**.
+
+## 1) Terminology and invariants
+
+**Boot path**
+- The path POPSLoader was launched from (boot argv[0] if available, else fallback). Used to derive the app directory.
+
+**App dir (APP_DIR)**
+- The directory used for runtime assets (Lua scripts, images, IRX). Derived from the launch path.
+
+**POPS root**
+- The directory that POPStarter expects to contain VCDs (e.g., `mass:/POPS/`, `smb:/POPS/`, or a mounted `pfs` path).
+- POPSLoader **must** provide a fully qualified VCD path to POPStarter, built from this root.
+
+**VCD basename**
+- The filename portion of the VCD (e.g., `SLUS_012.34.VCD` or `XX.SLUS_012.34.VCD`).
+- This is the `game` value passed to the launch pipeline.
+
+**VCD full path / boot string**
+- The concatenation of the POPS root and the normalized VCD basename (including any required prefix).
+- This is the boot string passed to POPStarter as part of the argument list.
+
+**Source mode**
+- The source of the game/VCD, used to determine POPS root and prefix rules.
+- Derived from the game location and/or UI scene:
+  - `mass` if path begins with `mass` or UI scene is USB.
+  - `mmce` (handoff still uses `mass` semantics) if path begins with `mmce` or UI scene is SMB/MMCE.
+  - `pfs` for HDD if path begins with `pfs` or UI scene is HDD.
+  - **TODO: verify** other device prefixes if present elsewhere.
+
+## 2) Device rules table (prefix + root + example argv)
+
+> **Invariant:** POPStarter must receive the **full VCD boot string** (including prefix when required) in the argument list. POPSLoader currently passes the boot string as the **first extra argument** (argv[1]) and `--nr` as argv[2].
+
+| Source mode | POPS root | Required prefix | Example argv[1] (boot string) |
+| --- | --- | --- | --- |
+| HDD (`pfs`) | **pfs mount**, e.g. `pfs0:/` or `pfs1:/` (mounted `__.POPS` partition) | *(none)* | `pfs1:/SLUS_012.34.VCD` |
+| SMB | `smb:/POPS/` | `SB.` | `smb:/POPS/SB.SLUS_012.34.VCD` |
+| MASS/USB/MMCE | `mass:/POPS/` | `XX.` | `mass:/POPS/XX.SLUS_012.34.VCD` |
+
+**Prefix rules**
+- HDD: **no prefix**
+- SMB: `SB.`
+- MASS/MMCE/USB: `XX.`
+
+These prefix rules are implemented in `BuildPopstarterBootString()`.
+
+## 3) End-to-end launch sequence (current code)
+
+1. **User selects a game** (VCD basename) from the UI list.
+2. **Determine source mode** via `ResolveLaunchPolicy()`:
+   - Uses `gamelocation` prefix (`mass`, `mmce`, `pfs`) if available; otherwise falls back to the current UI scene.
+3. **Normalize/translate the game path** using the selected launch policy:
+   - `NormalizeIsraPath()` translates `isra:` paths into device-specific `mass:`/`pfs:` equivalents.
+   - MMCE paths are translated to `mass:/` for POPStarter handoff.
+4. **Compute `pops_root`**:
+   - `pfs` → use the normalized gamelocation directly.
+   - `SMB/MMCE` page → use `smb:/POPS/`.
+   - Otherwise → use `mass:/POPS/`.
+5. **Build the boot string** with `BuildPopstarterBootString(source_mode, pops_root, basename)`:
+   - Applies the correct prefix and ensures `pops_root` is slash-terminated.
+6. **Build argv list**:
+   - `argv[1] = boot string` (first extra arg)
+   - `argv[2] = "--nr"`
+7. **Exec POPStarter** via `System.loadELF(popstarter, reboot_iop, argv[1], argv[2])`.
+   - The underlying ELF loader inserts POPStarter’s path as `argv[0]` and shifts the extra args.
+
+## 4) Argument list and POPStarter handoff (verified)
+
+### What POPSLoader passes to POPStarter
+POPSLoader’s Lua side passes the boot string and `--nr` as extra args to `System.loadELF()`. The loader then constructs the final `ExecPS2()` argv list as:
+
+```
+argv[0] = <resolved POPSTARTER path>
+argv[1] = <boot string>     (full VCD path with prefix when required)
+argv[2] = "--nr"            (optional)
+```
+
+This is verified by:
+- `System.loadELF(popstarter, reboot_iop, argv[1], argv[2])` in Lua.
+- `lua_loadELF` printing extra args as `argv[0]`, `argv[1]`, etc.
+- `LoadELFFromFileWithPartition` inserting POPStarter path into `launch_argv[0]` and shifting extras.
+
+### Where POPStarter parses argv
+**TODO: verify.** POPStarter argument parsing is **not** present in this repository. To confirm which argv index POPStarter reads for the VCD boot string, locate POPStarter’s source (or official docs) and cite the exact file/function/line.
+
+## 5) Expected log lines (validation)
+
+Use these log lines to validate end-to-end argument construction and handoff:
+
+### From POPSLoader (Lua)
+- `LAUNCH: vcd basename: ...`
+- `LAUNCH: pops root: ...`
+- `LAUNCH: bootparam: ...`
+- `LAUNCH: bootparam prefix: ... prefix injected: ...`
+- `LAUNCH: exec argv[0]: ...`
+- `LAUNCH: exec argv[1]: ...`
+- `LAUNCH RETURNED rc=...`
+
+These are written to the on-device `launch.log` via `LaunchLog()`.
+
+### From the ELF loader (C)
+- `LAUNCH: popstarter path: ...`
+- `LAUNCH: argv[0]: ...` (resolved POPStarter path)
+- `LAUNCH: argv[1]: ...` (boot string)
+- `LAUNCH: argv[2]: ...` (`--nr` if present)
+
+These appear on the console/tty when loader debug output is visible.

--- a/docs/LAUNCH_PIPELINE.md
+++ b/docs/LAUNCH_PIPELINE.md
@@ -22,13 +22,14 @@ This document describes **how POPSLoader constructs and hands off the POPStarter
 - The concatenation of the POPS root and the normalized VCD basename (including any required prefix).
 - This is the boot string passed to the ELF loader as an argument.
 
-**Source mode**
-- The source of the game/VCD, used to determine POPS root and prefix rules.
-- Derived from the game location and/or UI scene:
-  - `mass` if path begins with `mass` or UI scene is USB.
-  - `mmce` (handoff still uses `mass` semantics) if path begins with `mmce` or UI scene is SMB/MMCE.
-  - `pfs` for HDD if path begins with `pfs` or UI scene is HDD.
-  - **TODO: verify** other device prefixes if present elsewhere.
+**Launch policy inputs**
+- POPSLoader derives a launch policy from **two inputs**:
+  1) `policy.mode` from `ResolveLaunchPolicy(gamelocation)`
+  2) `device_page` (UI scene label)
+- `policy.mode` is **not** an MMCE-specific mode. It is either:
+  - `mass` (USB or MMCE), or
+  - a `pfs*` prefix (HDD).
+- The final POPS root + prefix used for the boot string are computed in `PLDR.RunPOPStarterGame` using **both** `policy.mode` and `device_page` (see step 4 below).
 
 ## 2) Device rules table (prefix + root + boot string)
 
@@ -50,8 +51,9 @@ These prefix rules are implemented in `BuildPopstarterBootString()`.
 ## 3) End-to-end launch sequence (current code)
 
 1. **User selects a game** (VCD basename) from the UI list.
-2. **Determine source mode** via `ResolveLaunchPolicy()`:
+2. **Determine launch policy** via `ResolveLaunchPolicy()`:
    - Uses `gamelocation` prefix (`mass`, `mmce`, `pfs`) if available; otherwise falls back to the current UI scene.
+   - Policy `mode` is `mass` (USB/MMCE) or `pfs*` (HDD).
 3. **Normalize/translate the game path** using the selected launch policy:
    - `NormalizeIsraPath()` translates `isra:` paths into device-specific `mass:`/`pfs:` equivalents.
    - MMCE paths are translated to `mass:/` for POPStarter handoff.

--- a/docs/SANITY_CHECK_REPORT.md
+++ b/docs/SANITY_CHECK_REPORT.md
@@ -1,0 +1,71 @@
+# POPSLoader Sanity Check Report (Launch + POPStarter Handoff)
+
+This report maps the current launch pipeline and documents the observed mismatch against expected POPStarter boot rules. It is **documentation-only** and does not change runtime behavior.
+
+## 1) Relevant files/functions (launch & path building)
+
+### Source mode selection
+- `ResolveLaunchPolicy(gamelocation)` in `bin/POPSLDR/system.lua`
+  - Picks a device policy based on `gamelocation` prefix (`mass`, `mmce`, `pfs`) or UI scene fallback (`GUSB`, `GSMB`, `GHDD`).
+  - Returns a policy containing `mode` (e.g., `mass`, `pfs`) and a UI label.
+
+### POPS root selection
+- `PLDR.RunPOPStarterGame(gamelocation, game)` in `bin/POPSLDR/system.lua`
+  - Computes `pops_root` based on `source_mode` and device page:
+    - `pfs` → use normalized gamelocation.
+    - `SMB/MMCE` → `smb:/POPS/`.
+    - Else → `mass:/POPS/`.
+
+### Prefix injection / boot string construction
+- `BuildPopstarterBootString(source_mode, pops_root, basename)` in `bin/POPSLDR/system.lua`
+  - Prefixes VCD name: `pfs` → none, `smb` → `SB.`, else `XX.`.
+  - Returns `pops_root + basename` and the prefix used.
+
+### argv assembly (Lua)
+- `PLDR.RunPOPStarterGame(...)` builds:
+  - `argv = { bootparam, "--nr" }`
+- `LaunchEngine(...)` passes the args into the ELF loader:
+  - `System.loadELF(popstarter, reboot_iop, argv[1], argv[2])`
+
+### argv assembly (C + loader)
+- `lua_loadELF` in `src/luasystem.cpp` prints extra args and calls `LoadELFFromFile(elf, argc, argv)`.
+- `LoadELFFromFileWithPartition` in `src/elf_loader/src/elf.c`:
+  - Resolves POPStarter path.
+  - Inserts POPStarter path as `argv[0]` and shifts extras (`bootparam`, `--nr`) to `argv[1]`, `argv[2]`.
+  - Calls `ExecPS2` with the final argv list.
+
+### Exec / handoff
+- `ExecPS2` is called from `LoadELFFromFileWithPartition` in `src/elf_loader/src/elf.c` with the constructed argv list.
+
+## 2) Current behavior vs expected behavior
+
+### Expected behavior (requirements)
+- HDD: **no prefix** and POPS root should be a `pfs` mount of `__.POPS` (e.g., `pfs0:/` or `pfs1:/`).
+- SMB: prefix `SB.` and POPS root `smb:/POPS/`.
+- MASS/MMCE/USB: prefix `XX.` and POPS root `mass:/POPS/`.
+- POPStarter must receive the **full VCD boot string** (with correct prefix) in the argv list.
+
+### Current behavior (from code)
+- Prefix selection is tied to `source_mode` (`pfs` → none, `smb` → `SB.`, else `XX.`).
+- POPS root selection uses a three-branch rule:
+  - If `source_mode` matches `^pfs`, `pops_root = normalized_gamelocation`.
+  - Else if `device_page == "SMB/MMCE"`, `pops_root = "smb:/POPS/"`.
+  - Else `pops_root = "mass:/POPS/"`.
+
+### Reported mismatch (user observation)
+- **Observation:** HDD mode produced `mass:/POPS/` and injected `XX.`.
+- **Code path that can cause this:**
+  - If `source_mode` is not `pfs` and device page is not `SMB/MMCE`, the default branch sets `pops_root = "mass:/POPS/"` and `boot_source_mode = "mass"`, which yields the `XX.` prefix.
+- **TODO: verify** the actual `gamelocation` value and the `device_page`/UI scene at the moment of the failing launch. The mismatch suggests the HDD launch path is not being recognized as `pfs` (or the UI scene fallback is not `GHDD`).
+
+## 3) Recommended fix plan (next step, smallest diffs)
+
+> **No code changes in this pass.** The following is a minimal fix plan for a follow-up PR.
+
+1. **Instrument launch context** (if needed) to confirm `source_mode`, `device_page`, and `gamelocation` at handoff (already logged via `LaunchLog`).
+2. **Ensure HDD launches are tagged as `pfs`** before `BuildPopstarterBootString`:
+   - Verify that HDD `gamelocation` is always a `pfs*:/` path, or
+   - Force `boot_source_mode = "pfs"` when UI scene is `GHDD` (if/when `gamelocation` is not `pfs`).
+3. **Add a focused regression check**: log/validate `pops_root` and prefix for HDD selection.
+
+These steps keep diffs minimal while ensuring HDD uses **no prefix** and a `pfs` POPS root.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+> **DEPRECATED**: This page is legacy Enceladus documentation and is **not** authoritative for POPSLoader. For current POPSLoader documentation, see the repository README and `docs/LAUNCH_PIPELINE.md`.
+
 <br />
 <p align="center">
   <a href="https://github.com/DanielSant0s/Enceladus/">
@@ -178,7 +180,3 @@ Here are some direct and indirect thanks to the people who made the project viab
 * fjtrujy - Help on porting current Lua language versions and general code help
 * Rinnegatamante - Having created lpp, which served as a great initial guide
 * Whole PS2DEV team
-
-
-
-

--- a/truth_sheet.md
+++ b/truth_sheet.md
@@ -1,5 +1,7 @@
 # Truth Sheet (audit, ground-truth only)
 
+> **DEPRECATED**: This file is no longer maintained as canonical documentation. For current launch behavior and device rules, see `docs/LAUNCH_PIPELINE.md`. For runtime layout, see `docs/RUNTIME_LAYOUT.md`.
+
 ## What this project is
 POPSLoader is an open-source launcher for POPStarter, scripted in Lua and based on the Enceladus project.【F:README.md†L1-L4】
 


### PR DESCRIPTION
### Motivation
- Make the POPSLoader launch pipeline, device/mode prefix rules, and POPStarter handoff unambiguous after an observed HDD→mass/XX mismatch. 
- Provide operable debugging and agent guidance so follow-up fixes can be small, verifiable, and code-referenced without changing runtime behavior.

### Description
- Add `docs/LAUNCH_PIPELINE.md` as the single source of truth describing terminology, source modes, pops-root/prefix rules (HDD: none, SMB: `SB.`, MASS/MMCE/USB: `XX.`), the end-to-end selection→bootstring→exec sequence, expected log lines, and an explicit TODO to verify POPStarter argument parsing (POPStarter source is not in this repo). 
- Add `docs/DEBUGGING.md` with minimal logging guidelines (change-detected/throttled), a concise log-collection checklist for black-screen/handoff failures, and the set of Lua/ELF loader lines to gather. 
- Add `docs/SANITY_CHECK_REPORT.md` mapping the relevant code locations and functions involved in launch/path building (`bin/POPSLDR/system.lua`, `src/luasystem.cpp`, `src/elf_loader/src/elf.c`), document current vs expected behavior, explain why HDD could fall into the `mass:/POPS/`+`XX.` branch, and propose a minimal follow-up fix plan. 
- Add `agents.md` containing contributor rules (search-first, cite code, avoid inventing rules, preserve prefix invariants) and change discipline (small diffs, no per-frame logs). 
- No runtime code was changed; only documentation files were added and committed.

### Testing
- No automated tests were executed because this change is documentation-only (CI/build not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971435175b083218950ef688d17d72e)