### PR TITLE
Align footer legends with global input rules

### DIFF
--- a/bin/POPSLDR/pops_profiles.lua
+++ b/bin/POPSLDR/pops_profiles.lua
@@ -7,6 +7,7 @@
 --]]
 LOG("Registering POPStarter profiles...")
 local DEFAULT_PROFILE = 1 -- change this for a different default profile. default package points to local popstarter path
+PLDR.DEFAULT_PROFILE = DEFAULT_PROFILE
 -- to register an ELF that is stored on the same folder than POPSLOADER, please do it this way:
 -- System.currentDirectory().."/POPSTARTER.ELF"
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -224,6 +224,56 @@ UI = {
       order_with_r2 = {"triangle", "circle", "cross", "square", "R2"};
       order_with_start = {"triangle", "circle", "cross", "start"};
       order_with_start_r2 = {"triangle", "circle", "cross", "square", "start", "R2"};
+      labels = {
+        triangle = "Credits",
+        circle_main = "Exit",
+        circle_other = "Back",
+        start_profiles = "Profiles",
+        start_reset = "Reset Defaults",
+        cross_confirm = "Confirm",
+        cross_enter = "Enter",
+        cross_select = "Select",
+        cross_launch = "Launch"
+      };
+      legend_cache = {};
+      LegendKey = function (order_id, circle_label, cross_label, start_label, square_label, r2_label)
+        return table.concat({
+          tostring(order_id or ""),
+          tostring(circle_label or ""),
+          tostring(cross_label or ""),
+          tostring(start_label or ""),
+          tostring(square_label or ""),
+          tostring(r2_label or "")
+        }, "|")
+      end;
+      ResolveLegend = function (opts)
+        local order = opts.order or UI.Footer.order
+        local order_id = opts.order_id or "default"
+        local circle_label = opts.circle or UI.Footer.labels.circle_other
+        local cross_label = opts.cross or UI.Footer.labels.cross_confirm
+        local start_label = opts.start or UI.Footer.labels.start_profiles
+        local square_label = opts.square
+        local r2_label = opts.R2
+        local key = UI.Footer.LegendKey(order_id, circle_label, cross_label, start_label, square_label, r2_label)
+        local cached = UI.Footer.legend_cache[key]
+        if cached ~= nil then
+          return cached.labels, cached.order
+        end
+        local labels = {
+          triangle = UI.Footer.labels.triangle,
+          circle = circle_label,
+          cross = cross_label,
+          start = start_label
+        }
+        if square_label ~= nil then
+          labels.square = square_label
+        end
+        if r2_label ~= nil then
+          labels.R2 = r2_label
+        end
+        UI.Footer.legend_cache[key] = {labels = labels, order = order}
+        return labels, order
+      end;
       Draw = function (labels, order)
         local safe = UI.LAYOUT.SAFE
         local entries = order or UI.Footer.order
@@ -625,9 +675,13 @@ if found == nil then return end
         UI.Modal.HandleInput()
         return true
       end
+      if UI.LAUNCHING then return false end
+      if UI.Pad.Events.START and UI.CURSCENE ~= UI.SCENES.MPROFILE then
+        UI.SceneChange(UI.SCENES.MPROFILE)
+        return true
+      end
       if allow_exit == nil then allow_exit = true end
       if not allow_exit then return false end
-      if UI.LAUNCHING then return false end
       if UI.Pad.Events.EXIT then
         UI.Modal.OpenExit()
         return true
@@ -663,15 +717,18 @@ if found == nil then return end
         if UI.HandleGlobalInput(false) then return end
           if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
           if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
-          UI.Footer.Draw({
-            triangle = "Credits",
-            circle = "Back",
-            cross = "Confirm",
+          if UI.Pad.Events.CONFIRM then
+            UI.Notif_queue.add("Not implemented yet")
+          end
+          local labels, order = UI.Footer.ResolveLegend({
+            order = UI.Footer.order_with_start_r2,
+            order_id = "start_r2",
+            circle = UI.Footer.labels.circle_other,
+            cross = UI.Footer.labels.cross_confirm,
             square = "Cover Art",
-            start = "Settings",
-            R2 = ""
-
-          }, UI.Footer.order_with_start_r2)
+            start = UI.Footer.labels.start_profiles
+          })
+          UI.Footer.Draw(labels, order)
           return
         end
         local ammount = #PLDR.GAMES
@@ -726,8 +783,10 @@ if found == nil then return end
             PLDR.ApplyPopstarterPack("MX4SIO")
           end
         end
-        if UI.Pad.Events.CONFIRM and ammount > 0 then
-          if not doesFileExist(PLDR.POPSTARTER_PATH) then
+        if UI.Pad.Events.CONFIRM then
+          if ammount <= 0 then
+            UI.Notif_queue.add("No games found")
+          elseif not doesFileExist(PLDR.POPSTARTER_PATH) then
             UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..PLDR.POPSTARTER_PATH)
           else
             if UI.CURSCENE ~= UI.SCENES.GHDD then -- only check if game can be found on USB and SMB
