### PR TITLE
Add AI-assist documentation scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,9 @@ POPSLoader is an open-source launcher for POPStarter, scripted in Lua and based 
 - Basic runtime smoke checks (without hardware):
   - TODO: verify available emulator/scripted checks. Inspect `bin/POPSLDR/system.lua` and the sample Lua scripts for any lightweight runtime validations that can be run on a host or in PCSX2.【F:bin/POPSLDR/system.lua†L1-L200】【F:samples/fractal.lua†L1-L1】
 - Docs updated if runtime layout changes (e.g., `POPSLDR/` layout, POPStarter paths, or device path rules).【F:README.md†L6-L10】【F:etc/boot.lua†L1-L60】
+
+## 8) AI-assist scaffolding (repo-local)
+- Repo map and ownership/boundary notes: `docs/ai/REPO_MAP.md`.【F:docs/ai/REPO_MAP.md†L1-L28】
+- UI rendering flow, scenes, input mapping, and alignment rules: `docs/ai/UI_MAP.md`.【F:docs/ai/UI_MAP.md†L1-L40】
+- Device detection signals, flags, and call sites: `docs/ai/DEVICE_DETECT.md`.【F:docs/ai/DEVICE_DETECT.md†L1-L30】
+- Change-discipline checklist (including regression checklist): `docs/ai/CHANGE_RULES.md`.【F:docs/ai/CHANGE_RULES.md†L1-L20】

--- a/docs/ai/CHANGE_RULES.md
+++ b/docs/ai/CHANGE_RULES.md
@@ -1,0 +1,20 @@
+# Change rules (discipline + regression checklist)
+
+## Snowball discipline (keep changes narrow)
+- Prefer small, isolated diffs and avoid unrelated refactors unless necessary for the task.【F:agents.md†L15-L18】
+- Do not invent behavior; when uncertain, mark **TODO: verify** and cite the file(s) to inspect next.【F:agents.md†L3-L13】
+- Do not change prefix rules (HDD: none, SMB: `SB.`, MASS/MMCE/USB: `XX.`).【F:agents.md†L6-L9】
+- Use existing logging patterns and avoid per-frame UI spam (throttle input/debug logs).【F:docs/DEBUGGING.md†L5-L12】
+
+## Full-file output rule (response formatting)
+- **UNKNOWN (not documented in repo):** The requirement to output full file contents for modified files is not present in repository docs.
+  - Suggested verification command: `rg -n "full file|full-file|full content" -g "*.md"`
+
+## Regression checklist (doc-only changes should still consider runtime behavior)
+1. **Build parity with CI:** CI runs `make clean elfloader all package`; use this as the gold standard when validating build changes.【F:.github/workflows/compilation.yml†L32-L35】
+2. **Runtime layout expectations:** Confirm any file moves or asset layout updates against `docs/RUNTIME_LAYOUT.md` before changing UI/asset resolution logic.【F:docs/RUNTIME_LAYOUT.md†L1-L31】
+3. **Launch/debug logging:** If modifying launch behavior, ensure the minimal `LAUNCH:` log lines are still emitted per `docs/DEBUGGING.md`.【F:docs/DEBUGGING.md†L19-L55】
+
+## UNKNOWNs (not found in repo)
+- **Snowball discipline terminology:** The term "snowball discipline" is not defined in repo docs; interpret it using the existing change-discipline guidance above.
+  - Suggested verification command: `rg -n "snowball" -g "*.md"`

