### PR TITLE
HDD: mount on pfs1 during launch prep and hand off unprefixed selector

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1250,6 +1250,9 @@ end
 
 local function ResolveLaunchPolicy(gamelocation, ui_scene)
   local current_scene = ui_scene or (UI and UI.CURSCENE or "unknown")
+  if current_scene == UI.SCENES.GHDD then
+    return BuildLaunchPolicy("HDD", "pfs", "pfs", nil), "HDD"
+  end
   if current_scene == UI.SCENES.GMX4SIO then
     return BuildLaunchPolicy("MX4SIO", "mx4sio", "mx4sio", nil), "MX4SIO"
   end
@@ -1275,9 +1278,6 @@ local function ResolveLaunchPolicy(gamelocation, ui_scene)
     local mmce_prefix = PLDR.MMCE.PREFIX or "mmce0:/"
     local mmce_device = string.match(mmce_prefix, "^([%a]+%d*)") or "mmce0"
     return BuildLaunchPolicy("MMCE", "mass", mmce_device, TranslateMMCEPathForPopStarter), "SMB/MMCE"
-  end
-  if current_scene == UI.SCENES.GHDD then
-    return BuildLaunchPolicy("HDD", "pfs", "pfs", nil), "HDD"
   end
   return BuildLaunchPolicy("unknown", "mass", "mass", nil), "unknown"
 end
@@ -1433,7 +1433,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   LaunchLog("LAUNCH: selector prefix:", selector_prefix)
   LaunchLog("LAUNCH: argv0 selector:", argv0_selector)
   if policy.name == "HDD" then
-    LaunchLog("HDD LAUNCH argv0:", argv0_selector)
+    LaunchLog("HDD LAUNCH argv0: ["..tostring(argv0_selector).."]")
   end
   LaunchLog("LAUNCH: loadELF argc (caller):", #argv)
   if fallback_bootparam ~= nil then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1377,7 +1377,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     if hdd_selector_name == "" then
       hdd_selector_name = game_name
     end
-    argv0_selector = BuildPopstarterSelector(selector_prefix, hdd_selector_name)
+    argv0_selector = BuildPopstarterSelector("", hdd_selector_name)
   end
   if selector_prefix == "" and string.upper(game_name) == "POPSTARTER" then
     LaunchLog("LAUNCH: Internal error: game_base derived as POPSTARTER; refusing to launch.", vcd_basename_raw)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -796,6 +796,18 @@ local function BuildLiteralElfName(value)
   return trimmed..".ELF"
 end
 
+local function BuildDisplayNameFromEntry(entry)
+  if entry == nil or entry == "" then
+    return ""
+  end
+  local display_name = entry
+  local hdd_relpath = string.match(display_name, "^[^|]+|(.+)$")
+  if hdd_relpath ~= nil then
+    display_name = string.match(hdd_relpath, "([^/]+)$") or hdd_relpath
+  end
+  return string.gsub(display_name, "%.[Vv][Cc][Dd]$", "")
+end
+
 local function BuildPopstarterSelector(prefix, vcd_filename)
   if vcd_filename == nil or vcd_filename == "" then
     return ""
@@ -1236,9 +1248,9 @@ local function LaunchEngine(popstarter, argv, reboot_iop, context)
   )
 end
 
-local function ResolveLaunchPolicy(gamelocation)
-  local ui_scene = UI and UI.CURSCENE or "unknown"
-  if ui_scene == UI.SCENES.GMX4SIO then
+local function ResolveLaunchPolicy(gamelocation, ui_scene)
+  local current_scene = ui_scene or (UI and UI.CURSCENE or "unknown")
+  if current_scene == UI.SCENES.GMX4SIO then
     return BuildLaunchPolicy("MX4SIO", "mx4sio", "mx4sio", nil), "MX4SIO"
   end
   if string.match(gamelocation, "^mx4sio") then
@@ -1256,22 +1268,22 @@ local function ResolveLaunchPolicy(gamelocation)
     local prefix = GetDevicePrefix(gamelocation) or "pfs"
     return BuildLaunchPolicy("HDD", prefix, prefix, nil), "HDD"
   end
-  if UI.IsUsbScene(ui_scene) then
+  if UI.IsUsbScene(current_scene) then
     return BuildLaunchPolicy("USB", "mass", "mass", nil), "USB"
   end
-  if ui_scene == UI.SCENES.GSMB then
+  if current_scene == UI.SCENES.GSMB then
     local mmce_prefix = PLDR.MMCE.PREFIX or "mmce0:/"
     local mmce_device = string.match(mmce_prefix, "^([%a]+%d*)") or "mmce0"
     return BuildLaunchPolicy("MMCE", "mass", mmce_device, TranslateMMCEPathForPopStarter), "SMB/MMCE"
   end