@@ -738,28 +797,30 @@ if found == nil then return end
             PLDR.RunPOPStarterGame(PLDR.GAMEPATH, PLDR.GAMES[UI.GameList.CURR])
           end
         end
-        local footer_labels = {
-          triangle = "Credits",
-          circle = "Back",
-          cross = "Confirm",
-          square = "Cover Art",
-          start = "Settings"
-        }
-        local footer_order = UI.Footer.order_with_start_r2
+        local r2_label = nil
         if UI.CURSCENE == UI.SCENES.GUSBFAT then
-          footer_labels.R2 = "Reset POPSTARTER"
-          footer_order = UI.Footer.order_with_start_r2
+          r2_label = "Reset POPSTARTER"
         elseif UI.CURSCENE == UI.SCENES.GUSBEXFAT then
-          footer_labels.R2 = "Install USBEXFAT pack"
-          footer_order = UI.Footer.order_with_start_r2
+          r2_label = "Install USBEXFAT pack"
         elseif UI.CURSCENE == UI.SCENES.GSMB and UI.device_lock == DEVLOCK.MMCE then
-          footer_labels.R2 = "Install MMCE pack"
-          footer_order = UI.Footer.order_with_start_r2
+          r2_label = "Install MMCE pack"
         elseif UI.CURSCENE == UI.SCENES.GMX4SIO then
-          footer_labels.R2 = "Install MX4SIO pack"
-          footer_order = UI.Footer.order_with_start_r2
+          r2_label = "Install MX4SIO pack"
         end
-        UI.Footer.Draw(footer_labels, footer_order)
+        local cross_label = UI.Footer.labels.cross_launch
+        if ammount <= 0 then
+          cross_label = UI.Footer.labels.cross_confirm
+        end
+        local labels, order = UI.Footer.ResolveLegend({
+          order = UI.Footer.order_with_start_r2,
+          order_id = "start_r2",
+          circle = UI.Footer.labels.circle_other,
+          cross = cross_label,
+          square = "Cover Art",
+          start = UI.Footer.labels.start_profiles,
+          R2 = r2_label
+        })
+        UI.Footer.Draw(labels, order)
       end;
     };
     ProfileQuery = {
@@ -778,6 +839,15 @@ if found == nil then return end
         if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
         if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) end
         if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
+        if UI.Pad.Events.START then
+          local default_profile = tonumber(PLDR.DEFAULT_PROFILE) or 1
+          UI.ProfileQuery.curopt = CLAMP(default_profile, 1, profcnt)
+          local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
+          if profile ~= nil then
+            PLDR.POPSTARTER_PATH = profile.ELF
+          end
+          UI.Notif_queue.add("Profile defaults restored")
+        end
         if UI.Pad.Events.CONFIRM then
           if not doesFileExist(PLDR.PROFILES[UI.ProfileQuery.curopt].ELF) then
             UI.Notif_queue.add("POPStarter ELF missing")
@@ -786,15 +856,15 @@ if found == nil then return end
             UI.SceneChange(UI.SCENES.MMAIN)
           end
         end
