### PR TITLE
Smooth main menu carousel edge icon fade

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -994,16 +994,21 @@ if found == nil then return end
           if dist <= 2 then
             return Round(Lerp(19, 6, dist - 1))
           end
-          return 6
+          if dist <= 3 then
+            return Round(Lerp(6, 0, dist - 2))
+          end
+          return 0
         end
-        for k = -2, 2 do
+        for k = -3, 3 do
           local idx = WrapIndex(base_scroll + k, profcnt)
           local x = center_x + slot_spacing * (k - scroll_frac)
           local y = center_y
           local dist = math.abs(k - scroll_frac)
           local alpha = SlotAlpha(dist)
-          local tint = Color.new(128, 128, 128, alpha)
-          DrawIcon(idx, x, y, tint)
+          if alpha > 0 then
+            local tint = Color.new(128, 128, 128, alpha)
+            DrawIcon(idx, x, y, tint)
+          end
         end
         Font.ftPrint(UI.FONT.LABEL, Round(center_label_x), center_label_y, 8, UI.SCR.X, 16, UI.MainMenu.opts[center_label_idx], UI.COLORS.TEXT_PRIMARY)
         local labels, order = UI.Footer.ResolveLegend({


### PR DESCRIPTION
### Motivation
- Fix the visible "pop in" of the farthest-right carousel icon by extending the alpha falloff to include one extra slot on each side while keeping existing sliding and transparency behavior intact, and to avoid introducing jumping or breaking icon transparency; TODO: verify on real hardware/emulator.

### Description
- Extend the icon alpha ramp by adding an extra falloff range so alpha interpolates from 6 to 0 for outer slots. 
- Render one additional slot on each side (`for k = -3, 3`) so partially-visible icons are drawn with low alpha instead of suddenly appearing. 
- Skip drawing icons whose computed alpha is `0` to avoid unnecessary draws while preserving the existing tint and drawing path. 
- Change applied in `bin/POPSLDR/ui.lua` around the carousel drawing logic (`SlotAlpha` and the icon draw loop). 

### Testing
- No automated tests were run for this UI-only change (no CI or unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f7bb5b888321bc9e4263e1c6636d)