### PR TITLE
Remove HDD launch debug UI and debug-only delays

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1204,20 +1204,6 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   if policy.name == "HDD" then
     reboot_iop = 0
   end
-  if policy.name == "HDD" then
-    UI.BottomDraw.Play()
-    Font.ftPrintMultiLineAligned(
-      LFONT,
-      UI.SCR.X_MID,
-      120,
-      20,
-      UI.SCR.X,
-      UI.SCR.Y,
-      "HDD: EXEC POPSTARTER",
-      UI.CCOL.YELLOW
-    )
-    UI.flip()
-  end
   LaunchEngine(popstarter, argv, reboot_iop, context)
 end
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,7 +440,6 @@ int main(int argc, char * argv[])
         if (errMsg != NULL)
         {
             scr_setfontcolor(0x0000ff);
-            sleep(1); //ensures message is printed no matter what
 		    scr_clear();
 		    scr_setXY(5, 2);
 		    scr_printf("Enceladus ERROR!\n");
@@ -448,7 +447,6 @@ int main(int argc, char * argv[])
 		    puts(errMsg);
 		    scr_printf("\nPress [start] to restart\n");
         	while (!isButtonPressed(PAD_START)) {
-                	sleep(1);
 		    }
             scr_setfontcolor(0xffffff);
         }


### PR DESCRIPTION
### Motivation
- Remove temporary on-screen diagnostics and artificial delays that were added to aid HDD bring-up debugging, while preserving all functional behavior and runtime logic.

### Description
- Deleted the HDD-only pre-launch banner that printed `"HDD: EXEC POPSTARTER"` and the associated `UI.flip()` in `bin/POPSLDR/system.lua`.
- Removed debug-only `sleep(1)` calls used to keep an error message visible in the error display loop in `src/main.cpp`.
- Only draw/debug/delay code was removed and no control flow, mounts, `argv` handling, BOOT_DEVICE logic, `pfs0`/`pfs1` behavior, or USB/MMCE paths were changed.

### Testing
- No automated tests were executed for this change.
- CI build (`make clean elfloader all package`) was not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d684c9a883219a760318b57e484b)