-        UI.Footer.Draw({
-          triangle = "Credits",
-          circle = "Back",
-          cross = "Confirm",
+        local labels, order = UI.Footer.ResolveLegend({
+          order = UI.Footer.order_with_start_r2,
+          order_id = "start_r2",
+          circle = UI.Footer.labels.circle_other,
+          cross = UI.Footer.labels.cross_select,
           square = "Cover Art",
-          start = "Settings",
-            R2 = ""
-
-        }, UI.Footer.order_with_start_r2)
+          start = UI.Footer.labels.start_reset
+        })
+        UI.Footer.Draw(labels, order)
       end;
     };
     MainMenu = {
@@ -956,13 +1026,14 @@ if found == nil then return end
           DrawIcon(idx, x, y, tint)
         end
         Font.ftPrint(UI.FONT.LABEL, Round(center_label_x), center_label_y, 8, UI.SCR.X, 16, UI.MainMenu.opts[center_label_idx], UI.COLORS.TEXT_PRIMARY)
-        UI.Footer.Draw({
-          triangle = "Credits",
-          circle = "Exit",
-          cross = "Select",
-          start = "Settings"
-
-        }, UI.Footer.order_with_start)
+        local labels, order = UI.Footer.ResolveLegend({
+          order = UI.Footer.order_with_start,
+          order_id = "start",
+          circle = UI.Footer.labels.circle_main,
+          cross = UI.Footer.labels.cross_select,
+          start = UI.Footer.labels.start_profiles
+        })
+        UI.Footer.Draw(labels, order)
         if UI.MainMenu._draw_only then return end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
@@ -982,7 +1053,6 @@ if found == nil then return end
             carousel.slide = 0
           end
         end
-        if UI.Pad.Events.START then UI.SceneChange(UI.SCENES.MPROFILE) end
         if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
         if UI.Pad.Events.BACK then UI.Modal.OpenExit() end
         if UI.Pad.Events.CONFIRM then
@@ -1319,15 +1389,15 @@ if you bought it you\'ve been scammed
           UI.Credits.INCR = -1
         end
 
-        UI.Footer.Draw({
-          triangle = "Credits",
-          circle = "Back",
-          cross = "Confirm",
+        local labels, order = UI.Footer.ResolveLegend({
+          order = UI.Footer.order_with_start_r2,
+          order_id = "start_r2",
+          circle = UI.Footer.labels.circle_other,
+          cross = UI.Footer.labels.cross_confirm,
           square = "Cover Art",
-          start = "Settings",
-            R2 = ""
-
-        }, UI.Footer.order_with_start_r2)
+          start = UI.Footer.labels.start_profiles
+        })
+        UI.Footer.Draw(labels, order)
       end
     };
   }


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth for footer button labels and stabilize legend ordering so labels are truthful and consistent across scenes and popups.
- Enforce the global input rules: `Start` opens Profiles (and `Start` on Profiles resets to defaults), `Triangle` shows Credits, `O` is Back/Exit depending on context, and `X` maps to Confirm/Enter/Select/Launch per scene.
- Avoid per-frame string work by caching resolved legends and keep changes limited to labels/legend resolution without changing exit/dialog/transition logic.

### Description
- Centralized footer label definitions and resolution in `UI.Footer`: added `labels`, `legend_cache`, `LegendKey`, and `ResolveLegend` to produce a stable `(labels, order)` pair and cache it for reuse, minimizing runtime string operations. (file: `bin/POPSLDR/ui.lua`)
- Replaced ad-hoc per-scene footer label tables with calls to `UI.Footer.ResolveLegend(...)` across Main Menu, Game List, Profiles, Credits, and placeholder pages so the same mapping and ordering is used everywhere. (file: `bin/POPSLDR/ui.lua`)
- Implemented global `Start` handling to open the Profiles scene (`UI.SceneChange(UI.SCENES.MPROFILE)`) when pressed outside the Profiles page, and implemented `Start` on the Profiles page to restore the default profile and set `PLDR.POPSTARTER_PATH` accordingly, adding a notification on restore. (file: `bin/POPSLDR/ui.lua`)
- Exposed the profile default index as `PLDR.DEFAULT_PROFILE` to allow the Profiles page to reset to the packaged default. (file: `bin/POPSLDR/pops_profiles.lua`)
- Improved Game List confirm logic to show a helpful notification when no games are present and selected `cross` label selection now reflects `Launch` vs `Confirm` depending on context; added a small placeholder `Not implemented yet` notice for unimplemented pages. (file: `bin/POPSLDR/ui.lua`)

### Testing
- No automated tests were executed for this change set; changes were validated via local static inspection of the modified Lua files and targeted searches to ensure all footer draws were migrated to the new resolver and that `PLDR.DEFAULT_PROFILE` is set and consumed.
- Manual verification on hardware/emulator is TODO: run interactive checks by navigating these pages: `Main Menu`, `Game List` (USB FAT/exFAT, SMB/MMCE, MX4SIO, HDD), `Profiles`, `Credits`, `Exit modal`, and the device-lock modal to confirm legend labels and `Start`/`X`/`O` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979debf2774832196a792dbc38fd964)