### PR TITLE
Improve boot script lookup fallback

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -125,7 +125,42 @@ function RunScript(S)
   end
 end
 
-local SYS = System.resolveAsset("system.lua")
+local function ResolveSystemScript()
+  local resolved = System.resolveAsset("system.lua")
+  if resolved ~= nil then
+    return resolved
+  end
+  local tried = {}
+  local function push_dir(dir)
+    if dir == nil or dir == "" then
+      return
+    end
+    local normalized = ensure_dir(dir)
+    if tried[normalized] then
+      return
+    end
+    tried[normalized] = true
+    local direct = normalized.."system.lua"
+    if doesFileExist(direct) then
+      return direct
+    end
+    local legacy = normalized.."POPSLDR/system.lua"
+    if doesFileExist(legacy) then
+      return legacy
+    end
+  end
+  local fallback = push_dir(APP_DIR)
+  if fallback ~= nil then
+    return fallback
+  end
+  fallback = push_dir(System.currentDirectory())
+  if fallback ~= nil then
+    return fallback
+  end
+  return nil
+end
+
+local SYS = ResolveSystemScript()
 if SYS ~= nil then
 	RunScript(SYS);
 else


### PR DESCRIPTION
### Motivation
- Prevent boot-time failure when `system.lua` is not found via `System.resolveAsset` by attempting reasonable fallbacks before erroring.

### Description
- Add a `ResolveSystemScript` helper in `etc/boot.lua` that first calls `System.resolveAsset("system.lua")` and returns it if found.
- If unresolved, the helper normalizes and probes `APP_DIR` and `System.currentDirectory()` for `system.lua` and legacy `POPSLDR/system.lua` using `ensure_dir` and `doesFileExist`.
- Replace the original single-call lookup with `local SYS = ResolveSystemScript()` and preserve the original error message when no candidate is found.
- Change is limited to `etc/boot.lua` and preserves existing behavior while adding robust fallback checks.

### Testing
- No automated tests were executed for this change and CI/build steps were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972eae13250832180f269788f18c9ae)