### PR TITLE
Add popsbdm IOP devctl + `System.getMassBackend()` to detect USB vs MX4SIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ EE_BIN_PKD = $(BINDIR)POPSLOADER.ELF
 
 EE_LIBS = -L$(PS2SDK)/ports/lib -L$(PS2DEV)/gsKit/lib/ -Lmodules/ds34bt/ee/ -Lmodules/ds34usb/ee/ -lpatches -lfileXio -lpad -ldebug -llua -lmath3d -ljpeg -lfreetype -lgskit_toolkit -lgskit -ldmakit -lpng -lz -lmc -laudsrv  -lds34bt -lds34usb
 EE_LIBS += src/elf_loader/libcustom-elf-loader.a
-EE_INCS += -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(PS2SDK)/ports/include/zlib
+EE_INCS += -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(PS2SDK)/ports/include/zlib -Icommon
 EE_INCS += -Imodules/ds34bt/ee -Imodules/ds34usb/ee
 
 EE_CFLAGS   += -Wno-sign-compare -fno-strict-aliasing -fno-exceptions -DLUA_USE_PS2
@@ -76,7 +76,7 @@ IOP_MODULES = iomanX.o fileXio.o \
 			  usbd.o audsrv.o bdm.o bdmfs_fatfs.o \
 			  usbmass_bd.o cdfs.o ds34bt.o ds34usb.o \
 			  ps2dev9.o ps2atad.o ps2hdd-osd.o ps2fs.o mmceman.o \
-			  mx4sio_bd.o bdm_query.o
+			  mx4sio_bd.o bdm_query.o popsbdm.o
 
 EMBEDDED_RSC = boot.o builtin_font.o
 
@@ -141,6 +141,12 @@ iop/bdm_query/bdm_query.irx: iop/bdm_query
 
 $(EE_ASM_DIR)bdm_query.c: iop/bdm_query/bdm_query.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ bdm_query_irx
+
+iop/popsbdm/popsbdm.irx: iop/popsbdm
+	$(MAKE) -C $<
+
+$(EE_ASM_DIR)popsbdm.c: iop/popsbdm/popsbdm.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ popsbdm_irx
 
 # PS2SDK MX4SIO IRX (embedded)
 PS2SDK_MX4SIO_DIR = iop/embed/PS2SDK_MX4SIO

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -117,6 +117,16 @@ local function ResolveIrx(name)
   return System.resolveAssetType(name, ASSET_IRX) or JoinPath(APP_DIR_LOCAL, name)
 end
 
+local function GetMassBackend()
+  if System ~= nil and System.getMassBackend ~= nil then
+    local ok, backend = pcall(System.getMassBackend)
+    if ok and type(backend) == "string" then
+      return backend
+    end
+  end
+  return "UNKNOWN"
+end
+
 local function DetectBootDevice()
   local boot_path = NormalizeDirPath(BOOT_PATH_RAW or "")
   local prefix = string.match(boot_path, "^([%a]+%d*):")
@@ -130,6 +140,13 @@ local function DetectBootDevice()
     return "MX4SIO", boot_path, prefix
   end
   if string.match(prefix, "^mass%d*$") then
+    local backend = GetMassBackend()
+    if backend == "MX4SIO" then
+      return "MX4SIO", boot_path, prefix
+    end
+    if backend == "USB" then
+      return "USB", boot_path, prefix
+    end
     local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
     local usb_marker = JoinPath(APP_DIR_LOCAL, ".boot_usb")
     if doesFileExist(mx_marker) then
@@ -1433,6 +1450,10 @@ local function ResolveLaunchPolicy(gamelocation, ui_scene)
     return BuildLaunchPolicy("MX4SIO", "mx4sio", "mx4sio", nil), "MX4SIO"
   end
   if string.match(gamelocation, "^mass") then
+    local backend = GetMassBackend()
+    if backend == "MX4SIO" then
+      return BuildLaunchPolicy("MX4SIO", "mx4sio", "mx4sio", nil), "MX4SIO"
+    end
     return BuildLaunchPolicy("USB", "mass", "mass", nil), "USB"
   end
   if string.match(gamelocation, "^mmce") then