--- a/docs/ai/DEVICE_DETECT.md
+++ b/docs/ai/DEVICE_DETECT.md
@@ -1,0 +1,30 @@
+# Device detection map (signals, flags, call sites)
+
+## Boot-device detection (Lua, early runtime)
+- **Boot path source:** `BOOT_PATH_RAW = System.currentDirectory()` in `system.lua` seeds boot device detection and APP_DIR normalization.【F:bin/POPSLDR/system.lua†L14-L77】
+- **Prefix check + marker files:** `DetectBootDevice()` inspects the device prefix (`mmce`, `mx4sio`, `mass`) and uses marker files (`.boot_mx4sio`, `.boot_usb`) in `APP_DIR` to disambiguate USB vs MX4SIO for `mass:` boots.【F:bin/POPSLDR/system.lua†L119-L141】
+- **Boot locks:** The result sets `UI.boot_device` and `UI.boot_locks` to prevent switching to incompatible device drivers in the same session.【F:bin/POPSLDR/system.lua†L261-L279】【F:bin/POPSLDR/ui.lua†L26-L41】
+
+## MMCE detection
+- **IOP init & readiness flags (C++):** `main.cpp` loads `mmceman` when `fileXio` is ready; on success, it defers probing by setting `mmce_slot0_ready = -1` and `mmce_slot1_ready = -1`, otherwise sets both to `0` (not ready).【F:src/main.cpp†L339-L368】
+- **Lua globals:** `MMCE_SLOT0_READY` / `MMCE_SLOT1_READY` are exported to Lua in `luaSystem_init`.【F:src/luasystem.cpp†L1131-L1135】
+- **Initial slot list:** `system.lua` consumes those globals to seed `PLDR.MMCE.SLOTS` and `PLDR.MMCE.PREFIX` before on-demand probing starts.【F:bin/POPSLDR/system.lua†L223-L235】
+- **On-demand slot probe:** `PLDR.DetectMMCESlot()` checks for `mmce0:/` and `mmce1:/` directories, populates `PLDR.MMCE.SLOTS`, and selects `PLDR.MMCE.PREFIX`.【F:bin/POPSLDR/system.lua†L284-L305】
+- **UI usage:** MMCE slot info is surfaced in the GSMB page and can be cycled with Triangle when multiple slots are present.【F:bin/POPSLDR/ui.lua†L244-L285】
+
+## MX4SIO detection
+- **Lua hint marker:** `DetectMX4SIOPrefixHint()` returns `mx4sio:/` when `.boot_mx4sio` exists in `APP_DIR`, and the hint is stored in `PLDR.MX4SIO.PREFIX_HINT`.【F:bin/POPSLDR/system.lua†L195-L216】
+- **Lua API call:** UI triggers `System.initMX4SIO(hint)` when entering the MX4SIO page and updates `PLDR.MX4SIO.READY` / `PLDR.MX4SIO.ROOT` based on the result.【F:bin/POPSLDR/ui.lua†L410-L428】
+- **C implementation:** `System.initMX4SIO` maps to `mx4sio_init_and_get_root`, which loads `mx4sio_bd.irx` and probes `mx4sio:/` or `mx4sio0:/` for a valid `POPS/` directory (the success condition).【F:src/luasystem.cpp†L125-L176】【F:src/luasystem.cpp†L976-L990】【F:src/luasystem.cpp†L1026-L1029】
+
+## USB mass readiness
+- **Preflight probe:** `main.cpp` loops on `stat("mass:/")` with retries to wait for USB readiness before booting Lua.【F:src/main.cpp†L396-L408】
+
+## SMB networking
+- **SMB Lua bindings exist** (`src/luaSMB.cpp`), but **the UI routes the "SMB" page to MMCE behavior** (GSMB scene). There is no explicit SMB device detection in the UI code path.
+  - Evidence for GSMB → MMCE behavior: GSMB scenes call `PLDR.GetMMCESlots()` and use MMCE prefixes.【F:bin/POPSLDR/ui.lua†L244-L401】
+  - SMB binding entrypoint: `src/luaSMB.cpp` defines SMB login logic and uses the `smb:` device path.【F:src/luaSMB.cpp†L1-L65】
+
+## UNKNOWNs (not found in repo)
+- **SMB device detection flow:** No UI-side logic explicitly detects SMB availability; if a separate SMB discovery path exists, it is UNKNOWN.
+  - Suggested command: `rg -n "SMB|smb" bin/POPSLDR src`

