### PR TITLE
Enable MX4SIO page game listing

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1217,7 +1217,8 @@ end
         UI.GameList.MAXDRAW = layout.LIST_MAX
         local titles = {
           [UI.SCENES.GUSBFAT] = "USB FAT32",
-          [UI.SCENES.GUSBEXFAT] = "USB exFAT"
+          [UI.SCENES.GUSBEXFAT] = "USB exFAT",
+          [UI.SCENES.GMX4SIO] = "MX4SIO"
         }
         local scene_title = titles[UI.CURSCENE]
         if scene_title ~= nil then
@@ -1660,7 +1661,53 @@ end
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            UI.Notif_queue.add("Not Implemented Yet")
+            local can_enter, reason, lock = UI.canEnterDevice(DEVLOCK.MX4SIO)
+            if not can_enter then
+              UI.Notif_queue.add("Device locked to "..UI.device_lock_name(lock))
+              return
+            end
+            if System == nil or System.initMX4SIO == nil then
+              UI.Notif_queue.add("MX4SIO init unavailable")
+              return
+            end
+            local hint = nil
+            if PLDR ~= nil and PLDR.MX4SIO ~= nil then
+              hint = PLDR.MX4SIO.PREFIX_HINT
+            end
+            local ok_init, ready, root = pcall(System.initMX4SIO, hint)
+            if not ok_init then
+              UI.Notif_queue.add("MX4SIO init error")
+              if PLDR ~= nil and PLDR.MX4SIO ~= nil then
+                PLDR.MX4SIO.READY = false
+                PLDR.MX4SIO.ROOT = nil
+              end
+              return
+            end
+            if not ready or root == nil then
+              UI.Notif_queue.add("No MX4SIO device found (POPS/ missing)")
+              if PLDR ~= nil and PLDR.MX4SIO ~= nil then
+                PLDR.MX4SIO.READY = false
+                PLDR.MX4SIO.ROOT = nil
+              end
+              return
+            end
+            if type(EnsureTrailingSlash) == "function" then
+              root = EnsureTrailingSlash(root)
+            elseif string.sub(root, -1) ~= "/" then
+              root = root.."/"
+            end
+            if PLDR ~= nil and PLDR.MX4SIO ~= nil then
+              PLDR.MX4SIO.READY = true
+              PLDR.MX4SIO.ROOT = root
+            end
+            PLDR.CleanupGameList()
+            local game_root = root.."POPS/"
+            if type(JoinPath) == "function" then
+              game_root = JoinPath(root, "POPS/")
+            end
+            PLDR.GetPS1GameLists(game_root, true)
+            UI.setDeviceLock(DEVLOCK.MX4SIO)
+            UI.SceneChange(UI.SCENES.GMX4SIO)
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- Finish the MX4SIO UI flow so MX4SIO devices can be initialized and shown on their own game list page without leaking into USB game lists or vice versa.  
- Avoid confusing boot/device locks by checking `UI.canEnterDevice` and by preserving/resetting `PLDR.MX4SIO` state on errors.  
- Keep the change narrow and accessible for verification on hardware or CI (TODO: verify runtime on real hardware/emulator).

### Description
- Added an MX4SIO page title to the game list view so `GMX4SIO` shows as "MX4SIO" in the list header.  
- Implemented MainMenu flow for the MX4SIO option: it checks device lock via `UI.canEnterDevice`, calls `System.initMX4SIO(hint)` inside `pcall`, validates the returned `ready` and `root`, normalizes the root, sets `PLDR.MX4SIO.READY`/`ROOT`, and populates the MX4SIO game list via `PLDR.GetPS1GameLists(root.."POPS/", true)` before switching to `UI.SCENES.GMX4SIO`.  
- Ensured errors during init reset `PLDR.MX4SIO` state and surface a user notification; feature-detection is used for helpers like `EnsureTrailingSlash` and `JoinPath`.  
- Modified file: `bin/POPSLDR/ui.lua` (wires UI -> `System.initMX4SIO` and game-list population). 

### Testing
- No automated tests were executed for this change (CI not invoked).  
- Manual static checks performed: code updated and committed locally; runtime behavior still requires verification on hardware or emulator and CI build (`make clean elfloader all package`) as a follow-up (TODO: verify).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abeb66a908321830b6ae7b260a43f)