@@ -1445,6 +1466,10 @@ local function ResolveLaunchPolicy(gamelocation, ui_scene)
     return BuildLaunchPolicy("HDD", prefix, prefix, nil), "HDD"
   end
   if UI.IsUsbScene(current_scene) then
+    local backend = GetMassBackend()
+    if backend == "MX4SIO" then
+      return BuildLaunchPolicy("MX4SIO", "mx4sio", "mx4sio", nil), "MX4SIO"
+    end
     return BuildLaunchPolicy("USB", "mass", "mass", nil), "USB"
   end
   if current_scene == UI.SCENES.GSMB then
@@ -1482,10 +1507,15 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     pops_root = normalized_gamelocation
     boot_source_mode = "pfs"
     device_mode = "pfs"
-  elseif string.match(normalized_gamelocation, "^mx4sio") then
+  elseif string.match(normalized_gamelocation, "^mx4sio") or source_mode == "mx4sio" then
     pops_root = normalized_gamelocation
     boot_source_mode = "mx4sio"
     device_mode = normalized_gamelocation
+    if source_mode == "mx4sio" and (normalized_gamelocation == nil or normalized_gamelocation == "" or string.match(normalized_gamelocation, "^mass")) then
+      local mx_root = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.ROOT or "mx4sio:/"
+      pops_root = mx_root
+      device_mode = mx_root
+    end
   elseif string.match(normalized_gamelocation, "^mmce%d:/") then
     mmce_prefix = PLDR.MMCE.PREFIX or string.match(normalized_gamelocation, "^(mmce%d:/)")
     if mmce_prefix == nil then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1354,6 +1354,21 @@ end
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #PLDR.PROFILES
+        if not UI.ProfileQuery.logged then
+          local bootpath = "unknown"
+          if System ~= nil and System.currentDirectory ~= nil then
+            bootpath = System.currentDirectory()
+          end
+          local backend = "UNKNOWN"
+          if System ~= nil and System.getMassBackend ~= nil then
+            local ok_backend, value = pcall(System.getMassBackend)
+            if ok_backend and type(value) == "string" then
+              backend = value
+            end
+          end
+          LOG("Profile page entry: current_bootpath=", tostring(bootpath), "mass_backend=", tostring(backend))
+          UI.ProfileQuery.logged = true
+        end
         if UI.ProfileQuery.bdma_mode == nil then
           if PLDR.GetBDMAMode ~= nil then
             UI.ProfileQuery.bdma_mode = PLDR.GetBDMAMode()
@@ -1375,6 +1390,7 @@ end
         if UI.HandleGlobalInput(false) then return end
         if UI.Pad.Events.EXIT then
           UI.ProfileQuery.bdma_mode = nil
+          UI.ProfileQuery.logged = false
           UI.SceneChange(UI.SCENES.CREDITS)
         end
         if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
@@ -1394,6 +1410,7 @@ end
         end
         if UI.Pad.Events.BACK then
           UI.ProfileQuery.bdma_mode = nil
+          UI.ProfileQuery.logged = false
           UI.SceneChange(UI.SCENES.MMAIN)
         end
         if UI.Pad.Events.START then
@@ -1423,6 +1440,7 @@ end
           else
             PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
             UI.ProfileQuery.bdma_mode = nil
+            UI.ProfileQuery.logged = false
             UI.SceneChange(UI.SCENES.MMAIN)
           end
         end

--- a/common/popsbdm_devctl.h
+++ b/common/popsbdm_devctl.h
@@ -1,0 +1,27 @@
+#ifndef POPSBDM_DEVCTL_H
+#define POPSBDM_DEVCTL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define POPSBDM_DEVCTL_GET_BACKEND 0xB001
+
+typedef enum popsbdm_backend {
+	POPSBDM_BACKEND_UNKNOWN = 0,
+	POPSBDM_BACKEND_USB = 1,
+	POPSBDM_BACKEND_MX4SIO = 2
+} popsbdm_backend_t;
+
+#define POPSBDM_BACKEND_DETAIL_LEN 32
+
+typedef struct popsbdm_backend_info {
+	int backend;
+	char detail[POPSBDM_BACKEND_DETAIL_LEN];
+} popsbdm_backend_info_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/iop/popsbdm/Makefile
+++ b/iop/popsbdm/Makefile
@@ -6,7 +6,7 @@ IOP_IMPORT_INCS += \
 	system/iomanx \
 	system/sysclib
 