--- a/docs/ai/REPO_MAP.md
+++ b/docs/ai/REPO_MAP.md
@@ -1,0 +1,28 @@
+# Repo map (POPSLoader)
+
+## Project identity (from repo)
+- POPSLoader is a Lua-scripted launcher built on the Enceladus runtime and packaged as `POPSLOADER.ELF` with scripts, textures, and modules in this repo.【F:README.md†L5-L8】
+
+## Entrypoints and boot chain
+- **EE entrypoint:** `main()` in `src/main.cpp` initializes IOP modules, sets the boot/app paths, then runs the embedded Lua boot script in a loop via `runScript(bootString, true)`.【F:src/main.cpp†L321-L437】
+- **Lua boot:** `etc/boot.lua` sets the Lua `package.path`, initializes fonts, and loads `system.lua` via `System.resolveAsset` + `RunScript`.【F:etc/boot.lua†L9-L133】
+- **Lua runtime:** `bin/POPSLDR/system.lua` loads UI modules (`ui.lua`, `images.lua`) and drives the main UI loop (`UI.WelcomeDraw.Play()` + `while true` scene dispatch).【F:bin/POPSLDR/system.lua†L241-L283】【F:bin/POPSLDR/system.lua†L1298-L1319】
+
+## UI stack (Lua)
+- **Scene/controller layer:** `bin/POPSLDR/ui.lua` defines `UI.SCENES`, menu logic, input handling, and per-scene render/interaction functions (main menu, profile selection, game list, credits).【F:bin/POPSLDR/ui.lua†L11-L603】
+- **UI assets:** `bin/POPSLDR/images.lua` enumerates UI image assets and lazy-loads them via `Graphics.loadImage` using `System.resolveAssetType` fallback logic.【F:bin/POPSLDR/images.lua†L10-L65】
+
+## Native runtime + Lua bindings
+- **System/Lua bindings:** `src/luasystem.cpp` registers the `System` table and global flags like `MMCE_SLOT0_READY` / `MMCE_SLOT1_READY` for Lua-side device detection and asset resolution.【F:src/luasystem.cpp†L1104-L1135】
+- **Graphics/Lua bindings:** `src/luagraphics.cpp` exposes `Font.ftPrint` (alignment parameter + width/height) that calls `fntRenderString`, forming the basis of UI text layout.【F:src/luagraphics.cpp†L114-L127】
+- **Font alignment rules:** `src/fntsys.cpp` defines alignment bitmasks (`ALIGN_HCENTER`, `ALIGN_VCENTER`, etc.) and applies them in `fntRenderString`.【F:src/fntsys.cpp†L102-L109】【F:src/fntsys.cpp†L603-L623】
+
+## Runtime layout & asset boundaries
+- **Runtime layout rules:** `docs/RUNTIME_LAYOUT.md` is the canonical reference for asset layout and search order (flat layout first, legacy fallbacks).【F:docs/RUNTIME_LAYOUT.md†L1-L31】
+- **Lua search path:** `etc/boot.lua` defines the Lua search order (APP_DIR first, legacy `POPSLDR/` fallback).【F:etc/boot.lua†L9-L11】
+
+## Ownership/boundaries (what to touch for what)
+- **`src/` (C/C++ runtime):** Bootstraps EE, loads IOP modules, provides Lua bindings, graphics/font subsystems, and device probing logic. Changes here affect the runtime and system APIs used by Lua.【F:src/main.cpp†L321-L437】【F:src/luasystem.cpp†L1104-L1135】【F:src/luagraphics.cpp†L114-L127】
+- **`etc/` (embedded boot Lua):** Controls Lua boot sequencing, search paths, and font initialization. Changes here affect bootstrap and asset resolution order.【F:etc/boot.lua†L9-L133】
+- **`bin/POPSLDR/` (Lua UI + launch logic):** UI scenes, input mapping, asset lookups, and game launch orchestration. Changes here affect user-visible behavior and launch flows.【F:bin/POPSLDR/system.lua†L14-L349】【F:bin/POPSLDR/ui.lua†L11-L603】
+- **`docs/` (documentation):** Canonical docs for runtime layout, launch behavior, and debugging guidance. Updates here do not change runtime behavior.【F:README.md†L13-L20】【F:docs/RUNTIME_LAYOUT.md†L1-L31】