-  if ui_scene == UI.SCENES.GHDD then
+  if current_scene == UI.SCENES.GHDD then
     return BuildLaunchPolicy("HDD", "pfs", "pfs", nil), "HDD"
   end
   return BuildLaunchPolicy("unknown", "mass", "mass", nil), "unknown"
 end
 
-function PLDR.RunPOPStarterGame(gamelocation, game)
-  local policy, device_page = ResolveLaunchPolicy(gamelocation)
+function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
+  local policy, device_page = ResolveLaunchPolicy(gamelocation, ui_scene)
   local hdd_init = nil
   local hdd_partition_label = nil
   local hdd_relpath = nil
@@ -1378,7 +1390,8 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local selector_prefix = SelectPopstarterSelectorPrefix(device_page)
   local argv0_selector = BuildPopstarterSelectorPath(device_page, game_name)
   if policy.name == "HDD" then
-    argv0_selector = BuildLiteralElfName(game_name)
+    local display_name = BuildDisplayNameFromEntry(game)
+    argv0_selector = BuildLiteralElfName(display_name)
   end
   if selector_prefix == "" and string.upper(game_name) == "POPSTARTER" then
     LaunchLog("LAUNCH: Internal error: game_base derived as POPSTARTER; refusing to launch.", vcd_basename_raw)
@@ -1419,6 +1432,9 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   LaunchLog("LAUNCH: selector mode:", SELECTOR_MODE)
   LaunchLog("LAUNCH: selector prefix:", selector_prefix)
   LaunchLog("LAUNCH: argv0 selector:", argv0_selector)
