### PR TITLE
Add device-lock deny prompt with logging and tighten MX4SIO probe checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ IOP_MODULES = iomanX.o fileXio.o \
 			  sio2man.o mcman.o mcserv.o padman.o libsd.o \
 			  usbd.o audsrv.o bdm.o bdmfs_fatfs.o \
 			  usbmass_bd.o cdfs.o ds34bt.o ds34usb.o \
-			  ps2dev9.o ps2atad.o ps2hdd-osd.o ps2fs.o mmceman.o
+			  ps2dev9.o ps2atad.o ps2hdd-osd.o ps2fs.o mmceman.o \
+			  bdmassault_usbd.o bdmassault_usbhdfsd.o
 
 EMBEDDED_RSC = boot.o builtin_font.o
 
@@ -134,6 +135,15 @@ modules/ds34usb/iop/ds34usb.irx: modules/ds34usb/iop
 
 $(EE_ASM_DIR)ds34usb.c: modules/ds34usb/iop/ds34usb.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ ds34usb_irx
+
+# BDMAssault MX4SIO IRX bundle (embedded)
+BDMASSAULT_MX4SIO_DIR = iop/embed/BDMASSAULT_MX4SIO
+
+$(EE_ASM_DIR)bdmassault_usbd.c: $(BDMASSAULT_MX4SIO_DIR)/usbd.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ bdmassault_usbd_irx
+
+$(EE_ASM_DIR)bdmassault_usbhdfsd.c: $(BDMASSAULT_MX4SIO_DIR)/usbhdfsd.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ bdmassault_usbhdfsd_irx
 
 #------------------------------------------------------------------#
 elfloader: src/elf_loader/libcustom-elf-loader.a

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -41,6 +41,8 @@ for x=1, #IMGS do
   local key = IMGS[x]:match("(.+)%..+$")
   IMG_SOURCES[key] = IMGS[x]
 end
