### PR TITLE
Smooth carousel icon scroll and UI polish (preload, alpha, labels, credits)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -221,14 +221,14 @@ UI = {
     };
     Footer = {
       order = {"triangle", "circle", "cross", "square"};
-      order_with_r2 = {"triangle", "circle", "cross", "square", "R2"};
+      order_with_r2 = {"triangle", "circle", "cross", "square"};
       order_with_start = {"triangle", "circle", "cross", "start"};
-      order_with_start_r2 = {"triangle", "circle", "cross", "square", "start", "R2"};
+      order_with_start_r2 = {"triangle", "circle", "cross", "square", "start"};
       labels = {
         triangle = "Credits",
         circle_main = "Exit",
         circle_other = "Back",
-        start_profiles = "Profiles",
+        start_profiles = "Settings",
         start_reset = "Reset Defaults",
         cross_confirm = "Confirm",
         cross_enter = "Enter",
@@ -267,9 +267,6 @@ UI = {
         }
         if square_label ~= nil then
           labels.square = square_label
-        end
-        if r2_label ~= nil then
-          labels.R2 = r2_label
         end
         UI.Footer.legend_cache[key] = {labels = labels, order = order}
         return labels, order
@@ -772,17 +769,6 @@ if found == nil then return end
         if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
         if UI.Pad.Events.NAV_UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
         if UI.Pad.Events.NAV_LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
-        if UI.Pad.Events.R2 then
-          if UI.CURSCENE == UI.SCENES.GUSBFAT then
-            PLDR.ResetPopstarterPack()
-          elseif UI.CURSCENE == UI.SCENES.GUSBEXFAT then
-            PLDR.ApplyPopstarterPack("USBEXFAT")
-          elseif UI.CURSCENE == UI.SCENES.GSMB and UI.device_lock == DEVLOCK.MMCE then
-            PLDR.ApplyPopstarterPack("MMCE")
-          elseif UI.CURSCENE == UI.SCENES.GMX4SIO then
-            PLDR.ApplyPopstarterPack("MX4SIO")
-          end
-        end
         if UI.Pad.Events.CONFIRM then
           if ammount <= 0 then
             UI.Notif_queue.add("No games found")
@@ -797,16 +783,6 @@ if found == nil then return end
             PLDR.RunPOPStarterGame(PLDR.GAMEPATH, PLDR.GAMES[UI.GameList.CURR])
           end
         end
-        local r2_label = nil
-        if UI.CURSCENE == UI.SCENES.GUSBFAT then
-          r2_label = "Reset POPSTARTER"
-        elseif UI.CURSCENE == UI.SCENES.GUSBEXFAT then
-          r2_label = "Install USBEXFAT pack"
-        elseif UI.CURSCENE == UI.SCENES.GSMB and UI.device_lock == DEVLOCK.MMCE then
-          r2_label = "Install MMCE pack"
-        elseif UI.CURSCENE == UI.SCENES.GMX4SIO then
-          r2_label = "Install MX4SIO pack"
-        end
         local cross_label = UI.Footer.labels.cross_launch
         if ammount <= 0 then
           cross_label = UI.Footer.labels.cross_confirm
@@ -817,8 +793,7 @@ if found == nil then return end
           circle = UI.Footer.labels.circle_other,
           cross = cross_label,
           square = "Cover Art",
-          start = UI.Footer.labels.start_profiles,
-          R2 = r2_label
+          start = UI.Footer.labels.start_profiles
         })
         UI.Footer.Draw(labels, order)
       end;
@@ -891,17 +866,13 @@ if found == nil then return end
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
-        Font.ftPrintMultiLineAligned(UI.FONT.TITLE, UI.SCR.X_MID, layout.TITLE_Y, 16, UI.SCR.X, 32, "POPSLoader by Matias Israelson\nGUI for POPStarter and BDMAssault", UI.COLORS.TEXT_PRIMARY)
+        Font.ftPrintMultiLineAligned(UI.FONT.TITLE, UI.SCR.X_MID, layout.TITLE_Y, 16, UI.SCR.X, 32, "POPSLoader\nby Matias Israelson\nGUI for POPStarter and BDMAssault", UI.COLORS.TEXT_PRIMARY)
         local status_y = layout.STATUS_Y + 16
         if UI.boot_device ~= nil and UI.boot_device ~= DEVLOCK.NONE then
           Font.ftPrint(UI.FONT.STATUS, UI.SCR.X_MID, status_y, 8, UI.SCR.X, 16, "Booted from: "..UI.device_lock_name(UI.boot_device), UI.COLORS.TEXT_PRIMARY)
           status_y = status_y + 12
         end
 	        -- Pages are no longer presented as "locked" in the UI.