-IOP_CFLAGS += -I../../common
+IOP_CFLAGS += -I../../common -I$(PS2SDK)/iop/system/iomanx/include
 
 include $(PS2SDK)/Defs.make
 include ../../modules/Rules.bin.make

--- a/iop/popsbdm/Makefile
+++ b/iop/popsbdm/Makefile
@@ -6,7 +6,8 @@ IOP_IMPORT_INCS += \
 	system/iomanx \
 	system/sysclib
 
-IOP_CFLAGS += -I../../common -I$(PS2SDK)/iop/system/iomanx/include
+IOP_INCS += -I$(PS2SDK)/iop/system/iomanx/include
+IOP_CFLAGS += -I../../common
 
 include $(PS2SDK)/Defs.make
 include ../../modules/Rules.bin.make

--- a/iop/popsbdm/Makefile
+++ b/iop/popsbdm/Makefile
@@ -1,0 +1,13 @@
+IOP_BIN = popsbdm.irx
+IOP_OBJS = popsbdm.o imports.o
+
+IOP_IMPORT_INCS += \
+	fs/bdm \
+	system/iomanx \
+	system/sysclib
+
+IOP_CFLAGS += -I../../common
+
+include $(PS2SDK)/Defs.make
+include ../../modules/Rules.bin.make
+include $(PS2SDK)/samples/Makefile.iopglobal

--- a/iop/popsbdm/imports.lst
+++ b/iop/popsbdm/imports.lst
@@ -1,0 +1,14 @@
+iomanX_IMPORTS_start
+I_iomanX_AddDrv
+iomanX_IMPORTS_end
+
+sysclib_IMPORTS_start
+I_memset
+I_strncpy
+I_strlen
+I_strncmp
+sysclib_IMPORTS_end
+
+bdm_IMPORTS_start
+I_bdm_get_bd
+bdm_IMPORTS_end

--- a/iop/popsbdm/imports.lst
+++ b/iop/popsbdm/imports.lst
@@ -1,5 +1,5 @@
 iomanX_IMPORTS_start
-I_iomanX_AddDrv
+I_AddDrv
 iomanX_IMPORTS_end
 
 sysclib_IMPORTS_start

--- a/iop/popsbdm/irx_imports.h
+++ b/iop/popsbdm/irx_imports.h
@@ -1,0 +1,20 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+#ifndef IOP_POPSBDM_IMPORTS_H
+#define IOP_POPSBDM_IMPORTS_H
+
+#include "irx.h"
+
+/* Please keep these in alphabetical order! */
+#include "bdm.h"
+#include "iomanX.h"
+#include "sysclib.h"
+
+#endif

--- a/iop/popsbdm/popsbdm.c
+++ b/iop/popsbdm/popsbdm.c
@@ -109,5 +109,8 @@ int _start(int argc, char *argv[])
 {
 	(void)argc;
 	(void)argv;
-	return iomanX_AddDrv(&popsbdm_device) ? MODULE_NO_RESIDENT_END : MODULE_RESIDENT_END;
+	if (iomanX_AddDrv(&popsbdm_device) < 0) {
+		return MODULE_NO_RESIDENT_END;
+	}
+	return MODULE_RESIDENT_END;
 }

