### PR TITLE
Harden UI asset loading and safe-area layout

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -51,8 +51,11 @@ end
 IMG_SOURCES["MMCE"] = "MMCE.png"
 IMG_SOURCES["MX4SIO"] = "MX4SIO.png"
 
+local IMG_FAILED = {}
+
 IMG = setmetatable({}, {
   __index = function (tbl, key)
+    if IMG_FAILED[key] then return nil end
     local source = IMG_SOURCES[key]
     if source == nil then return nil end
     if BOOT_PROF and BOOT_PROF.stamp and not BOOT_PROF.textures_ready then
@@ -61,7 +64,26 @@ IMG = setmetatable({}, {
     end
     local path = ResolveImage(source)
     local img = Graphics.loadImage(path)
-    if img == nil then error("Could not load '"..path.."'") end
+    if img == nil then
+      LOGF("Image load failed: %s", path)
+      IMG_FAILED[key] = true
+      if key ~= "MISSING" then
+        local missing_source = IMG_SOURCES["MISSING"]
+        if missing_source ~= nil and not IMG_FAILED["MISSING"] then
+          local missing_path = ResolveImage(missing_source)
+          local missing_img = Graphics.loadImage(missing_path)
+          if missing_img ~= nil then
+            Graphics.setImageFilters(missing_img, LINEAR)
+            rawset(tbl, "MISSING", missing_img)
+            rawset(tbl, key, missing_img)
+            return missing_img
+          end
+          LOGF("Image load failed: %s", missing_path)
+          IMG_FAILED["MISSING"] = true
+        end
+      end
+      return nil
+    end
     Graphics.setImageFilters(img, LINEAR)
     rawset(tbl, key, img)
     return img

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -156,6 +156,7 @@ UI = {
       local safe_h = UI.SCR.Y - safe.T - safe.B
       UI.LAYOUT.SAFE_W = safe_w
       UI.LAYOUT.SAFE_H = safe_h
+      UI.LAYOUT.SAFE_X_MID = Round(safe.L + (safe_w / 2))
       UI.LAYOUT.TITLE_Y = Round(safe.T + 6)
       UI.LAYOUT.STATUS_Y = Round(UI.LAYOUT.TITLE_Y + 20)
       UI.LAYOUT.ICON_ROW_Y = Round(UI.SCR.Y_MID - 40)
@@ -243,16 +244,41 @@ UI = {
         end
         local labelY = UI.LAYOUT.FOOTER_LABEL_Y
         -- Centered/tighter spacing (avoids running off-screen on real CRT overscan).
-	        local spacing
-	        if count <= 1 then
-	          spacing = 0
-	        else
-	          local max_spacing = math.floor(UI.LAYOUT.SAFE_W / (count + 0.5))
-	          spacing = math.min(140, max_spacing)
-	          if spacing < 96 then spacing = 96 end
-	        end
-	        local total_w = spacing * (count - 1)
-	        local start_x = Round(UI.SCR.X_MID - (total_w / 2))
+        local max_w = 0
+        for i = 1, count do
+          local key = entries[i]
+          local icon = IMG[key]
+          if icon ~= nil then
+            local w = Graphics.getImageWidth(icon)
+            if w ~= nil and w > max_w then
+              max_w = w
+            end
+          end
+        end
+        local max_half_w = max_w / 2
+        local spacing
+        if count <= 1 then
+          spacing = 0
+        else
+          local max_spacing = math.floor(UI.LAYOUT.SAFE_W / (count + 0.5))
+          spacing = math.min(140, max_spacing)
+          if spacing < 96 then spacing = 96 end
+        end
+        local safe_left = (safe and safe.L) or 0
+        local safe_right = UI.SCR.X - ((safe and safe.R) or 0)
+        local available = (safe_right - max_half_w) - (safe_left + max_half_w)
+        if available < 0 then available = 0 end
+        if count > 1 then
+          local max_fit_spacing = math.floor(available / (count - 1))
+          if spacing > max_fit_spacing then spacing = max_fit_spacing end
+        end
+        if spacing < 0 then spacing = 0 end
+        local total_w = spacing * (count - 1)
+        local safe_center = UI.LAYOUT.SAFE_X_MID or UI.SCR.X_MID
+        local start_x = Round((safe_left + max_half_w) + ((available - total_w) / 2))
+        if count <= 1 then
+          start_x = safe_center
+        end
         for i = 1, count do
           local key = entries[i]
           local icon = IMG[key]
@@ -376,6 +402,7 @@ if found == nil then return end
           boot_sound_hold_frames = math.floor((sec * 60) + 0.5)
         end
         local function DrawSplashCover(img, screen_w, screen_h, alpha)
+          if img == nil then return end
           local img_w = Graphics.getImageWidth(img)
           local img_h = Graphics.getImageHeight(img)
           local scale = 1
@@ -860,10 +887,10 @@ if found == nil then return end
             carousel.allowOptWrite = false
           end
         end
-        local center_x = UI.SCR.X_MID
+        local center_x = layout.SAFE_X_MID or UI.SCR.X_MID
         local usable_top = layout.STATUS_Y + 24
         local usable_bottom = layout.FOOTER_ICON_Y - 24
-	        local center_y = Round((usable_top + usable_bottom) / 2) + 10
+        local center_y = Round((usable_top + usable_bottom) / 2)
 	        if layout.CAROUSEL_Y_OFFSET ~= nil then
 	          center_y = center_y + layout.CAROUSEL_Y_OFFSET
 	        end
@@ -880,6 +907,7 @@ if found == nil then return end
         local function DrawIcon(index, x, y, scale, color)
           local key = icon_keys[index]
           local icon = ResolveIcon(key)
+          if icon == nil then return end
           local icon_w = Round(Graphics.getImageWidth(icon) * scale)
           local icon_h = Round(Graphics.getImageHeight(icon) * scale)
           local pos_x = Round(x - (icon_w / 2))
@@ -887,7 +915,10 @@ if found == nil then return end
           Graphics.drawScaleImage(icon, pos_x, pos_y, icon_w, icon_h, color)
         end
         local first_icon = ResolveIcon(icon_keys[1] or "MISSING")
-        local base_icon_w = Graphics.getImageWidth(first_icon)
+        local base_icon_w = 0
+        if first_icon ~= nil then
+          base_icon_w = Graphics.getImageWidth(first_icon)
+        end
         local slot_margin = 0
         local safe_w = (UI.SCR.X - UI.LAYOUT.SAFE.L - UI.LAYOUT.SAFE.R)
         -- Target: show 5 icons (-2..2) without clipping on overscan-heavy TVs.


### PR DESCRIPTION
### Motivation
- Prevent boot-time crashes and black-screen dead-ends caused by missing/corrupt UI images by making image loading non-fatal and providing a fallback path.【bin/POPSLDR/images.lua】
- Fix footer/carousel placement so the button bar never clips on the right edge and to remove phantom left/bottom margins by respecting computed safe-area bounds.【bin/POPSLDR/ui.lua】
- Keep changes minimal and defensive to avoid altering scene flow or removing existing fallbacks; surface unknowns for hardware verification. (TODO: verify overscan on real CRT hardware/emulator.)

### Description
- images.lua: Add `IMG_FAILED` cache to avoid repeated failed loads and convert the lazy `IMG` loader to return the `MISSING` placeholder instead of calling `error()` when an image cannot be loaded, and log failures via `LOGF` so missing assets are non-fatal; preserves existing lazy caching behavior.【bin/POPSLDR/images.lua L46-L90】
- ui.lua: Add `UI.LAYOUT.SAFE_X_MID` (computed in `RecalcLayout`) and use safe-area-derived centers for carousel and footer positioning to ensure centering respects left/right safe margins rather than always using screen midpoint.【bin/POPSLDR/ui.lua L149-L160】【bin/POPSLDR/ui.lua L890-L896】
- ui.lua: Harden splash draw path by guarding `DrawSplashCover` against a nil image so splash flow continues if `IMG.PSL` is missing.【bin/POPSLDR/ui.lua L404-L419】
- ui.lua: Rework footer `Draw` spacing calculation to measure icon widths and clamp spacing so icons and labels are placed within safe left/right bounds (prevents right-side clipping and phantom margins); compute a start_x based on safe-left + available area rather than raw screen center.【bin/POPSLDR/ui.lua L246-L281】
- ui.lua: Add guards in carousel drawing (`DrawIcon` early-return on nil image, safer `base_icon_w` initialization, remove the extra +10 vertical offset) to avoid per-frame errors when images are unavailable and to stabilize vertical centering.【bin/POPSLDR/ui.lua L907-L921】【bin/POPSLDR/ui.lua L890-L894】

### Testing
- Automated tests: none executed for runtime graphics (no hardware/renderer test run).  Local static validation was performed by opening and inspecting the modified files and ensuring Lua syntax context matches surrounding code. (No `make`/CI build was run in this change.)
- Recommendation (required for merge): run CI build target `make clean elfloader all package` to validate compilation/packaging and perform manual/emulator verification of overscan behavior and splash fallback (TODO: verify on real hardware or PCSX2).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cd6bd8b48321b9cec470b134f48e)