-        if UI.BUILD_INFO ~= nil and UI.BUILD_INFO.stamp ~= nil then
-          local stamp_y = Round(layout.FOOTER_LABEL_Y - 18)
-          Font.ftPrint(SFONT, layout.SAFE.L, stamp_y, 0, UI.SCR.X, 16, UI.BUILD_INFO.stamp, UI.CCOL.GREY)
-        end
         local icon_map = {
           ["MMCE"] = "MMCE",
           ["MX4SIO"] = "MX4SIO",
@@ -974,6 +945,12 @@ if found == nil then return end
         local function ResolveIcon(key)
           return IMG[key] or IMG["MISSING"]
         end
+        if not UI.MainMenu.icons_ready then
+          for _, key in ipairs(icon_keys) do
+            ResolveIcon(key)
+          end
+          UI.MainMenu.icons_ready = true
+        end
         local function DrawIcon(index, x, y, color)
           local key = icon_keys[index]
           local icon = ResolveIcon(key)
@@ -1001,6 +978,7 @@ if found == nil then return end
         if slot_spacing > max_spacing then slot_spacing = max_spacing end
         local base_sel = carousel.currentIndex
         local slide = carousel.slide or 0
+        local scroll = carousel.currentIndex + (carousel.animActive and slide or 0)
         local center_label_x = center_x
         local center_label_y = Round(center_y + 90)
         local center_label_idx = carousel.animActive and carousel.targetIndex or base_sel
@@ -1009,15 +987,15 @@ if found == nil then return end
         end
         local function SlotAlpha(dist)
           if dist <= 1 then
-            return Round(Lerp(128, 40, dist))
+            return Round(Lerp(128, 19, dist))
           end
           if dist <= 2 then
-            return Round(Lerp(40, 8, dist - 1))
+            return Round(Lerp(19, 6, dist - 1))
           end
-          return 8
+          return 6
         end
         for k = -2, 2 do
-          local idx = WrapIndex(base_sel + k, profcnt)
+          local idx = WrapIndex(math.floor(scroll + k + 0.5), profcnt)
           local x = center_x + slot_spacing * (k - slide)
           local y = center_y
           local dist = math.abs(k - slide)
@@ -1290,82 +1268,10 @@ if found == nil then return end
       end;
     };
     Credits = {
-      Q = 1;
-      INCR = -1;
-      exit_active = false;
-      exit_timer = nil;
-      exit_start = 0;
-      exit_dur_ms = 550;
       Play = function ()
         local layout = UI.LAYOUT
+        local currcol = UI.CCOL.GREY
 
-        -- Crossfade credits -> main menu (no fade-to-black).
-        if UI.Credits.exit_active then
-          if UI.Credits.exit_timer == nil then
-            UI.Credits.exit_timer = Timer.new()
-            UI.Credits.exit_start = Timer.getTime(UI.Credits.exit_timer)
-          end
-          local now = Timer.getTime(UI.Credits.exit_timer)
-          local t = (now - (UI.Credits.exit_start or now)) / (UI.Credits.exit_dur_ms or 1)
-          if t < 0 then t = 0 end
-          if t > 1 then t = 1 end
-          local alpha = Round(128 * (1 - t))
-          local currcol = Color.new(128, 128, 128, alpha)
-
-          -- Draw main menu underlay first.
-          Screen.clear(UI.SCR.BGCOL)
-          if IMG.BGM ~= nil then
-            Graphics.drawScaleImage(IMG.BGM, 0, 0, UI.SCR.X, UI.SCR.Y)
-          elseif IMG.BKG ~= nil then
-            Graphics.drawScaleImage(IMG.BKG, 0, 0, UI.SCR.X, UI.SCR.Y)
-          end
-          if UI.MainMenu ~= nil and UI.MainMenu.DrawOnly ~= nil then
-            UI.MainMenu.DrawOnly()
-          end
-
-          -- Draw credits on top, fading out.
-          Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 20, UI.SCR.X, 40, "POPStarter Loader\n"..tostring(POPSLDR_VER or ""), currcol)
-          Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 20, UI.SCR.X, 40, "Coded By El_isra", currcol)
-          Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 80, 20, UI.SCR.X, UI.SCR.Y, [[
-Based on Enceladus by Daniel santos
-
-Special thanks to:
-krHACKen: for making POPStarter
-uyjulian, fjtrujy, HWC and others for always helping me
-
-This program is free and open source
-if you bought it you\'ve been scammed
-]], currcol)
-
-          -- When done, switch to main menu without using Transition (avoids black fade).
-          if t >= 1 then
-            UI.Credits.exit_active = false
-            UI.Credits.exit_timer = nil
-            UI.Credits.Q = 1
-            UI.Credits.INCR = -1
-            if UI.Transition ~= nil then UI.Transition.allowSceneWrite = true end
-            UI.CURSCENE = UI.SCENES.MMAIN
-            if UI.Transition ~= nil then
-              UI.Transition.allowSceneWrite = false
-              UI.Transition.active = false
-              UI.Transition.target = nil
-            end
-          end
-          return
-        end
-
-        if UI.Credits.Q == 0 then
-          -- Start crossfade instead of Transition-to-black.
-          UI.Credits.exit_active = true
-          UI.Credits.exit_timer = nil
-          UI.Credits.exit_start = 0
-          UI.Credits.Q = 1
-          UI.Credits.INCR = -1
-          return
-        end
-
-        local currcol = Color.new(128, 128, 128, UI.Credits.Q)
-        UI.Credits.Q = CLAMP(UI.Credits.Q-UI.Credits.INCR, 0, 128)
         Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 20, UI.SCR.X, 40, "POPStarter Loader\n"..tostring(POPSLDR_VER or ""), currcol)
         Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 20, UI.SCR.X, 40, "Coded By El_isra", currcol)
         Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 80, 20, UI.SCR.X, UI.SCR.Y, [[
@@ -1378,15 +1284,15 @@ uyjulian, fjtrujy, HWC and others for always helping me
 This program is free and open source
 if you bought it you\'ve been scammed
 ]], currcol)