--- a/iop/popsbdm/popsbdm.c
+++ b/iop/popsbdm/popsbdm.c
@@ -1,0 +1,113 @@
+#include <bdm.h>
+#include <errno.h>
+#include <iomanX.h>
+#include <irx.h>
+#include <loadcore.h>
+#include <sysclib.h>
+#include <types.h>
+
+#include "irx_imports.h"
+#include "popsbdm_devctl.h"
+
+IRX_ID("popsbdm", 1, 0);
+
+#define POPSBDM_MAX_DEVICES 16
+
+static int popsbdm_open(iomanX_iop_file_t *f, const char *name, int flags, int mode)
+{
+	(void)f;
+	(void)name;
+	(void)flags;
+	(void)mode;
+	return 0;
+}
+
+static int popsbdm_close(iomanX_iop_file_t *f)
+{
+	(void)f;
+	return 0;
+}
+
+static int popsbdm_name_matches(const char *name, const char *prefix)
+{
+	size_t prefix_len = strlen(prefix);
+	return strncmp(name, prefix, prefix_len) == 0;
+}
+
+static void popsbdm_detect_backend(popsbdm_backend_info_t *out)
+{
+	struct block_device *devices[POPSBDM_MAX_DEVICES];
+	int found_usb = 0;
+	int found_mx4sio = 0;
+
+	memset(out, 0, sizeof(*out));
+	out->backend = POPSBDM_BACKEND_UNKNOWN;
+	out->detail[0] = '\0';
+
+	memset(devices, 0, sizeof(devices));
+	bdm_get_bd(devices, POPSBDM_MAX_DEVICES);
+
+	for (int i = 0; i < POPSBDM_MAX_DEVICES; ++i) {
+		struct block_device *bd = devices[i];
+		if (bd == NULL || bd->name == NULL) {
+			continue;
+		}
+		// TODO: verify driver name strings for mx4sio/usbmass in PS2SDK BDM backends.
+		if (popsbdm_name_matches(bd->name, "mx4sio")) {
+			found_mx4sio = 1;
+		} else if (popsbdm_name_matches(bd->name, "usbmass")) {
+			found_usb = 1;
+		}
+	}
+
+	if (found_mx4sio && !found_usb) {
+		out->backend = POPSBDM_BACKEND_MX4SIO;
+		strncpy(out->detail, "mx4sio", sizeof(out->detail) - 1);
+	} else if (found_usb && !found_mx4sio) {
+		out->backend = POPSBDM_BACKEND_USB;
+		strncpy(out->detail, "usbmass", sizeof(out->detail) - 1);
+	} else if (found_usb && found_mx4sio) {
+		strncpy(out->detail, "usbmass+mx4sio", sizeof(out->detail) - 1);
+	}
+	out->detail[sizeof(out->detail) - 1] = '\0';
+}
+
+static int popsbdm_devctl(iomanX_iop_file_t *f, const char *name, int cmd, void *arg,
+                          unsigned int arglen, void *buf, unsigned int buflen)
+{
+	(void)f;
+	(void)name;
+	(void)arg;
+	(void)arglen;
+
+	if (cmd != POPSBDM_DEVCTL_GET_BACKEND) {
+		return -EINVAL;
+	}
+	if (buf == NULL || buflen < sizeof(popsbdm_backend_info_t)) {
+		return -EINVAL;
+	}
+	popsbdm_backend_info_t *out = (popsbdm_backend_info_t *)buf;
+	popsbdm_detect_backend(out);
+	return 0;
+}
+
+static iomanX_iop_device_ops_t popsbdm_ops = {
+	.open = popsbdm_open,
+	.close = popsbdm_close,
+	.devctl = popsbdm_devctl,
+};
+
+static iomanX_iop_device_t popsbdm_device = {
+	.name = "popsbdm",
+	.type = IOP_DT_FS,
+	.version = 1,
+	.desc = "POPS BDM backend",
+	.ops = &popsbdm_ops,
+};
+
+int _start(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+	return iomanX_AddDrv(&popsbdm_device) ? MODULE_NO_RESIDENT_END : MODULE_RESIDENT_END;
+}

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -16,6 +16,7 @@
 
 #include "include/system.h"
 #include "include/dprintf.h"
+#include "popsbdm_devctl.h"
 
 #define MAX_DIR_FILES 512
 
@@ -994,6 +995,30 @@ static int lua_mx4sio_init(lua_State *L)
 	return 2;
 }
 
