### PR TITLE
Add selectable loader backend and default HDD launches to embedded loader (preserve argv[0])

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -171,6 +171,10 @@ PLDR = {
     PREFIX = nil,
     SLOTS = {},
     INDEX = 1
+  },
+  LAUNCH_BACKEND = {
+    default = "execps2",
+    hdd = "loader"
   }
 }
 if BOOTPATH ~= nil then
@@ -384,13 +388,16 @@ function PLDR.HDD.BuildGameList()
   PLDR.GAMES = {}
   if type(PLDR.HDDCACHE) == "table" and PLDR.HDD.USECACHE then PLDR.GAMES = PLDR.HDDCACHE end
   PLDR.HDD.GAMEPARTS = {}
+  PLDR.HDD.GAMEINFO = {}
   if not PLDR.HDD.FOUNDANY then return end
   if PLDR.HDD.MAINPART then
     if HDD.MountPartition("hdd0:__.POPS", 0, FIO_MT_RDONLY) then
       local start_index = #PLDR.GAMES
       PLDR.GetPS1GameLists("pfs0:/", true)
       for i = start_index + 1, #PLDR.GAMES do
-        PLDR.HDD.GAMEPARTS[PLDR.GAMES[i]] = "hdd0:__.POPS"
+        local game_name = PLDR.GAMES[i]
+        PLDR.HDD.GAMEPARTS[game_name] = "hdd0:__.POPS"
+        PLDR.HDD.GAMEINFO[game_name] = {partition = "__.POPS", mount = "hdd0:__.POPS"}
       end
       HDD.UMountPartition(0)
     end
@@ -400,9 +407,12 @@ function PLDR.HDD.BuildGameList()
       if HDD.MountPartition("hdd0:__.POPS"..i, 0, FIO_MT_RDONLY) then
         local start_index = #PLDR.GAMES
         local partition = "hdd0:__.POPS"..i
+        local partition_label = "__.POPS"..i
         PLDR.GetPS1GameLists("pfs0:/", true)
         for j = start_index + 1, #PLDR.GAMES do
-          PLDR.HDD.GAMEPARTS[PLDR.GAMES[j]] = partition
+          local game_name = PLDR.GAMES[j]
+          PLDR.HDD.GAMEPARTS[game_name] = partition
+          PLDR.HDD.GAMEINFO[game_name] = {partition = partition_label, mount = partition}
         end
         HDD.UMountPartition(0)
       end
@@ -569,6 +579,67 @@ local function BuildPopstarterSelectorPath(device_page, game_name)
   return game_name..".ELF"
 end
 