+        if UI.BUILD_INFO ~= nil and UI.BUILD_INFO.stamp ~= nil then
+          local stamp_y = Round(layout.FOOTER_LABEL_Y - 18)
+          Font.ftPrint(SFONT, layout.SAFE.L, stamp_y, 0, UI.SCR.X, 16, UI.BUILD_INFO.stamp, UI.CCOL.GREY)
+        end
 
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-        -- Any input exits credits back to main menu via crossfade (no black).
         if UI.Pad.Events.EXIT or UI.Pad.Events.BACK or UI.Pad.Events.ANY then
-          UI.Credits.exit_active = true
-          UI.Credits.exit_timer = nil
-          UI.Credits.exit_start = 0
-          UI.Credits.INCR = -1
+          UI.SceneChange(UI.SCENES.MMAIN)
         end
 
         local labels, order = UI.Footer.ResolveLegend({


### PR DESCRIPTION
### Motivation
- Prevent visible pop-in of the rightmost carousel icon by selecting icons based on the active scroll offset instead of snapping at animation end.  
- Improve main-menu visual polish: tighten icon transparency curve, make the title multiline, move build stamp to credits, and remove R2 from footer UX.  
- Keep icon texture loads one-time to avoid lazy-load pop-in during navigation.  

### Description
- Use a computed `scroll` position (`currentIndex + slide`) when choosing which icon keys to render and map visible slots with `WrapIndex(math.floor(scroll + k + 0.5), ...)` so the fifth slot swaps in smoothly during scrolls (`bin/POPSLDR/ui.lua`).  
- One-time preload of icons inside `UI.MainMenu.Play` via `ResolveIcon(key)` and `UI.MainMenu.icons_ready` to avoid lazy-load pop-in (`bin/POPSLDR/ui.lua`).  
- Tuned `SlotAlpha` function to increase off-center transparency (side slots receive lower alpha) so only the centered slot remains visually solid (`bin/POPSLDR/ui.lua`).  
- Updated main title to a three-line layout (`"POPSLoader\nby Matias Israelson\n..."`) and moved the build stamp printing out of the main menu into the `Credits` screen footer area (`bin/POPSLDR/ui.lua`).  
- Renamed footer `start_profiles` label to `Settings`, removed `R2` from footer ordering and legend rendering, and removed the R2-specific event handling to reflect the new UX (`bin/POPSLDR/ui.lua`).  
- Simplified credits exit to use the scene transition system via `UI.SceneChange(UI.SCENES.MMAIN)` instead of a bespoke crossfade state machine (`bin/POPSLDR/ui.lua`).  

### Testing
- No automated tests were run; changes were validated via static code inspection and targeted grep/sed checks in the repository.  
- TODO: verify runtime behavior on CI/emulator (e.g., `make clean elfloader all package` and run in emulator/console) to confirm the pop-in is fixed and transitions render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e7934b5483219fc052eab5f0b8b1)