--- a/docs/ai/UI_MAP.md
+++ b/docs/ai/UI_MAP.md
@@ -1,0 +1,40 @@
+# UI map (rendering flow, scenes, input, alignment)
+
+## Rendering flow (boot → UI loop)
+1. **EE entrypoint** runs the embedded Lua boot script via `runScript(bootString, true)`.【F:src/main.cpp†L321-L437】
+2. **Lua boot** (`etc/boot.lua`) sets `package.path`, initializes fonts, and loads `system.lua` via `System.resolveAsset` + `RunScript`.【F:etc/boot.lua†L9-L133】
+3. **Lua runtime** (`bin/POPSLDR/system.lua`) loads `ui.lua` and `images.lua`, runs the welcome splash (`UI.WelcomeDraw.Play()`), then enters the main scene loop that calls per-scene `Play()` functions and `UI.flip()` each frame.【F:bin/POPSLDR/system.lua†L241-L283】【F:bin/POPSLDR/system.lua†L1298-L1319】
+
+## Scenes/pages
+- **Scene table:** `UI.SCENES = {GUSB, GSMB, GMX4SIO, GHDD, MMAIN, MPROFILE, CREDITS}` in `ui.lua`.【F:bin/POPSLDR/ui.lua†L11-L15】
+- **Scene dispatch:** In the main loop, `MMAIN` → main menu, `MPROFILE` → profile picker, `<= GHDD` → game list, `CREDITS` → credits screen.【F:bin/POPSLDR/system.lua†L1304-L1314】
+- **Main menu options:** UI presents `USB`, `MMCE`, `MX4SIO`, `HDD` and routes to the corresponding device pages and game list population logic.【F:bin/POPSLDR/ui.lua†L330-L428】
+
+## Input mapping (Pads → UI events)
+- **Event mapping:** `Pad.Listen()` translates pad state into events:
+  - `PAD_CROSS` → `CONFIRM`
+  - `PAD_CIRCLE` → `BACK`
+  - `PAD_TRIANGLE` → `EXIT`
+  - `PAD_START` → `START`
+  - `PAD_SELECT` → `SELECT`
+  - D-pad → `NAV_UP/DOWN/LEFT/RIGHT` with neutral-gate handling.
+  【F:bin/POPSLDR/ui.lua†L456-L552】
+- **Action throttling:** `MIN_ACTION_MS` gates repeated action inputs to prevent rapid repeats.【F:bin/POPSLDR/ui.lua†L67-L69】【F:bin/POPSLDR/ui.lua†L518-L523】
+- **Global exit handling:** Triangle triggers the exit modal unless a modal or launch is active.【F:bin/POPSLDR/ui.lua†L221-L233】【F:bin/POPSLDR/ui.lua†L135-L176】
+
+## Layout and alignment rules
+- **Screen constants:** Base UI resolution and midpoints come from `UI.SCR` (`X=702`, `Y=480`, `X_MID`, `Y_MID`, `_480p`).【F:bin/POPSLDR/ui.lua†L59-L66】
+- **Font alignment:** `Font.ftPrint` takes an alignment bitmask that is passed to `fntRenderString`. Alignment flags include `ALIGN_HCENTER` and `ALIGN_VCENTER`, applied during render to shift text positioning. (UI commonly passes `8` for horizontal centering.)【F:src/luagraphics.cpp†L114-L127】【F:src/fntsys.cpp†L102-L109】【F:src/fntsys.cpp†L603-L623】【F:bin/POPSLDR/ui.lua†L109-L112】
+- **Font initialization:** Built-in fonts are loaded and sized during boot in `etc/boot.lua`.【F:etc/boot.lua†L74-L80】
+
+## UI assets (images)
+- **Image registry:** `images.lua` lists UI image files (USB/MMCE/MX4SIO/HDD icons, button glyphs) and lazily loads them via `Graphics.loadImage` with `System.resolveAssetType` fallback logic.【F:bin/POPSLDR/images.lua†L10-L65】
+
+## UI behaviors & pages (high-level)
+- **Exit modal:** `UI.Modal.OpenExit()` shows a confirmation box and `System.exitToBrowser()` is called on confirm.【F:bin/POPSLDR/ui.lua†L135-L176】
+- **Game list page:** `UI.GameList.Play()` renders the list, handles navigation, and calls `PLDR.RunPOPStarterGame` on confirm when a game is selected.【F:bin/POPSLDR/ui.lua†L242-L303】
+- **Main menu routing:** Selecting a device option triggers device detection and game list population (`PLDR.GetPS1GameLists` for USB/MMCE/MX4SIO; HDD module init + list build for HDD).【F:bin/POPSLDR/ui.lua†L365-L451】
+
+## UNKNOWNs (not found in repo)
+- **Exact meaning of alignment constants at the Lua call sites** beyond the `ALIGN_*` bitmask definitions is not described in docs; to confirm usage, inspect `fntRenderString` and call sites.
+  - Suggested command: `rg -n "ftPrint" bin/POPSLDR src` (call sites) and `rg -n "ALIGN_" src/fntsys.cpp` (definitions).


### PR DESCRIPTION
### Motivation
- Provide machine- and human-readable scaffolding that documents repo layout, UI flow, device detection, and change discipline to reduce guesswork when making changes. 
- Centralize AI/human guidance so tools and contributors can locate authoritative call sites and invariants without altering runtime behavior.

### Description
- Add `docs/ai/REPO_MAP.md` describing entrypoints and ownership and referencing `src/main.cpp`, `etc/boot.lua`, and `bin/POPSLDR/system.lua`. 
- Add `docs/ai/UI_MAP.md` documenting rendering flow, scenes, input mapping, and alignment rules and referencing `bin/POPSLDR/ui.lua`, `bin/POPSLDR/images.lua`, and `src/fntsys.cpp`. 
- Add `docs/ai/DEVICE_DETECT.md` mapping device-detection signals and flags and citing `src/main.cpp`, `src/luasystem.cpp`, and `bin/POPSLDR/system.lua`. 
- Add `docs/ai/CHANGE_RULES.md` with change-discipline guidance and a small regression checklist, and update `AGENTS.md` to link the new `docs/ai/*` files.

### Testing
- No automated tests were run because this is a documentation-only change. 
- Recommend running the CI build target `make clean elfloader all package` (as used by `.github/workflows/compilation.yml`) for downstream validation if any code changes are later introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697788368c2c8321990ea3175c7ec017)