+static int lua_get_mass_backend(lua_State *L)
+{
+	popsbdm_backend_info_t info;
+	memset(&info, 0, sizeof(info));
+	int ret = fileXioDevctl("popsbdm:", POPSBDM_DEVCTL_GET_BACKEND,
+	                        NULL, 0, &info, sizeof(info));
+	if (ret < 0) {
+		lua_pushstring(L, "UNKNOWN");
+		return 1;
+	}
+	switch (info.backend) {
+		case POPSBDM_BACKEND_USB:
+			lua_pushstring(L, "USB");
+			break;
+		case POPSBDM_BACKEND_MX4SIO:
+			lua_pushstring(L, "MX4SIO");
+			break;
+		default:
+			lua_pushstring(L, "UNKNOWN");
+			break;
+	}
+	return 1;
+}
+
 static const luaL_Reg System_functions[] = {
 	{"openFile",                   lua_openfile},
 	{"readFile",                   lua_readfile},
@@ -1026,6 +1051,7 @@ static const luaL_Reg System_functions[] = {
 	{"resolveAsset",           lua_resolveAsset},
 	{"resolveAssetType",   lua_resolveAssetType},
 	{"initMX4SIO",             lua_mx4sio_init},
+	{"getMassBackend",     lua_get_mass_backend},
 	{"bdmList",                lua_bdm_list},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,9 @@ extern unsigned int size_bdmfs_fatfs_irx;
 extern unsigned char usbmass_bd_irx;
 extern unsigned int size_usbmass_bd_irx;
 
+extern unsigned char popsbdm_irx;
+extern unsigned int size_popsbdm_irx;
+
 extern unsigned char audsrv_irx;
 extern unsigned int size_audsrv_irx;
 
@@ -388,6 +391,7 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(bdm_irx);
     LOAD_IRX_NARG(bdmfs_fatfs_irx);
     LOAD_IRX_NARG(usbmass_bd_irx);
+    LOAD_IRX_NARG(popsbdm_irx);
 
     LOAD_IRX_NARG(cdfs_irx);
 


### PR DESCRIPTION
### Motivation
- Provide an authoritative IOP-side way to identify the mass backend (USB vs MX4SIO) and expose it to Lua so runtime logic does not guess from device prefixes or UI state.

### Description
- Add a shared header `common/popsbdm_devctl.h` that defines `POPSBDM_DEVCTL_GET_BACKEND`, backend enum values, and the output struct `popsbdm_backend_info_t`.
- Implement a new IOP driver `iop/popsbdm/popsbdm.c` which registers the `popsbdm:` device and handles `POPSBDM_DEVCTL_GET_BACKEND` by calling `bdm_get_bd()` and matching backend driver names to determine USB vs MX4SIO.
- Wire the new IOP module into the build by adding `iop/popsbdm` Makefile + imports and embedding `popsbdm.irx` in `Makefile`, and load it at boot from `src/main.cpp`.
- Expose the result to EE/Lua via `System.getMassBackend()` in `src/luasystem.cpp`, which calls `fileXioDevctl("popsbdm:", POPSBDM_DEVCTL_GET_BACKEND, ...)` and returns the string "USB", "MX4SIO", or "UNKNOWN".
- Use the new API in `bin/POPSLDR/system.lua` to disambiguate `mass:` boots and to choose MX4SIO launch paths, and add a one-time debug log on the profile page in `bin/POPSLDR/ui.lua` that prints `current_bootpath` and the detected backend.

### Testing
- No automated tests were executed for this change (the CI/build target `make clean elfloader all package` was not run here). 
- Expected manual test matrix: with only MX4SIO present `System.getMassBackend()` should return `"MX4SIO"`; with only USB present it should return `"USB"`; if both are present the driver will populate detail as `"usbmass+mx4sio"` and the reported backend will be `"UNKNOWN"`.
- TODO: verify the backend driver name strings (`"mx4sio"` and `"usbmass"`) used by `popsbdm` on real hardware or with the PS2SDK BDM backends and run a full CI build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697acbc9e8a08321ab0cb5c9ddbb1e2c)