+local function HexByteDump(value)
+  if value == nil then
+    return ""
+  end
+  local bytes = {}
+  for i = 1, #value do
+    bytes[#bytes + 1] = string.format("%02X", string.byte(value, i))
+  end
+  return table.concat(bytes, " ")
+end
+
+local function FormatFilenameForDebug(value)
+  if value == nil then
+    return "<nil>"
+  end
+  local printable = {}
+  for i = 1, #value do
+    local byte = string.byte(value, i)
+    if byte >= 32 and byte <= 126 then
+      printable[#printable + 1] = string.char(byte)
+    else
+      printable[#printable + 1] = string.format("\\x%02X", byte)
+    end
+  end
+  return table.concat(printable)
+end
+
+local function NormalizeVcdBasenameForMatch(filename, fold_case)
+  if filename == nil then
+    return ""
+  end
+  local basename = StripVcdExtension(filename)
+  basename = string.gsub(basename, "\226\128\153", "'")
+  basename = string.gsub(basename, "\226\128\152", "'")
+  if fold_case then
+    basename = string.lower(basename)
+  end
+  return basename
+end
+
+local function FindVcdNearMatch(target, entries, fold_case)
+  if target == nil or entries == nil then
+    return nil
+  end
+  local target_norm = NormalizeVcdBasenameForMatch(target, fold_case)
+  if target_norm == "" then
+    return nil
+  end
+  for i = 1, #entries do
+    local entry = entries[i]
+    if entry ~= nil and entry.name ~= nil and not entry.directory then
+      if string.lower(string.sub(entry.name, -4)) == ".vcd" then
+        if NormalizeVcdBasenameForMatch(entry.name, fold_case) == target_norm then
+          return entry.name
+        end
+      end
+    end
+  end
+  return nil
+end
+
 local function DeriveGameNameFromSelection(raw_selection)
   local vcd_filename = ExtractVcdFilename(raw_selection or "")
   return SanitizeGameName(StripVcdExtension(vcd_filename))
@@ -646,6 +717,7 @@ local function EnsureHDDReadyForLaunch(game)
     init_ok = false,
     status = nil,
     mount_partition = nil,
+    mount_partition_label = nil,
     mount_ok = nil
   }
   PLDR.LoadHDDModules()
@@ -654,8 +726,10 @@ local function EnsureHDDReadyForLaunch(game)
   if not result.init_ok or result.status ~= 0 then
     return result
   end
-  local partition = PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
+  local info = PLDR.HDD.GAMEINFO and PLDR.HDD.GAMEINFO[game] or nil
+  local partition = info and info.mount or PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
   result.mount_partition = partition
+  result.mount_partition_label = info and info.partition or "__.POPS"
   result.mount_ok = HDD.MountPartition(partition, 0, FIO_MT_RDONLY)
   return result
 end
@@ -669,6 +743,14 @@ local function LogPopstarterArgs(args)
   for i = 1, #args do
     LaunchLog("LAUNCH: argv["..(i - 1).."]:", args[i])
   end
+end
+
+local function SelectLaunchBackend(context)
+  local backend = PLDR.LAUNCH_BACKEND or {}
+  if context and context.device_page == "HDD" then
+    return backend.hdd or "loader"
+  end
+  return backend.default or "execps2"
 end
 
 local function AppendLaunchLog(line)
@@ -688,6 +770,30 @@ local function AppendLaunchLog(line)
     System.writeFile(fd, line, #line)
     System.closeFile(fd)
   end
+end
+
+local function ShowHddVcdOpenError(context, mount_partition, partition_label, filename, open_rc, candidate)
+  SetLaunchPhase(LaunchState.PHASE_FAILED)
+  UI.LAUNCHING = false
+  local body = string.format(
+    "HDD VCD OPEN FAILED\npartition: %s\nmount: %s\nfile: %s\nfile(hex): %s\nrc: %s\ncandidate: %s\nPress X/O to continue.",
+    tostring(partition_label),
+    tostring(mount_partition),
+    FormatFilenameForDebug(filename),
+    HexByteDump(filename),
+    tostring(open_rc),
+    tostring(candidate or "<none>")
+  )
+  while true do
+    UI.BottomDraw.Play()
+    Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, 120, 18, UI.SCR.X, UI.SCR.Y, body, UI.CCOL.GREY)
+    Input_GetEvent()
+    if UI.Pad.Events.CONFIRM or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
+      break
+    end
+    UI.flip()
+  end
+  UI.SceneChange(UI.SCENES.MMAIN)
 end
 
 function LaunchLog(...)
@@ -895,13 +1001,27 @@ local function LaunchEngine(popstarter, argv, reboot_iop, context)
     "reboot_iop="..tostring(reboot_iop)
   )
   LaunchLog("LAUNCH: loadELF argc (caller):", exec_args and #exec_args or 0)
+  local backend = SelectLaunchBackend(context)
+  LaunchLog("LAUNCH: backend:", backend)
   local rc
   if exec_args ~= nil and #exec_args > 0 and unpack_fn ~= nil then
-    rc = System.loadELF(popstarter, reboot_iop, unpack_fn(exec_args))
+    if System.loadELFBackend ~= nil then
+      rc = System.loadELFBackend(popstarter, reboot_iop, backend, unpack_fn(exec_args))
+    else
+      rc = System.loadELF(popstarter, reboot_iop, unpack_fn(exec_args))
+    end
   elseif exec_args ~= nil and #exec_args == 1 then
-    rc = System.loadELF(popstarter, reboot_iop, exec_args[1])
+    if System.loadELFBackend ~= nil then
+      rc = System.loadELFBackend(popstarter, reboot_iop, backend, exec_args[1])
+    else
+      rc = System.loadELF(popstarter, reboot_iop, exec_args[1])
+    end
   else
-    rc = System.loadELF(popstarter, reboot_iop)
+    if System.loadELFBackend ~= nil then
+      rc = System.loadELFBackend(popstarter, reboot_iop, backend)
+    else
+      rc = System.loadELF(popstarter, reboot_iop)
+    end
   end
   LaunchLog("LAUNCH RETURNED rc="..tostring(rc))
   LOG(">>> UNHANDLED ERROR at Launching game '", context and context.game or "unknown", " via ", popstarter, " Failed")
@@ -988,6 +1108,42 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local boot_source_mode = source_mode
   local device_mode = "unknown"
   local mmce_prefix = nil
+  if policy.name == "HDD" then
+    local open_ok = false
+    local open_rc = nil
+    local ok_open, fd_or_err = pcall(System.openFile, "pfs0:/"..game, FREAD)
+    if ok_open and type(fd_or_err) == "number" and fd_or_err >= 0 then
+      open_ok = true
+      System.closeFile(fd_or_err)
+    else
+      open_rc = fd_or_err
+    end
+    if not open_ok then
+      local entries = System.listDirectory("pfs0:/") or {}
+      local candidate = FindVcdNearMatch(game, entries, false)
+      local candidate_ci = nil
+      if candidate == nil then
+        candidate_ci = FindVcdNearMatch(game, entries, true)
+      end
+      LaunchLog("LAUNCH: HDD VCD open failed.",
+        "mount:", hdd_init and hdd_init.mount_partition or "unknown",
+        "partition:", hdd_init and hdd_init.mount_partition_label or "unknown",
+        "file:", FormatFilenameForDebug(game),
+        "file_hex:", HexByteDump(game),
+        "rc:", tostring(open_rc),
+        "candidate:", tostring(candidate or "<none>"),
+        "candidate_ci:", tostring(candidate_ci or "<none>"))
+      ShowHddVcdOpenError(
+        nil,
+        hdd_init and hdd_init.mount_partition or "unknown",
+        hdd_init and hdd_init.mount_partition_label or "unknown",
+        game,
+        open_rc,
+        candidate or candidate_ci
+      )
+      return
+    end
+  end
   if string.match(source_mode, "^pfs") then
     pops_root = normalized_gamelocation
     boot_source_mode = "pfs"

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -7,7 +7,11 @@ local function ensure_dir(path)
 end
 
 local BASE_DIR = ensure_dir(APP_DIR or System.currentDirectory())
-package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+local function UpdatePackagePath(base_dir)
+  BASE_DIR = ensure_dir(base_dir or System.currentDirectory())
+  package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
+end
+UpdatePackagePath(APP_DIR or System.currentDirectory())
 function LOG(...)
   print_uart(...)
 end
@@ -49,6 +53,31 @@ function GetMountData(PATH)
   return mountpart, pfsindx, filepath
 end
 
+local function NormalizePfsPath(path, index)
+  if path == nil or path == "" then
+    return path
+  end
+  return string.gsub(path, "^pfs:", ("pfs%d:"):format(index))
+end
+
+local function DetermineActivePopsPartition(boot_partition)
+  if boot_partition ~= nil and string.match(boot_partition, "^hdd0:__%.POPS%d*$") then
+    return boot_partition
+  end
+  -- TODO: verify active POPS partition selection per prompt 2 (e.g., config, UI selection, or a saved marker).
+  return "hdd0:__.POPS"
+end
+
+local function MountFirstAvailablePartition(partitions, index, open_mode)
+  for _, partition in ipairs(partitions) do
+    if partition ~= nil and partition ~= "" then
+      if HDD.MountPartition(partition, index, open_mode) then
+        return partition
+      end
+    end
+  end
+  return nil
+end
 
 local ARGV0 = System.GetArgv0()
 if string.find(ARGV0, "^hdd0:") then
@@ -62,10 +91,43 @@ if string.find(ARGV0, "^hdd0:") then
       LOG("ERROR", MODULE..".IRX", ID, RET)
     else
       System.sleep(2) -- lets give it time to get ready
-      if HDD.MountPartition(MNTPART, 0) then -- mount to "pfs3:" and NEVER USE IT FOR ANYTHING ELSE
+      local active_pops = DetermineActivePopsPartition(MNTPART)
+      local pops_candidates = {active_pops}
+      if active_pops ~= "hdd0:__.POPS" then
+        table.insert(pops_candidates, "hdd0:__.POPS")
+      end
+      for i = 1, 9 do
+        table.insert(pops_candidates, ("hdd0:__.POPS%d"):format(i))
+      end
+      -- pfs0 reserved for POPS bank for PopStarter
+      local mounted_pops = MountFirstAvailablePartition(pops_candidates, 0, FIO_MT_RDONLY)
+      if mounted_pops == nil then
+        LOG("ERROR: failed to mount POPS partition to pfs0 (TODO: verify partition selection logic).")
+      end
+
+      local boot_mount_index = 0
+      if MNTPART ~= nil and MNTPART ~= "" and MNTPART ~= mounted_pops then
+        boot_mount_index = 9
+        -- boot partition mounted at pfs9 for assets
+        if not HDD.MountPartition(MNTPART, boot_mount_index) then
+          LOG("ERROR: failed to mount boot partition for assets:", MNTPART)
+        end
+      end
+
+      BOOTPATH = NormalizePfsPath(BOOTPATH, boot_mount_index)
+      if BOOTPATH ~= nil then
         BOOTPATH, _, _ = string.match(BOOTPATH, "(.-)([^/]-([^%.]+))$")
         System.currentDirectory(BOOTPATH)
+        APP_DIR = System.currentDirectory()
+        UpdatePackagePath(APP_DIR)
         LOGF("new bootpath: '%s'\n", BOOTPATH)
+        if boot_mount_index == 9 then
+          local ui_modern = "pfs9:/POPSLDR/ui.lua"
+          local ui_flat = "pfs9:/ui.lua"
+          if not doesFileExist(ui_modern) and not doesFileExist(ui_flat) then
+            error("HDD boot partition missing ui.lua at pfs9:/ (checked POPSLDR/ui.lua and ui.lua)")
+          end
+        end
       end
     end
   end
@@ -125,7 +187,20 @@ function RunScript(S)
   end
 end
 
-local SYS = System.resolveAsset("system.lua")
+local function ResolveSystemScript()
+  local base = ensure_dir(APP_DIR or System.currentDirectory())
+  local modern = base.."system.lua"
+  local legacy = base.."POPSLDR/system.lua"
+  if doesFileExist(modern) then
+    return modern
+  end
+  if doesFileExist(legacy) then
+    return legacy
+  end
+  return System.resolveAsset("system.lua")
+end
+
+local SYS = ResolveSystemScript()
 if SYS ~= nil then
 	RunScript(SYS);
 else

--- a/src/elf_loader/include/elf-loader.h
+++ b/src/elf_loader/include/elf-loader.h
@@ -23,6 +23,7 @@ extern "C" {
 // Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileWithLoader(const char *filename, int argc, char *argv[]);
 
 /** Modify argv[0] when partition info should be kept
  *

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -18,7 +18,46 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <tamtypes.h>
 #define DPRINTF(x...) printf(x)
+
+extern unsigned char loader_elf[];
+extern unsigned int size_loader_elf;
+
+//--------------------------------------------------------------
+// ELF-header structures and identifiers
+#define ELF_MAGIC	0x464c457f
+#define ELF_PT_LOAD	1
+//--------------------------------------------------------------
+typedef struct
+{
+	u8	ident[16];
+	u16	type;
+	u16	machine;
+	u32	version;
+	u32	entry;
+	u32	phoff;
+	u32	shoff;
+	u32	flags;
+	u16	ehsize;
+	u16	phentsize;
+	u16	phnum;
+	u16	shentsize;
+	u16	shnum;
+	u16	shstrndx;
+} elf_header_t;
+//--------------------------------------------------------------
+typedef struct
+{
+	u32	  type;
+	u32	  offset;
+	void *vaddr;
+	u32	  paddr;
+	u32	  filesz;
+	u32	  memsz;
+	u32	  flags;
+	u32	  align;
+} elf_pheader_t;
 
 static bool is_host_path(const char *filename) {
 	return (filename != NULL && strncmp(filename, "host:/", 6) == 0);
@@ -137,6 +176,33 @@ static void wipe_bramMem(void) {
 			"\tsq $0, 32(%0) \n"
 			"\tsq $0, 48(%0) \n" ::"r"(i));
 	}
+}
+
+static int ExecEmbeddedLoader(int argc, char *argv[]) {
+	u8 *boot_elf = (u8 *)&loader_elf;
+	elf_header_t *boot_header = (elf_header_t *)boot_elf;
+	elf_pheader_t *boot_pheader;
+	int i;
+
+	if ((*(u32*)boot_header->ident) != ELF_MAGIC) {
+		return -5;
+	}
+
+	boot_pheader = (elf_pheader_t *)(boot_elf + boot_header->phoff);
+	for (i = 0; i < boot_header->phnum; i++) {
+		if (boot_pheader[i].type != ELF_PT_LOAD) {
+			continue;
+		}
+		memcpy(boot_pheader[i].vaddr, boot_elf + boot_pheader[i].offset, boot_pheader[i].filesz);
+		if (boot_pheader[i].memsz > boot_pheader[i].filesz) {
+			memset((void*)((int)boot_pheader[i].vaddr + boot_pheader[i].filesz), 0,
+				boot_pheader[i].memsz - boot_pheader[i].filesz);
+		}
+	}
+
+	SifExitRpc();
+	ExecPS2((void *)boot_header->entry, 0, argc, argv);
+	return -1;
 }
 
 int LoadELFFromFileWithPartition(const char *filename, int argc, char *argv[]) {
@@ -278,4 +344,52 @@ int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[])
 
 	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
 	return -1;
+}
+
+int LoadELFFromFileWithLoader(const char *filename, int argc, char *argv[])
+{
+	int i;
+	int loader_argc = argc + 1;
+	static const int kMaxArgc = 32;
+	static char *loader_argv[33];
+	static char loader_arg_storage[2048];
+	char resolved_path[256];
+	size_t storage_offset = 0;
+
+	if (argc <= 0 || argv == NULL || argv[0] == NULL) {
+		return -4;
+	}
+	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {
+		return -1;
+	}
+
+	DPRINTF("LAUNCH: Using LoaderExecPS2\n");
+	append_launch_log_fmt("backend", -1, "loader");
+	DPRINTF("LAUNCH: loader exec path=%s\n", resolved_path);
+
+	if (loader_argc + 1 > kMaxArgc) {
+		return -2;
+	}
+	loader_argv[0] = store_arg(resolved_path, loader_arg_storage, sizeof(loader_arg_storage), &storage_offset);
+	if (!loader_argv[0]) {
+		return -3;
+	}
+	for (i = 0; i < argc; i++) {
+		char *stored_arg = store_arg(argv[i], loader_arg_storage, sizeof(loader_arg_storage), &storage_offset);
+		if (!stored_arg) {
+			return -3;
+		}
+		loader_argv[i + 1] = stored_arg;
+	}
+	loader_argv[loader_argc] = NULL;
+
+	DPRINTF("LAUNCH: loader argc=%d\n", loader_argc);
+	for (i = 0; i < loader_argc; i++) {
+		DPRINTF("LAUNCH: loader argv[%d]=%s\n", i, loader_argv[i] ? loader_argv[i] : "(null)");
+		append_launch_log_fmt("loader_argv", i, loader_argv[i]);
+	}
+	append_launch_log_fmt("loader_exec_path", -1, resolved_path);
+
+	wipe_bramMem();
+	return ExecEmbeddedLoader(loader_argc, loader_argv);
 }

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 
 	elfdata.epc = 0;
 
-	// argv[0]=path to ELF, argv[1..]=arguments
+	// argv[0]=path to ELF, argv[1..]=arguments for target ELF (argv[0] preserved)
 	if (argc < 2) {  
 		SET_GS_BGCOLOUR(RED_BG);
 		return -EINVAL;
@@ -136,11 +136,11 @@ int main(int argc, char *argv[])
 
 		SET_GS_BGCOLOUR(PURPBLE_BG);
 		
-		DPRINTF("POPS EXEC: argc=%d\n", argc);
-		for (i = 0; i < argc; i++) {
-			DPRINTF("POPS EXEC: argv[%d] = %s\n", i, argv[i]);
+		DPRINTF("POPS EXEC: argc=%d\n", argc - 1);
+		for (i = 0; i < argc - 1; i++) {
+			DPRINTF("POPS EXEC: argv[%d] = %s\n", i, argv[i + 1]);
 		}
-		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+		return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, &argv[1]);
 	} else {
 		SET_GS_BGCOLOUR(MAGENTA_BG);
 		SifExitRpc();

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <string.h>
 #include <libmc.h>
 #include <malloc.h>
 #include <sys/fcntl.h>
@@ -492,6 +493,7 @@ static int lua_checkexist(lua_State *L){
 extern "C" {
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileWithLoader(const char *filename, int argc, char *argv[]);
 }
 static int lua_loadELF(lua_State *L)
 {
@@ -516,6 +518,54 @@ static int lua_loadELF(lua_State *L)
 	}
 	printf("# Loading ELF argv0 default (argc=0)\n");
 	int rc = LoadELFFromFile(elftoload, 0, NULL);
+	lua_pushinteger(L, rc);
+	return 1;
+}
+
+static int lua_loadELFBackend(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc < 3) return luaL_error(L, "%s(path, reboot_iop, backend, args...): not enough args", __FUNCTION__);
+	size_t size;
+	const char *elftoload = luaL_checklstring(L, 1, &size);
+	int rebootIOP = luaL_checkinteger(L, 2);
+	const char *backend = luaL_checkstring(L, 3);
+	int extra_args = argc - 3;
+	static char selector_buf[256];
+	static char *argv_static[2];
+	printf("# Loading ELF '%s' backend=%s iop_reboot=%d, extra_args=%d\n", elftoload, backend ? backend : "(null)", rebootIOP, extra_args);
+	if (extra_args > 0) {
+		const char *selector = luaL_checkstring(L, 4);
+		snprintf(selector_buf, sizeof(selector_buf), "%s", selector ? selector : "");
+		argv_static[0] = selector_buf;
+		argv_static[1] = NULL;
+		printf("# Loading ELF argv0='%s' argc=1\n", argv_static[0]);
+		if (backend && strcmp(backend, "loader") == 0) {
+			int rc = LoadELFFromFileWithLoader(elftoload, 1, argv_static);
+			lua_pushinteger(L, rc);
+			return 1;
+		}
+		if (backend && strcmp(backend, "loadexec") == 0) {
+			int rc = LoadELFFromFile(elftoload, 1, argv_static);
+			lua_pushinteger(L, rc);
+			return 1;
+		}
+		int rc = LoadELFFromFileExecPS2(elftoload, 1, argv_static);
+		lua_pushinteger(L, rc);
+		return 1;
+	}
+	printf("# Loading ELF argv0 default (argc=0)\n");
+	if (backend && strcmp(backend, "loader") == 0) {
+		int rc = LoadELFFromFileWithLoader(elftoload, 0, NULL);
+		lua_pushinteger(L, rc);
+		return 1;
+	}
+	if (backend && strcmp(backend, "loadexec") == 0) {
+		int rc = LoadELFFromFile(elftoload, 0, NULL);
+		lua_pushinteger(L, rc);
+		return 1;
+	}
+	int rc = LoadELFFromFileExecPS2(elftoload, 0, NULL);
 	lua_pushinteger(L, rc);
 	return 1;
 }
@@ -771,6 +821,7 @@ static const luaL_Reg System_functions[] = {
 	{"exitToBrowser",                  lua_exit},
 	{"getMCInfo",                 lua_getmcinfo},
 	{"loadELF",                 	lua_loadELF},
+	{"loadELFBackend",            lua_loadELFBackend},
 	{"checkValidDisc",       lua_checkValidDisc},
 	{"getDiscType",             lua_getDiscType},
 	{"checkDiscTray",         lua_checkDiscTray},


### PR DESCRIPTION
### Motivation
- HDD-launched POPStarter runs were hanging early (EE TLB misses); the change provides an alternate launch backend that performs IOP reset/module reloads to work around launch-state issues. 
- Allow runtime selection between the existing `LoadExecPS2` path and a loader-based `SifLoadElf`+`ExecPS2` path so HDD launches can use the more-resetting loader by default. 
- Improve diagnostics for HDD VCD open failures to make mismatched filenames and mount/partition state easier to investigate.

### Description
- Add a runtime backend toggle (`PLDR.LAUNCH_BACKEND`) and selection logic in `bin/POPSLDR/system.lua`, and log which backend is chosen for each launch. 
- Route PopStarter launches through a new Lua binding `loadELFBackend` (added to `src/luasystem.cpp`) which calls one of three C entry points: the original `LoadELFFromFile` (LoadExecPS2), `LoadELFFromFileExecPS2` (SifLoadElf+ExecPS2), or the new `LoadELFFromFileWithLoader` (embedded loader path). 
- Implement `LoadELFFromFileWithLoader` and `ExecEmbeddedLoader` in `src/elf_loader/src/elf.c` and declare it in `src/elf_loader/include/elf-loader.h`, which loads an embedded loader image and calls `ExecPS2` after preparing argv. 
- Update the embedded loader (`src/elf_loader/src/loader/src/loader.c`) to preserve the selector argument semantics by passing the original selector as `argv[0]` to the target while using the loader ELF path in `argv[0]` for loading, and to call `ExecPS2` with `argv[1..]` so the target sees the expected argc/argv. 
- For HDD-specific handling, add per-game HDD metadata and mount bookkeeping (`PLDR.HDD.GAMEINFO`) and alter `EnsureHDDReadyForLaunch` to expose `mount_partition`/`mount_partition_label`; perform a `pfs0:/<game>` open check and, on failure, search `pfs0:/` for case-sensitive then case-insensitive VCD candidates. 
- Add helper utilities and diagnostics in `system.lua` (`HexByteDump`, `FormatFilenameForDebug`, `NormalizeVcdBasenameForMatch`, `FindVcdNearMatch`) and an on-screen error (`ShowHddVcdOpenError`) that shows partition, mount, printable filename, hex dump, return code, and candidate suggestions when opening a VCD fails. 
- Improve HDD boot partition mount logic and package-path handling in `etc/boot.lua` to mount a POPS partition to `pfs0:` (with an optional separate boot-part mount index used for assets) and update `package.path` accordingly.

### Testing
- No automated tests or CI were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697225e63ae883219682c9a217a32246)