+  if policy.name == "HDD" then
+    LaunchLog("HDD LAUNCH argv0:", argv0_selector)
+  end
   LaunchLog("LAUNCH: loadELF argc (caller):", #argv)
   if fallback_bootparam ~= nil then
     LaunchLog("LAUNCH: bootparam fallback:", fallback_bootparam, "exists:", tostring(fallback_exists))
@@ -1427,7 +1443,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local context = {
     device_page = device_page,
     device_mode = device_mode,
-    ui_scene = UI and UI.CURSCENE or "unknown",
+    ui_scene = ui_scene or (UI and UI.CURSCENE or "unknown"),
     source_mode = source_mode,
     raw_source_mode = raw_source_mode,
     gamelocation = gamelocation,

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -775,6 +775,27 @@ local function SanitizeGameName(name)
   return sanitized
 end
 
+local function TrimTrailingWhitespace(value)
+  if value == nil or value == "" then
+    return ""
+  end
+  return string.gsub(value, "%s+$", "")
+end
+
+local function BuildLiteralElfName(value)
+  if value == nil or value == "" then
+    return ""
+  end
+  local trimmed = TrimTrailingWhitespace(value)
+  if trimmed == "" then
+    return ""
+  end
+  if string.match(trimmed, "%.[Ee][Ll][Ff]$") then
+    return trimmed
+  end
+  return trimmed..".ELF"
+end
+
 local function BuildPopstarterSelector(prefix, vcd_filename)
   if vcd_filename == nil or vcd_filename == "" then
     return ""
@@ -916,8 +937,8 @@ local function EnsureHDDReadyForLaunch(game, partition_override)
   end
   local partition = partition_override or PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
   result.mount_partition = partition
-  HDD.UMountPartition(1)
-  result.mount_ok = HDD.MountPartition(partition, 1, FIO_MT_RDONLY)
+  HDD.UMountPartition(0)
+  result.mount_ok = HDD.MountPartition(partition, 0, FIO_MT_RDONLY)
   return result
 end
 
@@ -1261,21 +1282,6 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     if hdd_partition_label ~= nil then
       hdd_partition = "hdd0:"..hdd_partition_label
     end
-    hdd_init = EnsureHDDReadyForLaunch(game, hdd_partition)
-    if not hdd_init.init_ok or hdd_init.status ~= 0 or not hdd_init.mount_ok then
-      LaunchLog("LAUNCH: HDD not ready; aborting launch.")
-      BlockLaunchFailure(
-        "HDD init/mount failed",
-        ResolvePopstarterPath(PLDR.POPSTARTER_PATH),
-        device_page,
-        nil,
-        nil,
-        APP_DIR_LOCAL,
-        nil,
-        nil
-      )
-      return
-    end
   end
   local normalized_gamelocation = policy.normalize(gamelocation)
   local handoff_gamelocation = policy.handoff(normalized_gamelocation)
@@ -1313,15 +1319,11 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     device_mode = "mass"
   end
   if policy.name == "HDD" then
-    vcd_path = "pfs1:/"..NormalizeHddRelpath(hdd_relpath or game)
-    if string.match(NormalizeHddRelpath(hdd_relpath or game), "^POPS/") then
-      pops_root = "pfs1:/POPS/"
-    else
-      pops_root = "pfs1:/"
-    end
+    vcd_path = ""
+    pops_root = ""
     boot_source_mode = "pfs"
     device_mode = "pfs"
-    handoff_gamelocation = vcd_path
+    handoff_gamelocation = ""
   end
   local bootparam = nil
   local prefix = ""
@@ -1333,10 +1335,9 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local bootparam_basename_used = ""
   local prefix_used = ""
   if policy.name == "HDD" then
-    local relpath = NormalizeHddRelpath(hdd_relpath or game)
-    normalized_basename = ExtractVcdFilename(relpath)
-    bootparam = vcd_path
-    bootparam_basename_used = normalized_basename
+    normalized_basename = ""
+    bootparam = ""
+    bootparam_basename_used = ""
   else
     bootparam, prefix, normalized_basename, prefix_added = BuildPopstarterBootString(
       boot_source_mode,
@@ -1356,6 +1357,10 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   if policy.name == "HDD" then
     vcd_basename_raw = NormalizeHddRelpath(hdd_relpath or game)
   end
+  if policy.name == "HDD" then
+    normalized_basename = game_name
+    bootparam_basename_used = game_name
+  end
   if game_name == "" or string.upper(game_name) == "POPSTARTER" then
     LaunchLog("LAUNCH: GameName derivation failed for selection:", vcd_basename_raw)
     BlockLaunchFailure(
@@ -1373,11 +1378,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   local selector_prefix = SelectPopstarterSelectorPrefix(device_page)
   local argv0_selector = BuildPopstarterSelectorPath(device_page, game_name)
   if policy.name == "HDD" then
-    local hdd_selector_name = StripVcdExtension(ExtractVcdFilename(vcd_basename_raw))
-    if hdd_selector_name == "" then
-      hdd_selector_name = game_name
-    end
-    argv0_selector = BuildPopstarterSelector("", hdd_selector_name)
+    argv0_selector = BuildLiteralElfName(game_name)
   end
   if selector_prefix == "" and string.upper(game_name) == "POPSTARTER" then
     LaunchLog("LAUNCH: Internal error: game_base derived as POPSTARTER; refusing to launch.", vcd_basename_raw)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -916,8 +916,8 @@ local function EnsureHDDReadyForLaunch(game, partition_override)
   end
   local partition = partition_override or PLDR.HDD.GAMEPARTS[game] or "hdd0:__.POPS"
   result.mount_partition = partition
-  HDD.UMountPartition(0)
-  result.mount_ok = HDD.MountPartition(partition, 0, FIO_MT_RDONLY)
+  HDD.UMountPartition(1)
+  result.mount_ok = HDD.MountPartition(partition, 1, FIO_MT_RDONLY)
   return result
 end
 
@@ -1261,6 +1261,21 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     if hdd_partition_label ~= nil then
       hdd_partition = "hdd0:"..hdd_partition_label
     end
+    hdd_init = EnsureHDDReadyForLaunch(game, hdd_partition)
+    if not hdd_init.init_ok or hdd_init.status ~= 0 or not hdd_init.mount_ok then
+      LaunchLog("LAUNCH: HDD not ready; aborting launch.")
+      BlockLaunchFailure(
+        "HDD init/mount failed",
+        ResolvePopstarterPath(PLDR.POPSTARTER_PATH),
+        device_page,
+        nil,
+        nil,
+        APP_DIR_LOCAL,
+        nil,
+        nil
+      )
+      return
+    end
   end
   local normalized_gamelocation = policy.normalize(gamelocation)
   local handoff_gamelocation = policy.handoff(normalized_gamelocation)
@@ -1298,11 +1313,11 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
     device_mode = "mass"
   end
   if policy.name == "HDD" then
-    vcd_path = "pfs0:/"..NormalizeHddRelpath(hdd_relpath or game)
+    vcd_path = "pfs1:/"..NormalizeHddRelpath(hdd_relpath or game)
     if string.match(NormalizeHddRelpath(hdd_relpath or game), "^POPS/") then
-      pops_root = "pfs0:/POPS/"
+      pops_root = "pfs1:/POPS/"
     else
-      pops_root = "pfs0:/"
+      pops_root = "pfs1:/"
     end
     boot_source_mode = "pfs"
     device_mode = "pfs"
@@ -1357,6 +1372,13 @@ function PLDR.RunPOPStarterGame(gamelocation, game)
   end
   local selector_prefix = SelectPopstarterSelectorPrefix(device_page)
   local argv0_selector = BuildPopstarterSelectorPath(device_page, game_name)
+  if policy.name == "HDD" then
+    local hdd_selector_name = StripVcdExtension(ExtractVcdFilename(vcd_basename_raw))
+    if hdd_selector_name == "" then
+      hdd_selector_name = game_name
+    end
+    argv0_selector = BuildPopstarterSelector(selector_prefix, hdd_selector_name)
+  end
   if selector_prefix == "" and string.upper(game_name) == "POPSTARTER" then
     LaunchLog("LAUNCH: Internal error: game_base derived as POPSTARTER; refusing to launch.", vcd_basename_raw)
     BlockLaunchFailure(

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -895,7 +895,7 @@ if found == nil then return end
                 UI.Notif_queue.add("Cant find Game\n"..PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR])
               end
             end
-            PLDR.RunPOPStarterGame(PLDR.GAMEPATH, PLDR.GAMES[UI.GameList.CURR])
+            PLDR.RunPOPStarterGame(PLDR.GAMEPATH, PLDR.GAMES[UI.GameList.CURR], UI.CURSCENE)
           end
         end
         local cross_label = UI.Footer.labels.cross_launch

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -895,7 +895,11 @@ if found == nil then return end
                 UI.Notif_queue.add("Cant find Game\n"..PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR])
               end
             end
-            PLDR.RunPOPStarterGame(PLDR.GAMEPATH, PLDR.GAMES[UI.GameList.CURR], UI.CURSCENE)
+            local launch_path = PLDR.GAMEPATH
+            if UI.CURSCENE == UI.SCENES.GHDD then
+              launch_path = ""
+            end
+            PLDR.RunPOPStarterGame(launch_path, PLDR.GAMES[UI.GameList.CURR], UI.CURSCENE)
           end
         end
         local cross_label = UI.Footer.labels.cross_launch
@@ -1226,7 +1230,7 @@ if found == nil then return end
             else
               UI.Notif_queue.add("ERROR: Cant detect usable HDD ("..PLDR.HDD.STATUS..")")
             end
-            UI.SceneChange(UI.MainMenu.OPT)
+            UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
             PLDR.CleanupGameList()
             PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)


### PR DESCRIPTION
### Motivation
- Prevent touching `pfs0` during HDD handoff so POPStarter can decide what to do with `pfs0` itself and avoid giving it a prefixed selector; always prepare HDD partitions on `pfs1` or higher instead. 
- Ensure the handed-off selector is derived from the selected VCD basename (`<game>.ELF`) so POPStarter resolves device paths by presence/absence of a prefix. 
- Fail fast if HDD init/mount preparation fails so we do not attempt a broken handoff.

### Description
- Changed HDD mount/unmount calls in `bin/POPSLDR/system.lua` (`EnsureHDDReadyForLaunch`) to use partition index `1` instead of `0` so preparation uses `pfs1` (`HDD.UMountPartition(1)` / `HDD.MountPartition(..., 1, ...)`).
- Updated HDD internal path references from `pfs0:` to `pfs1:` for `vcd_path` and `pops_root` so runtime references point at the prepared mount. 
- Added a pre-handoff HDD readiness check call to `PLDR.RunPOPStarterGame` that calls `EnsureHDDReadyForLaunch(game, hdd_partition)` and aborts the launch with `BlockLaunchFailure` if init/mount fails. 
- Built the handoff selector for HDD by deriving the selector name from the VCD basename (stripping `.VCD`/extension) and calling `BuildPopstarterSelector(...)` so the final `argv[0]` is the game selector derived from the Gameslist; this leaves the prefix behavior to the existing `SelectPopstarterSelectorPrefix` logic (intended to be empty for HDD). 

### Testing
- Performed static repository verification (search/inspection of `bin/POPSLDR/system.lua` and surrounding logic) to confirm the mount index, path replacements, readiness check injection, and selector-build changes were applied and consistent; these inspections succeeded. 
- No PS2 toolchain or CI build was executed in this environment, so `make clean elfloader all package` was not run here and end-to-end runtime behavior on hardware/emulator was not validated. 
- TODO: verify at runtime that `SelectPopstarterSelectorPrefix` returns an empty prefix for HDD and that POPStarter correctly resolves `pfs0` when handed an unprefixed `<game>.ELF`; check `bin/POPSLDR/system.lua` (selector helpers) and validate with CI and an emulator/hardware smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2a1b9dc4832183334e5dd36394e7)