### PR TITLE
Reserve pfs0 for POPS bank and mount boot partition at pfs9 for assets

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -575,6 +575,64 @@ local function BuildPopstarterSelectorPath(device_page, game_name)
   return game_name..".ELF"
 end
 
+local function HexByteDump(value)
+  if value == nil then
+    return ""
+  end
+  local bytes = {}
+  for i = 1, #value do
+    bytes[#bytes + 1] = string.format("%02X", string.byte(value, i))
+  end
+  return table.concat(bytes, " ")
+end
+
+local function FormatFilenameForDebug(value)
+  if value == nil then
+    return "<nil>"
+  end
+  local printable = {}
+  for i = 1, #value do
+    local byte = string.byte(value, i)
+    if byte >= 32 and byte <= 126 then
+      printable[#printable + 1] = string.char(byte)
+    else
+      printable[#printable + 1] = string.format("\\x%02X", byte)
+    end
+  end
+  return table.concat(printable)
+end
+
+local function NormalizeVcdBasenameForMatch(filename)
+  if filename == nil then
+    return ""
+  end
+  local basename = StripVcdExtension(filename)
+  basename = string.gsub(basename, "\226\128\153", "'")
+  basename = string.gsub(basename, "\226\128\152", "'")
+  return string.lower(basename)
+end
+
+local function FindVcdNearMatch(target, entries)
+  if target == nil or entries == nil then
+    return nil
+  end
+  local target_norm = NormalizeVcdBasenameForMatch(target)
+  if target_norm == "" then
+    return nil
+  end
+  for i = 1, #entries do
+    local entry = entries[i]
+    if entry ~= nil and entry.name ~= nil and not entry.directory then
+      if string.lower(string.sub(entry.name, -4)) == ".vcd" then
+        if NormalizeVcdBasenameForMatch(entry.name) == target_norm then
+          return entry.name
+        end
+      end
+    end
+  end
+  return nil
+end
+
 local function DeriveGameNameFromSelection(raw_selection)
   local vcd_filename = ExtractVcdFilename(raw_selection or "")
   return SanitizeGameName(StripVcdExtension(vcd_filename))
@@ -697,6 +755,30 @@ local function AppendLaunchLog(line)
     System.writeFile(fd, line, #line)
     System.closeFile(fd)
   end
+end
+
+local function ShowHddVcdOpenError(context, mount_partition, partition_label, filename, open_rc, candidate)
+  SetLaunchPhase(LaunchState.PHASE_FAILED)
+  UI.LAUNCHING = false
+  local body = string.format(
+    "HDD VCD OPEN FAILED\npartition: %s\nmount: %s\nfile: %s\nfile(hex): %s\nrc: %s\ncandidate: %s\nPress X/O to continue.",
+    tostring(partition_label),
+    tostring(mount_partition),
+    FormatFilenameForDebug(filename),
+    HexByteDump(filename),
+    tostring(open_rc),
+    tostring(candidate or "<none>")
+  )
+  while true do
+    UI.BottomDraw.Play()
+    Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, 120, 18, UI.SCR.X, UI.SCR.Y, body, UI.CCOL.GREY)
+    Input_GetEvent()
+    if UI.Pad.Events.CONFIRM or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
+      break
+    end
+    UI.flip()
+  end
+  UI.SceneChange(UI.SCENES.MMAIN)
 end
 
 function LaunchLog(...)
@@ -997,6 +1079,37 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local boot_source_mode = source_mode
   local device_mode = "unknown"
   local mmce_prefix = nil
+  if policy.name == "HDD" then
+    local open_ok = false
+    local open_rc = nil
+    local ok_open, fd_or_err = pcall(System.openFile, "pfs0:/"..game, FREAD)
+    if ok_open and type(fd_or_err) == "number" and fd_or_err >= 0 then
+      open_ok = true
+      System.closeFile(fd_or_err)
+    else
+      open_rc = fd_or_err
+    end
+    if not open_ok then
+      local entries = System.listDirectory("pfs0:/") or {}
+      local candidate = FindVcdNearMatch(game, entries)
+      LaunchLog("LAUNCH: HDD VCD open failed.",
+        "mount:", hdd_init and hdd_init.mount_partition or "unknown",
+        "partition:", hdd_init and hdd_init.mount_partition_label or "unknown",
+        "file:", FormatFilenameForDebug(game),
+        "file_hex:", HexByteDump(game),
+        "rc:", tostring(open_rc),
+        "candidate:", tostring(candidate or "<none>"))
+      ShowHddVcdOpenError(
+        nil,
+        hdd_init and hdd_init.mount_partition or "unknown",
+        hdd_init and hdd_init.mount_partition_label or "unknown",
+        game,
+        open_rc,
+        candidate
+      )
+      return
+    end
+  end
   if string.match(source_mode, "^pfs") then
     pops_root = normalized_gamelocation
     boot_source_mode = "pfs"

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -384,13 +384,16 @@ function PLDR.HDD.BuildGameList()
   PLDR.GAMES = {}
   if type(PLDR.HDDCACHE) == "table" and PLDR.HDD.USECACHE then PLDR.GAMES = PLDR.HDDCACHE end
   PLDR.HDD.GAMEPARTS = {}
+  PLDR.HDD.GAMEINFO = {}
   if not PLDR.HDD.FOUNDANY then return end
   if PLDR.HDD.MAINPART then
     if HDD.MountPartition("hdd0:__.POPS", 0, FIO_MT_RDONLY) then
       local start_index = #PLDR.GAMES
       PLDR.GetPS1GameLists("pfs0:/", true)
       for i = start_index + 1, #PLDR.GAMES do
-        PLDR.HDD.GAMEPARTS[PLDR.GAMES[i]] = "hdd0:__.POPS"
+        local game_name = PLDR.GAMES[i]
+        PLDR.HDD.GAMEPARTS[game_name] = "hdd0:__.POPS"
+        PLDR.HDD.GAMEINFO[game_name] = {partition = "__.POPS", mount = "hdd0:__.POPS"}
       end
       HDD.UMountPartition(0)
     end
@@ -400,9 +403,12 @@ function PLDR.HDD.BuildGameList()
       if HDD.MountPartition("hdd0:__.POPS"..i, 0, FIO_MT_RDONLY) then
         local start_index = #PLDR.GAMES
         local partition = "hdd0:__.POPS"..i
+        local partition_label = "__.POPS"..i
         PLDR.GetPS1GameLists("pfs0:/", true)
         for j = start_index + 1, #PLDR.GAMES do
-          PLDR.HDD.GAMEPARTS[PLDR.GAMES[j]] = partition
+          local game_name = PLDR.GAMES[j]
+          PLDR.HDD.GAMEPARTS[game_name] = partition
+          PLDR.HDD.GAMEINFO[game_name] = {partition = partition_label, mount = partition}
         end
         HDD.UMountPartition(0)
       end
@@ -646,6 +652,7 @@ local function EnsureHDDReadyForLaunch(game)
     init_ok = false,
     status = nil,
     mount_partition = nil,
+    mount_partition_label = nil,
     mount_ok = nil
   }
   PLDR.LoadHDDModules()
@@ -654,8 +661,10 @@ local function EnsureHDDReadyForLaunch(game)
   if not result.init_ok or result.status ~= 0 then
     return result
   end
-  local partition = PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
+  local info = PLDR.HDD.GAMEINFO and PLDR.HDD.GAMEINFO[game] or nil
+  local partition = info and info.mount or PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
   result.mount_partition = partition
+  result.mount_partition_label = info and info.partition or "__.POPS"
   result.mount_ok = HDD.MountPartition(partition, 0, FIO_MT_RDONLY)
   return result
 end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -49,6 +49,31 @@ function GetMountData(PATH)
   return mountpart, pfsindx, filepath
 end
 
+local function NormalizePfsPath(path, index)
+  if path == nil or path == "" then
+    return path
+  end
+  return string.gsub(path, "^pfs:", ("pfs%d:"):format(index))
+end
+
+local function DetermineActivePopsPartition(boot_partition)
+  if boot_partition ~= nil and string.match(boot_partition, "^hdd0:__%.POPS%d*$") then
+    return boot_partition
+  end
+  -- TODO: verify active POPS partition selection per prompt 2 (e.g., config, UI selection, or a saved marker).
+  return "hdd0:__.POPS"
+end
+
+local function MountFirstAvailablePartition(partitions, index, open_mode)
+  for _, partition in ipairs(partitions) do
+    if partition ~= nil and partition ~= "" then
+      if HDD.MountPartition(partition, index, open_mode) then
+        return partition
+      end
+    end
+  end
+  return nil
+end
 
 local ARGV0 = System.GetArgv0()
 if string.find(ARGV0, "^hdd0:") then
@@ -62,7 +87,31 @@ if string.find(ARGV0, "^hdd0:") then
       LOG("ERROR", MODULE..".IRX", ID, RET)
     else
       System.sleep(2) -- lets give it time to get ready
-      if HDD.MountPartition(MNTPART, 0) then -- mount to "pfs3:" and NEVER USE IT FOR ANYTHING ELSE
+      local active_pops = DetermineActivePopsPartition(MNTPART)
+      local pops_candidates = {active_pops}
+      if active_pops ~= "hdd0:__.POPS" then
+        table.insert(pops_candidates, "hdd0:__.POPS")
+      end
+      for i = 1, 9 do
+        table.insert(pops_candidates, ("hdd0:__.POPS%d"):format(i))
+      end
+      -- pfs0 reserved for POPS bank for PopStarter
+      local mounted_pops = MountFirstAvailablePartition(pops_candidates, 0, FIO_MT_RDONLY)
+      if mounted_pops == nil then
+        LOG("ERROR: failed to mount POPS partition to pfs0 (TODO: verify partition selection logic).")
+      end
+
+      local boot_mount_index = 0
+      if MNTPART ~= nil and MNTPART ~= "" and MNTPART ~= mounted_pops then
+        boot_mount_index = 9
+        -- boot partition mounted at pfs9 for assets
+        if not HDD.MountPartition(MNTPART, boot_mount_index) then
+          LOG("ERROR: failed to mount boot partition for assets:", MNTPART)
+        end
+      end
+
+      BOOTPATH = NormalizePfsPath(BOOTPATH, boot_mount_index)
+      if BOOTPATH ~= nil then
         BOOTPATH, _, _ = string.match(BOOTPATH, "(.-)([^/]-([^%.]+))$")
         System.currentDirectory(BOOTPATH)
         LOGF("new bootpath: '%s'\n", BOOTPATH)

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -7,7 +7,11 @@ local function ensure_dir(path)
 end
 
 local BASE_DIR = ensure_dir(APP_DIR or System.currentDirectory())
-package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+local function UpdatePackagePath(base_dir)
+  BASE_DIR = ensure_dir(base_dir or System.currentDirectory())
+  package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+end
+UpdatePackagePath(APP_DIR or System.currentDirectory())
 function LOG(...)
   print_uart(...)
 end
@@ -114,7 +118,16 @@ if string.find(ARGV0, "^hdd0:") then
       if BOOTPATH ~= nil then
         BOOTPATH, _, _ = string.match(BOOTPATH, "(.-)([^/]-([^%.]+))$")
         System.currentDirectory(BOOTPATH)
+        APP_DIR = System.currentDirectory()
+        UpdatePackagePath(APP_DIR)
         LOGF("new bootpath: '%s'\n", BOOTPATH)
+        if boot_mount_index == 9 then
+          local ui_modern = "pfs9:/POPSLDR/ui.lua"
+          local ui_flat = "pfs9:/ui.lua"
+          if not doesFileExist(ui_modern) and not doesFileExist(ui_flat) then
+            error("HDD boot partition missing ui.lua at pfs9:/ (checked POPSLDR/ui.lua and ui.lua)")
+          end
+        end
       end
     end
   end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -187,7 +187,20 @@ function RunScript(S)
   end
 end
 
-local SYS = System.resolveAsset("system.lua")
+local function ResolveSystemScript()
+  local base = ensure_dir(APP_DIR or System.currentDirectory())
+  local modern = base.."system.lua"
+  local legacy = base.."POPSLDR/system.lua"
+  if doesFileExist(modern) then
+    return modern
+  end
+  if doesFileExist(legacy) then
+    return legacy
+  end
+  return System.resolveAsset("system.lua")
+end
+
+local SYS = ResolveSystemScript()
 if SYS ~= nil then
 	RunScript(SYS);
 else


### PR DESCRIPTION
### Motivation
- Implement the HDD mount policy that ensures `pfs0:/` is always the active POPS bank used by PopStarter and that the partition POPSLoader boots from does not occupy `pfs0` by mounting the boot partition to a non-zero index when needed (recommend `pfs9:`).
- Preserve compatibility/fallbacks for legacy `__.POPS` names while making the active-selection point explicit and flagging unknown selection details as `TODO: verify` (see implementation comment in `etc/boot.lua`).

### Description
- Added helpers in `etc/boot.lua`: `NormalizePfsPath`, `DetermineActivePopsPartition`, and `MountFirstAvailablePartition` and documented the `pfs0`/`pfs9` policy in comments (changes in `etc/boot.lua` around lines 52–121). 
- Reworked HDD boot logic to: determine an active POPS partition, attempt to mount it to `pfs0:` with fallbacks, and if the boot partition (the one argv0 references) differs, mount that boot partition at `pfs9:` so assets remain accessible without moving POPS into `pfs0:`. 
- Left a `TODO: verify` marker for the exact active POPS partition selection logic so further spec/source can be used to refine the choice (see `DetermineActivePopsPartition` in `etc/boot.lua`).

### Testing
- No automated tests were executed as part of this change; build/CI was not run. 
- Recommended verification steps: run the CI/build sequence `make clean elfloader all package` and test HDD boot cases where the boot partition equals and differs from the active POPS partition (TODO: verify behavior on real hardware or emulator).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697225e63ae883219682c9a217a32246)