+IMG_SOURCES["MMCE"] = "SMB.png"
+IMG_SOURCES["MX4SIO"] = "USB.png"
 
 IMG = setmetatable({}, {
   __index = function (tbl, key)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -167,6 +167,10 @@ PLDR = {
   USB = {
     MASSINDX = 0
   },
+  MX4SIO = {
+    READY = false,
+    ROOT = nil
+  },
   MMCE = {
     PROBED = false,
     PREFIX = nil,
@@ -577,7 +581,7 @@ local function BuildPopstarterSelector(prefix, vcd_filename)
 end
 
 local function SelectPopstarterSelectorPrefix(device_page)
-  if device_page == "USB" or device_page == "MMCE" or device_page == "SMB/MMCE" then
+  if device_page == "USB" or device_page == "MMCE" or device_page == "SMB/MMCE" or device_page == "MX4SIO" then
     return "XX."
   end
   if device_page == "HDD" then
@@ -593,7 +597,7 @@ local function BuildPopstarterSelectorPath(device_page, game_name)
   if device_page == "HDD" then
     return "hdd0:__.POPS/"..game_name..".ELF"
   end
-  if device_page == "USB" or device_page == "MMCE" or device_page == "SMB/MMCE" then
+  if device_page == "USB" or device_page == "MMCE" or device_page == "SMB/MMCE" or device_page == "MX4SIO" then
     return "mass:/POPS/XX."..game_name..".ELF"
   end
   return game_name..".ELF"
@@ -1004,6 +1008,9 @@ end
 
 local function ResolveLaunchPolicy(gamelocation)
   local ui_scene = UI and UI.CURSCENE or "unknown"
+  if ui_scene == UI.SCENES.GMX4SIO then
+    return BuildLaunchPolicy("MX4SIO", "mass", "mass", nil), "MX4SIO"
+  end
   if string.match(gamelocation, "^mass") then
     return BuildLaunchPolicy("USB", "mass", "mass", nil), "USB"
   end
@@ -1177,6 +1184,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   if fallback_bootparam ~= nil then
     LaunchLog("LAUNCH: bootparam fallback:", fallback_bootparam, "exists:", tostring(fallback_exists))
   end
+  LOG("Resolved game path:", vcd_path)
   local context = {
     device_page = device_page,
     device_mode = device_mode,

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -116,6 +116,28 @@ local function ResolveIrx(name)
   return System.resolveAssetType(name, ASSET_IRX) or JoinPath(APP_DIR_LOCAL, name)
 end
 
+local function DetectBootDevice()
+  local boot_path = NormalizeDirPath(BOOT_PATH_RAW or "")
+  local prefix = string.match(boot_path, "^([%a]+%d*):")
+  if prefix == nil then
+    return nil, boot_path, prefix
+  end
+  if string.match(prefix, "^mmce%d*$") then
+    return "MMCE", boot_path, prefix
+  end
+  if string.match(prefix, "^mass%d*$") then
+    local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
+    local usb_marker = JoinPath(APP_DIR_LOCAL, ".boot_usb")
+    if doesFileExist(mx_marker) then
+      return "MX4SIO", boot_path, prefix
+    end
+    if doesFileExist(usb_marker) then
+      return "USB", boot_path, prefix
+    end
+  end
+  return nil, boot_path, prefix
+end
+
 local function LoadIrxFromDir(dir)
   local normalized = NormalizeDirPath(dir)
   if not doesFolderExist(normalized) then return false end
@@ -219,6 +241,28 @@ if UI == nil then
   LOG("Boot cwd:", System.currentDirectory())
   LOG("package.path:", package.path)
   error("UI global not initialized (module returned nil or did not set UI)")
+end
+
+if UI.DEVLOCK ~= nil then
+  local boot_name, boot_path, boot_prefix = DetectBootDevice()
+  UI.boot_device = UI.DEVLOCK.NONE
+  UI.boot_locks = {}
+  if boot_name == "MX4SIO" then
+    UI.boot_device = UI.DEVLOCK.MX4SIO
+    UI.boot_locks[UI.DEVLOCK.USB] = true
+    UI.boot_locks[UI.DEVLOCK.MMCE] = true
+  elseif boot_name == "USB" then
+    UI.boot_device = UI.DEVLOCK.USB
+    UI.boot_locks[UI.DEVLOCK.MX4SIO] = true
+  elseif boot_name == "MMCE" then
+    UI.boot_device = UI.DEVLOCK.MMCE
+    UI.boot_locks[UI.DEVLOCK.MX4SIO] = true
+  end
+  if boot_name ~= nil then
+    LOG("Boot device detected:", boot_name, "prefix:", tostring(boot_prefix), "path:", tostring(boot_path))
+  else
+    LOG("Boot device detection ambiguous; no boot locks set.", "prefix:", tostring(boot_prefix), "path:", tostring(boot_path))
+  end
 end
 require("images")
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -7,11 +7,29 @@
 --]]
 
 LOG("Registering POPSLoader UI")
+local DEVLOCK = { NONE = 0, USB = 1, MMCE = 2, MX4SIO = 3 }
 local UI = {
-    LASTSCENE = 4;
-    CURSCENE = 4;
-    SCENES = {GUSB=1, GSMB=2, GHDD=3, MMAIN=4, MPROFILE=5, CREDITS=6};
+    LASTSCENE = 5;
+    CURSCENE = 5;
+    SCENES = {GUSB=1, GSMB=2, GMX4SIO=3, GHDD=4, MMAIN=5, MPROFILE=6, CREDITS=7};
     LAUNCHING = false;
+    device_lock = DEVLOCK.NONE;
+    device_lock_name = function (lock)
+      if lock == DEVLOCK.USB then return "USB" end
+      if lock == DEVLOCK.MMCE then return "MMCE" end
+      if lock == DEVLOCK.MX4SIO then return "MX4SIO" end
+      return "None"
+    end;
+    canEnterDevice = function (target)
+      if UI.device_lock == DEVLOCK.NONE then return true end
+      return UI.device_lock == target
+    end;
+    setDeviceLock = function (target)
+      if UI.device_lock == DEVLOCK.NONE then
+        UI.device_lock = target
+        LOG("Device lock set to "..UI.device_lock_name(target))
+      end
+    end;
     SceneChange = function (SCENE)
       UI.LASTSCENE = UI.CURSCENE
       UI.CURSCENE = SCENE
@@ -101,6 +119,8 @@ local UI = {
       body = "";
       options = {"Yes", "No"};
       selected = 2;
+      confirm_action = nil;
+      cancel_action = nil;
       OpenExit = function ()
         LOG("Exit requested")
         UI.Modal.active = true
@@ -108,11 +128,31 @@ local UI = {
         UI.Modal.body = "Return to OSDSYS?"
         UI.Modal.options = {"Yes", "No"}
         UI.Modal.selected = 2
+        UI.Modal.confirm_action = UI.Modal.ConfirmExit
+        UI.Modal.cancel_action = UI.Modal.Close
+      end;
+      OpenDeviceLock = function (active, target)
+        UI.Modal.active = true
+        UI.Modal.title = "Device drivers already loaded"
+        UI.Modal.body = ("Drivers for %s are already loaded.\nTo use %s, restart POPSLoader to reload drivers."):format(active, target)
+        UI.Modal.options = {"Return", "Exit"}
+        UI.Modal.selected = 1
+        UI.Modal.confirm_action = function ()
+          LOG("Device lock prompt choice: RETURN")
+          UI.Modal.Close()
+          UI.SceneChange(UI.SCENES.MMAIN)
+        end
+        UI.Modal.cancel_action = function ()
+          LOG("Device lock prompt choice: EXIT")
+          UI.Modal.ConfirmExit()
+        end
       end;
       Close = function ()
         UI.Modal.active = false
+        UI.Modal.confirm_action = nil
+        UI.Modal.cancel_action = nil
       end;
-      Confirm = function ()
+      ConfirmExit = function ()
         LOG("Exit confirmed")
         UI.LAUNCHING = true
         System.exitToBrowser()
@@ -127,9 +167,17 @@ local UI = {
           end
         elseif UI.Pad.Events.CONFIRM then
           if UI.Modal.selected == 1 then
-            UI.Modal.Confirm()
+            if UI.Modal.confirm_action ~= nil then
+              UI.Modal.confirm_action()
+            else
+              UI.Modal.Close()
+            end
           else
-            UI.Modal.Close()
+            if UI.Modal.cancel_action ~= nil then
+              UI.Modal.cancel_action()
+            else
+              UI.Modal.Close()
+            end
           end
         elseif UI.Pad.Events.BACK then
           UI.Modal.Close()
@@ -264,9 +312,9 @@ local UI = {
     };
     MainMenu = {
       OPT = 1;
-      opts = {"USB", "SMB", "HDD"};
+      opts = {"USB", "MMCE", "MX4SIO", "HDD"};
       Play = function ()
-        local profcnt = 3
+        local profcnt = #UI.MainMenu.opts
         Font.ftPrint(LFONT, UI.SCR.X_MID, 30, 8, UI.SCR.X, 16, "Welcome to POPStarter Loader", UI.CCOL.GREY)
         for x = 1, #UI.MainMenu.opts do
           Graphics.drawImage(IMG[UI.MainMenu.opts[x]], 256+(110*(x-1))-64, x == UI.MainMenu.OPT and (UI.SCR.Y_MID-65) or (UI.SCR.Y_MID-64),
@@ -286,16 +334,28 @@ local UI = {
         if UI.Pad.Events.SELECT then UI.SceneChange(UI.SCENES.CREDITS) end
           if UI.Pad.Events.CONFIRM then
           if UI.MainMenu.OPT == 1 then
+            if not UI.canEnterDevice(DEVLOCK.USB) then
+              LOG("Device lock denied entry to USB; active lock is "..UI.device_lock_name(UI.device_lock))
+              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "USB")
+              return
+            end
+            UI.setDeviceLock(DEVLOCK.USB)
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
-            UI.SceneChange(UI.MainMenu.OPT)
+            UI.SceneChange(UI.SCENES.GUSB)
           elseif UI.MainMenu.OPT == 2 then
+            if not UI.canEnterDevice(DEVLOCK.MMCE) then
+              LOG("Device lock denied entry to MMCE; active lock is "..UI.device_lock_name(UI.device_lock))
+              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "MMCE")
+              return
+            end
+            UI.setDeviceLock(DEVLOCK.MMCE)
             local slots = PLDR.GetMMCESlots()
             if #slots < 1 then
               UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
               PLDR.CleanupGameList()
               PLDR.GAMEPATH = ""
-              UI.SceneChange(UI.MainMenu.OPT)
+              UI.SceneChange(UI.SCENES.GSMB)
             else
               if PLDR.MMCE.PREFIX == nil then
                 PLDR.SetMMCESlot(1)
@@ -307,9 +367,33 @@ local UI = {
               end
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
-              UI.SceneChange(UI.MainMenu.OPT)
+              UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 3 then
+            if not UI.canEnterDevice(DEVLOCK.MX4SIO) then
+              LOG("Device lock denied entry to MX4SIO; active lock is "..UI.device_lock_name(UI.device_lock))
+              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "MX4SIO")
+              return
+            end
+            UI.setDeviceLock(DEVLOCK.MX4SIO)
+            LOG("Entering MX4SIO page")
+            LOG("MX4SIO init start")
+            PLDR.CleanupGameList()
+            local ok, root = System.initMX4SIO()
+            if not ok or root == nil then
+              PLDR.MX4SIO.READY = false
+              PLDR.MX4SIO.ROOT = nil
+              UI.Notif_queue.add("No MX4SIO device found (mass:/).")
+              PLDR.GAMEPATH = ""
+            else
+              PLDR.MX4SIO.READY = true
+              PLDR.MX4SIO.ROOT = root
+              local list = PLDR.GetPS1GameLists(root.."POPS/", true)
+              local count = list and #list or 0
+              LOG("MX4SIO games found:", count)
+            end
+            UI.SceneChange(UI.SCENES.GMX4SIO)
+          elseif UI.MainMenu.OPT == 4 then
             PLDR.LoadHDDModules()
             if UI.LASTSCENE == UI.SCENES.GHDD then
               LOG("skipping cache cleanup")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -13,7 +13,10 @@ local UI = {
     CURSCENE = 5;
     SCENES = {GUSB=1, GSMB=2, GMX4SIO=3, GHDD=4, MMAIN=5, MPROFILE=6, CREDITS=7};
     LAUNCHING = false;
+    DEVLOCK = DEVLOCK;
     device_lock = DEVLOCK.NONE;
+    boot_device = DEVLOCK.NONE;
+    boot_locks = {};
     device_lock_name = function (lock)
       if lock == DEVLOCK.USB then return "USB" end
       if lock == DEVLOCK.MMCE then return "MMCE" end
@@ -21,8 +24,16 @@ local UI = {
       return "None"
     end;
     canEnterDevice = function (target)
-      if UI.device_lock == DEVLOCK.NONE then return true end
-      return UI.device_lock == target
+      if UI.boot_locks ~= nil and UI.boot_locks[target] == true then
+        return false, "boot", UI.boot_device
+      end
+      if UI.device_lock == DEVLOCK.NONE then
+        return true
+      end
+      if UI.device_lock == target then
+        return true
+      end
+      return false, "session", UI.device_lock
     end;
     setDeviceLock = function (target)
       if UI.device_lock == DEVLOCK.NONE then
@@ -131,10 +142,16 @@ local UI = {
         UI.Modal.confirm_action = UI.Modal.ConfirmExit
         UI.Modal.cancel_action = UI.Modal.Close
       end;
-      OpenDeviceLock = function (active, target)
+      OpenDeviceLock = function (reason, active, target)
+        local active_name = UI.device_lock_name(active)
+        local target_name = UI.device_lock_name(target)
         UI.Modal.active = true
         UI.Modal.title = "Device drivers already loaded"
-        UI.Modal.body = ("Drivers for %s are already loaded.\nTo use %s, restart POPSLoader to reload drivers."):format(active, target)
+        if reason == "boot" then
+          UI.Modal.body = ("Current boot device (%s) requires drivers already loaded.\nTo use %s, restart POPSLoader to reload drivers."):format(active_name, target_name)
+        else
+          UI.Modal.body = ("Drivers for %s are already loaded.\nTo use %s, restart POPSLoader to reload drivers."):format(active_name, target_name)
+        end
         UI.Modal.options = {"Return", "Exit"}
         UI.Modal.selected = 1
         UI.Modal.confirm_action = function ()
@@ -316,6 +333,18 @@ local UI = {
       Play = function ()
         local profcnt = #UI.MainMenu.opts
         Font.ftPrint(LFONT, UI.SCR.X_MID, 30, 8, UI.SCR.X, 16, "Welcome to POPStarter Loader", UI.CCOL.GREY)
+        local status_y = 50
+        if UI.boot_device ~= nil and UI.boot_device ~= DEVLOCK.NONE then
+          Font.ftPrint(SFONT, UI.SCR.X_MID, status_y, 8, UI.SCR.X, 16, "Booted from: "..UI.device_lock_name(UI.boot_device), UI.CCOL.GREY)
+          status_y = status_y + 12
+        end
+        if UI.device_lock ~= nil and UI.device_lock ~= DEVLOCK.NONE then
+          Font.ftPrint(SFONT, UI.SCR.X_MID, status_y, 8, UI.SCR.X, 16, "Active Device: "..UI.device_lock_name(UI.device_lock).." (restart to switch)", UI.CCOL.GREY)
+          status_y = status_y + 12
+        end
+        if UI.boot_locks ~= nil and (UI.boot_locks[DEVLOCK.USB] or UI.boot_locks[DEVLOCK.MMCE] or UI.boot_locks[DEVLOCK.MX4SIO]) then
+          Font.ftPrint(SFONT, UI.SCR.X_MID, status_y, 8, UI.SCR.X, 16, "Some devices unavailable this session", UI.CCOL.GREY)
+        end
         for x = 1, #UI.MainMenu.opts do
           Graphics.drawImage(IMG[UI.MainMenu.opts[x]], 256+(110*(x-1))-64, x == UI.MainMenu.OPT and (UI.SCR.Y_MID-65) or (UI.SCR.Y_MID-64),
             x == UI.MainMenu.OPT and UI.CCOL.YELLOW or UI.CCOL.GREY)
@@ -334,22 +363,23 @@ local UI = {
         if UI.Pad.Events.SELECT then UI.SceneChange(UI.SCENES.CREDITS) end
           if UI.Pad.Events.CONFIRM then
           if UI.MainMenu.OPT == 1 then
-            if not UI.canEnterDevice(DEVLOCK.USB) then
-              LOG("Device lock denied entry to USB; active lock is "..UI.device_lock_name(UI.device_lock))
-              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "USB")
+            local ok, reason, active = UI.canEnterDevice(DEVLOCK.USB)
+            if not ok then
+              LOG("Device lock denied entry to USB; active lock is "..UI.device_lock_name(active))
+              UI.Modal.OpenDeviceLock(reason, active, DEVLOCK.USB)
               return
             end
-            UI.setDeviceLock(DEVLOCK.USB)
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
+            UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSB)
           elseif UI.MainMenu.OPT == 2 then
-            if not UI.canEnterDevice(DEVLOCK.MMCE) then
-              LOG("Device lock denied entry to MMCE; active lock is "..UI.device_lock_name(UI.device_lock))
-              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "MMCE")
+            local ok, reason, active = UI.canEnterDevice(DEVLOCK.MMCE)
+            if not ok then
+              LOG("Device lock denied entry to MMCE; active lock is "..UI.device_lock_name(active))
+              UI.Modal.OpenDeviceLock(reason, active, DEVLOCK.MMCE)
               return
             end
-            UI.setDeviceLock(DEVLOCK.MMCE)
             local slots = PLDR.GetMMCESlots()
             if #slots < 1 then
               UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
@@ -367,15 +397,16 @@ local UI = {
               end
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
+              UI.setDeviceLock(DEVLOCK.MMCE)
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 3 then
-            if not UI.canEnterDevice(DEVLOCK.MX4SIO) then
-              LOG("Device lock denied entry to MX4SIO; active lock is "..UI.device_lock_name(UI.device_lock))
-              UI.Modal.OpenDeviceLock(UI.device_lock_name(UI.device_lock), "MX4SIO")
+            local ok, reason, active = UI.canEnterDevice(DEVLOCK.MX4SIO)
+            if not ok then
+              LOG("Device lock denied entry to MX4SIO; active lock is "..UI.device_lock_name(active))
+              UI.Modal.OpenDeviceLock(reason, active, DEVLOCK.MX4SIO)
               return
             end
-            UI.setDeviceLock(DEVLOCK.MX4SIO)
             LOG("Entering MX4SIO page")
             LOG("MX4SIO init start")
             PLDR.CleanupGameList()
@@ -391,6 +422,7 @@ local UI = {
               local list = PLDR.GetPS1GameLists(root.."POPS/", true)
               local count = list and #list or 0
               LOG("MX4SIO games found:", count)
+              UI.setDeviceLock(DEVLOCK.MX4SIO)
             end
             UI.SceneChange(UI.SCENES.GMX4SIO)
           elseif UI.MainMenu.OPT == 4 then

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1,9 +1,13 @@
+#include <stdio.h>
 #include <unistd.h>
 #include <libmc.h>
 #include <malloc.h>
 #include <sys/fcntl.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#define NEWLIB_PORT_AWARE
+#include <fileXio_rpc.h>
+#include <fileio.h>
 #include "include/luaplayer.h"
 #include "include/md5.h"
 #include "include/graphics.h"
@@ -12,6 +16,73 @@
 #include "include/dprintf.h"
 
 #define MAX_DIR_FILES 512
+
+extern unsigned char bdmassault_usbd_irx[];
+extern unsigned int size_bdmassault_usbd_irx;
+extern unsigned char bdmassault_usbhdfsd_irx[];
+extern unsigned int size_bdmassault_usbhdfsd_irx;
+
+static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret)
+{
+	int id = -1;
+	int ret = -1;
+	id = SifExecModuleBuffer(irx, size, 0, NULL, &ret);
+	if (out_id) {
+		*out_id = id;
+	}
+	if (out_ret) {
+		*out_ret = ret;
+	}
+	DPRINTF("MX4SIO IRX load %s: id=%d ret=%d\n", name, id, ret);
+	if (id < 0 || ret < 0) {
+		DPRINTF("MX4SIO IRX load failed: %s id=%d ret=%d\n", name, id, ret);
+		return false;
+	}
+	return true;
+}
+
+static bool ProbeDir(const char *path, int *out_ret)
+{
+	int fd = fileXioDopen(path);
+	if (out_ret) {
+		*out_ret = fd;
+	}
+	if (fd >= 0) {
+		fileXioDclose(fd);
+		return true;
+	}
+	return false;
+}
+
+// MX4SIO init notes:
+// - Bundle inventory (iop/embed/BDMASSAULT_MX4SIO): usbd.irx, usbhdfsd.irx, README.MD, LICENSE, SourceCode-BDMAssault-mx4sio.tar.gz.
+// - IRX load order: usbd.irx (BDMAssault), then usbhdfsd.irx (BDMAssault).
+// - Success condition: mass:/ and mass:/POPS/ are accessible.
+// - TODO: verify any slot or adapter placement requirements for MX4SIO in hardware docs.
+int mx4sio_init_and_get_root(char *out_root, size_t out_sz)
+{
+	if (out_root == NULL || out_sz == 0) {
+		return -1;
+	}
+	DPRINTF("MX4SIO init start\n");
+	if (!LoadIrxCheckedBuffer("usbd.irx (BDMAssault)", bdmassault_usbd_irx, size_bdmassault_usbd_irx, NULL, NULL)) {
+		return -1;
+	}
+	if (!LoadIrxCheckedBuffer("usbhdfsd.irx (BDMAssault)", bdmassault_usbhdfsd_irx, size_bdmassault_usbhdfsd_irx, NULL, NULL)) {
+		return -1;
+	}
+	int mass_ret = -1;
+	bool mass_ok = ProbeDir("mass:/", &mass_ret);
+	DPRINTF("MX4SIO probe mass:/ ret=%d ok=%d\n", mass_ret, mass_ok);
+	int pops_ret = -1;
+	bool pops_ok = ProbeDir("mass:/POPS/", &pops_ret);
+	DPRINTF("MX4SIO probe mass:/POPS/ ret=%d ok=%d\n", pops_ret, pops_ok);
+	if (!mass_ok || !pops_ok) {
+		return -1;
+	}
+	snprintf(out_root, out_sz, "mass:/");
+	return 0;
+}
 
 static int lua_getCurrentDirectory(lua_State *L)
 {
@@ -747,6 +818,22 @@ static int lua_resolveAssetType(lua_State *L) {
 	return 1;
 }
 
+static int lua_mx4sio_init(lua_State *L)
+{
+	if (lua_gettop(L) != 0) {
+		return luaL_error(L, "Argument error: System.initMX4SIO() takes no arguments.");
+	}
+	char root[16] = {0};
+	int rc = mx4sio_init_and_get_root(root, sizeof(root));
+	lua_pushboolean(L, rc == 0);
+	if (rc == 0) {
+		lua_pushstring(L, root);
+	} else {
+		lua_pushnil(L);
+	}
+	return 2;
+}
+
 static const luaL_Reg System_functions[] = {
 	{"openFile",                   lua_openfile},
 	{"readFile",                   lua_readfile},
@@ -778,6 +865,7 @@ static const luaL_Reg System_functions[] = {
 	{"getAppDir",                 lua_getAppDir},
 	{"resolveAsset",           lua_resolveAsset},
 	{"resolveAssetType",   lua_resolveAssetType},
+	{"initMX4SIO",             lua_mx4sio_init},
 	{0, 0}
 };
 


### PR DESCRIPTION
### Motivation
- Prevent conflicting device stacks by denying mid-session switches to USB/MMCE/MX4SIO and presenting a two-choice prompt (`Return` / `Exit`) before any driver load or probe is attempted.
- Treat MX4SIO as a mass provider and require that `mass:/` and `mass:/POPS/` are accessible before reporting a successful init.
- Improve observability by logging when a device lock is set, when entry is denied, and which prompt action the user chose.

### Description
- UI changes in `bin/POPSLDR/ui.lua`: added `DEVLOCK` enum, `UI.device_lock` state and helpers `UI.canEnterDevice()` / `UI.setDeviceLock()` plus `device_lock_name()`, and added logging when the lock is set. 
- Modal/flow changes in `bin/POPSLDR/ui.lua`: implemented `UI.Modal.OpenDeviceLock()` using the existing modal mechanism to present the `Return` / `Exit` options and log the chosen action; wired deny checks and logging into the `MainMenu.Play()` handlers for USB/MMCE/MX4SIO and ensured the lock is set only on confirmed page entry while leaving HDD exempt. 
- System changes in `src/luasystem.cpp`: tightened `mx4sio_init_and_get_root()` success condition to require both `mass:/` and `mass:/POPS/` probes to succeed, added diagnostic probe logging, and exposed `System.initMX4SIO()` to Lua. 

### Testing
- No automated CI or build was executed for these changes in this environment, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735136443c832190482ea61737add5)