### PR TITLE
Defer nonessential IOP module loads until after graphics init and add HDD boot status

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,6 +129,9 @@ char app_dir[255];
 int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
 static clock_t boot_start = 0;
+static int g_booted_from_hdd = 0;
+static int g_status_line = 2;
+static int g_status_inited = 0;
 
 static unsigned int boot_ms(void)
 {
@@ -226,6 +229,26 @@ static int FixupMassGenericPath(char *io_path, size_t io_sz)
 static void BootStamp(const char *stage)
 {
     DPRINTF("BOOT: %s %u\n", stage, boot_ms());
+}
+
+static void BootStatus(const char *stage)
+{
+    BootStamp(stage);
+#if defined(BOOT_HDD)
+    if (g_booted_from_hdd) {
+        if (!g_status_inited) {
+            init_scr();
+            scr_setfontcolor(0xffffff);
+            scr_clear();
+            scr_setXY(5, 1);
+            scr_printf("HDD boot status\n");
+            g_status_inited = 1;
+            g_status_line = 3;
+        }
+        scr_setXY(5, g_status_line++);
+        scr_printf("%s\n", stage);
+    }
+#endif
 }
 
 void setLuaBootPath(int argc, char ** argv, int idx)
@@ -420,16 +443,13 @@ int main(int argc, char * argv[])
      */
     const int booted_from_hdd =
         (boot_path[0] && (!strncmp(boot_path, "pfs", 3) || !strncmp(boot_path, "hdd0:", 5)));
+    g_booted_from_hdd = booted_from_hdd ? 1 : 0;
 
 #if defined(BOOT_HDD)
     if (booted_from_hdd) {
-        init_scr();
-        scr_setfontcolor(0xffffff);
-        scr_clear();
-        scr_setXY(5, 2);
-        scr_printf("HDD boot: starting...\n");
-        scr_printf("boot_path: %s\n", boot_path);
-        scr_printf("(If this hangs, last line indicates stage)\n");
+        BootStatus("HDD boot: starting");
+        BootStatus(boot_path);
+        BootStatus("(If this hangs, last line indicates stage)");
     }
 #endif
 
@@ -444,10 +464,13 @@ int main(int argc, char * argv[])
         while (!SifIopReset("", 0)){};
         while (!SifIopSync()){};
         SifInitRpc(0);
-        BootStamp("IOP reset");
+        BootStatus("IOP reset");
     } else {
-        BootStamp("IOP reset (skipped: HDD boot)");
+        BootStatus("IOP reset (skipped: HDD boot)");
     }
+#else
+    SifInitRpc(0);
+    BootStatus("SIF RPC init");
 #endif
     
     // install sbv patch fix
@@ -460,11 +483,12 @@ int main(int argc, char * argv[])
 	LOAD_IRX_NARG(ppctty_irx);
 #endif
 
+    BootStatus("iomanX load");
     bool ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
-    BootStamp("iomanX load");
     bool filexio_ok = false;
     int filexio_ret = -1;
     if (ioman_ok) {
+        BootStatus("fileXio load");
         filexio_ok = LoadIrxChecked("fileXio_irx", fileXio_irx, size_fileXio_irx, NULL, NULL);
         if (filexio_ok) {
             filexio_ret = fileXioInit();
@@ -476,45 +500,11 @@ int main(int argc, char * argv[])
     } else {
         DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
     }
-    BootStamp("fileXio load/init");
-
-	LOAD_IRX_NARG(sio2man_irx);
-    if (filexio_ok) {
-        int mmceman_id = -1;
-        int mmceman_ret = -1;
-        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
-        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
-#ifdef DEBUG
-        if (mmceman_ok) {
-            smod_mod_info_t info;
-            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
-            if (lookup_ret < 0) {
-                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
-                DumpLoadedModules();
-            }
-        }
-#endif
-        BootStamp("mmceman load/init");
-        if (mmceman_ok) {
-            mmce_slot0_ready = -1;
-            mmce_slot1_ready = -1;
-            DPRINTF("MMCE probe deferred until MMCE page entry.\n");
-        } else {
-            mmce_slot0_ready = 0;
-            mmce_slot1_ready = 0;
-        }
+    if (!ioman_ok || !filexio_ok) {
+        BootStatus("fileXio init failed");
     } else {
-        DPRINTF("Skipping mmceman init; fileXio not ready.\n");
-        mmce_slot0_ready = 0;
-        mmce_slot1_ready = 0;
-        BootStamp("mmceman load/init (skipped)");
+        BootStatus("fileXio init ok");
     }
-    LOAD_IRX_NARG(mcman_irx);
-    LOAD_IRX_NARG(mcserv_irx);
-    initMC();
-    LOAD_IRX_NARG(padman_irx);
-
-    LOAD_IRX_NARG(libsd_irx);
 
     /*
      * Avoid mass/USB/BDM stack initialization when we were launched from HDD/PFS.
@@ -526,35 +516,17 @@ int main(int argc, char * argv[])
 #endif
 
     if (init_mass_stack) {
-        // load USB modules
-        LOAD_IRX_NARG(usbd_irx);
-
-        int ds3pads = 1;
-        LOAD_IRX(ds34usb_irx, 4, (char *)&ds3pads);
-        LOAD_IRX(ds34bt_irx, 4, (char *)&ds3pads);
-        ds34usb_init();
-        ds34bt_init();
-
-        LOAD_IRX_NARG(bdm_irx);
-        LOAD_IRX_NARG(bdmfs_fatfs_irx);
-        LOAD_IRX_NARG(usbmass_bd_irx);
-        BootStamp("mass stack load");
+        BootStatus("mass stack deferred");
     } else {
-        BootStamp("mass stack load (skipped: HDD boot)");
+        BootStatus("mass stack skipped (HDD boot)");
     }
 
 #if defined(BOOT_MX4SIO)
     /* Load MX4SIO backend early so booting from MX4SIO works before Lua starts. */
     bool mx4sio_bd_ok = LoadIrxChecked("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
     DPRINTF("mx4sio_bd load result: ok=%d\n", mx4sio_bd_ok ? 1 : 0);
-    BootStamp("mx4sio_bd load");
+    BootStatus("mx4sio_bd load");
 #endif
-
-    if (init_mass_stack) {
-        LOAD_IRX_NARG(cdfs_irx);
-    }
-
-    LOAD_IRX_NARG(audsrv_irx);
 
     //waitUntilDeviceIsReady by fjtrujy
 
@@ -584,23 +556,78 @@ int main(int argc, char * argv[])
         wait_root[0] = '\0';
     }
     if (!strncmp(wait_root, "mass", 4)) {
-        BootStamp("mass wait begin");
+        BootStatus("mass wait begin");
         while (ret != 0 && retries > 0) {
             ret = stat(wait_root, &buffer);
             nopdelay();
             retries--;
         }
-        BootStamp("mass wait end");
+        BootStatus("mass wait end");
     } else {
-        BootStamp("mass wait (skipped)");
+        BootStatus("mass wait skipped");
     }
 	
 	// Lua init
 	// init internals library
     
     // graphics (gsKit)
+    BootStatus("graphics init");
     initGraphics();
 
+    BootStatus("IOP modules (pad/sound/usb) init");
+    LOAD_IRX_NARG(sio2man_irx);
+    if (filexio_ok) {
+        int mmceman_id = -1;
+        int mmceman_ret = -1;
+        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+#ifdef DEBUG
+        if (mmceman_ok) {
+            smod_mod_info_t info;
+            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+            if (lookup_ret < 0) {
+                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                DumpLoadedModules();
+            }
+        }
+#endif
+        if (mmceman_ok) {
+            mmce_slot0_ready = -1;
+            mmce_slot1_ready = -1;
+            DPRINTF("MMCE probe deferred until MMCE page entry.\n");
+        } else {
+            mmce_slot0_ready = 0;
+            mmce_slot1_ready = 0;
+        }
+    } else {
+        DPRINTF("Skipping mmceman init; fileXio not ready.\n");
+        mmce_slot0_ready = 0;
+        mmce_slot1_ready = 0;
+    }
+    LOAD_IRX_NARG(mcman_irx);
+    LOAD_IRX_NARG(mcserv_irx);
+    initMC();
+    LOAD_IRX_NARG(padman_irx);
+    LOAD_IRX_NARG(libsd_irx);
+    LOAD_IRX_NARG(audsrv_irx);
+
+    if (init_mass_stack) {
+        // load USB modules
+        LOAD_IRX_NARG(usbd_irx);
+
+        int ds3pads = 1;
+        LOAD_IRX(ds34usb_irx, 4, (char *)&ds3pads);
+        LOAD_IRX(ds34bt_irx, 4, (char *)&ds3pads);
+        ds34usb_init();
+        ds34bt_init();
+
+        LOAD_IRX_NARG(bdm_irx);
+        LOAD_IRX_NARG(bdmfs_fatfs_irx);
+        LOAD_IRX_NARG(usbmass_bd_irx);
+        LOAD_IRX_NARG(cdfs_irx);
+    }
+
+    BootStatus("pad init");
     pad_init();
 
     // set base path luaplayer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,9 +38,9 @@ extern "C"{
 /*
  * EE-only early video probe.
  * Purpose: prove we reach main() when HDD-booted, without any SIF/IOP calls.
- * Draws a solid dark-red frame once, then continues.
+ * Draws a solid color frame once, then continues.
  */
-static void EarlyVideoProbe_HDD(void)
+static void EarlyVideoProbe_HDD(unsigned char r, unsigned char g, unsigned char b)
 {
     GSGLOBAL *gsGlobal = gsKit_init_global();
 
@@ -58,8 +58,8 @@ static void EarlyVideoProbe_HDD(void)
 
     gsKit_init_screen(gsGlobal);
 
-    /* Solid dark-red clear */
-    gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(0x40, 0x00, 0x00, 0x80, 0x00));
+    /* Solid color clear */
+    gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(r, g, b, 0x80, 0x00));
     gsKit_sync_flip(gsGlobal);
     gsKit_queue_exec(gsGlobal);
     gsKit_finish();
@@ -132,6 +132,8 @@ static clock_t boot_start = 0;
 static int g_booted_from_hdd = 0;
 static int g_status_line = 2;
 static int g_status_inited = 0;
+static int g_status_allow_text = 0;
+static unsigned int g_status_stage = 0;
 
 static unsigned int boot_ms(void)
 {
@@ -236,6 +238,22 @@ static void BootStatus(const char *stage)
     BootStamp(stage);
 #if defined(BOOT_HDD)
     if (g_booted_from_hdd) {
+        g_status_stage++;
+        if (!g_status_allow_text) {
+            unsigned char r = 0x20;
+            unsigned char g = 0x20;
+            unsigned char b = 0x20;
+            switch (g_status_stage % 6) {
+            case 0: r = 0x80; g = 0x00; b = 0x00; break;
+            case 1: r = 0x00; g = 0x80; b = 0x00; break;
+            case 2: r = 0x00; g = 0x00; b = 0x80; break;
+            case 3: r = 0x80; g = 0x80; b = 0x00; break;
+            case 4: r = 0x00; g = 0x80; b = 0x80; break;
+            default: r = 0x80; g = 0x00; b = 0x80; break;
+            }
+            EarlyVideoProbe_HDD(r, g, b);
+            return;
+        }
         if (!g_status_inited) {
             init_scr();
             scr_setfontcolor(0xffffff);
@@ -405,21 +423,7 @@ int main(int argc, char * argv[])
      * Must not call SIF/IOP routines (no SifInitRpc, no fileXio, no stat).
      * If this does not show when launching from HDD, we are not reaching main().
      */
-    init_scr();
-    scr_setfontcolor(0xffffff);
-    scr_clear();
-    scr_setXY(5, 1);
-    scr_printf("Entered main() (BOOT_HDD)\n");
-    if (ARGV0) {
-        scr_printf("ARGV0: %s\n", ARGV0);
-    }
-    /*
-     * Optional EE-only GS probe (dark red) when launched from pfs/hdd.
-     * Kept after init_scr so we always get some visible output first.
-     */
-    if (ARGV0 && (!strncmp(ARGV0, "pfs", 3) || !strncmp(ARGV0, "hdd", 3))) {
-        EarlyVideoProbe_HDD();
-    }
+    EarlyVideoProbe_HDD(0x10, 0x10, 0x40);
 #endif
     boot_start = clock();
     BootStamp("EE init start");
@@ -506,10 +510,14 @@ int main(int argc, char * argv[])
         BootStatus("fileXio init failed");
 #if defined(BOOT_HDD)
         if (g_booted_from_hdd) {
-            scr_setfontcolor(0x0000ff);
-            scr_printf("Fatal: fileXio unavailable\n");
-            scr_printf("Check iomanX/fileXio IRX\n");
-            scr_printf("Restart required\n");
+            if (!g_status_allow_text) {
+                EarlyVideoProbe_HDD(0x80, 0x00, 0x00);
+            } else {
+                scr_setfontcolor(0x0000ff);
+                scr_printf("Fatal: fileXio unavailable\n");
+                scr_printf("Check iomanX/fileXio IRX\n");
+                scr_printf("Restart required\n");
+            }
             for (;;) {
                 nopdelay();
             }
@@ -586,6 +594,8 @@ int main(int argc, char * argv[])
     // graphics (gsKit)
     BootStatus("graphics init");
     initGraphics();
+    g_status_allow_text = 1;
+    BootStatus("graphics init done");
 
     BootStatus("IOP modules (pad/sound/usb) init");
     LOAD_IRX_NARG(sio2man_irx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,6 +459,7 @@ int main(int argc, char * argv[])
      * If launched from HDD/PFS, do NOT reset the IOP (would drop the loader-owned PFS mount).
      * But we MUST still initialize SIF RPC before any module loads / RPC subsystems.
      */
+    BootStatus("SIF RPC init (begin)");
     SifInitRpc(0);
     if (!booted_from_hdd) {
         while (!SifIopReset("", 0)){};
@@ -469,8 +470,9 @@ int main(int argc, char * argv[])
         BootStatus("IOP reset (skipped: HDD boot)");
     }
 #else
+    BootStatus("SIF RPC init (begin)");
     SifInitRpc(0);
-    BootStatus("SIF RPC init");
+    BootStatus("SIF RPC init (done)");
 #endif
     
     // install sbv patch fix
@@ -502,6 +504,17 @@ int main(int argc, char * argv[])
     }
     if (!ioman_ok || !filexio_ok) {
         BootStatus("fileXio init failed");
+#if defined(BOOT_HDD)
+        if (g_booted_from_hdd) {
+            scr_setfontcolor(0x0000ff);
+            scr_printf("Fatal: fileXio unavailable\n");
+            scr_printf("Check iomanX/fileXio IRX\n");
+            scr_printf("Restart required\n");
+            for (;;) {
+                nopdelay();
+            }
+        }
+#endif
     } else {
         BootStatus("fileXio init ok");
     }


### PR DESCRIPTION
### Motivation
- Reduce black-screen hangs when booting from PFS/HDD by avoiding heavy IOP/mass stack work before graphics are available. 
- Make boot progress visible on-screen for HDD boots so the failing stage can be pinpointed without a debugger.
- Preserve minimal early IOP functionality required to load Lua scripts from PFS while avoiding IOP resets that would drop loader-owned mounts.

### Description
- Added HDD boot status helpers and globals (`g_booted_from_hdd`, `g_status_line`, `g_status_inited`) and a `BootStatus()` wrapper to log and optionally render staged messages on-screen for `BOOT_HDD` builds in `src/main.cpp`.
- Ensure `SifInitRpc()` is always called and avoid calling `SifIopReset()` when `booted_from_hdd` is detected, with visible status output for both paths.
- Kept `iomanX` and `fileXio` initialization early so scripts can be loaded from PFS, added explicit `BootStatus()` messages around their load/init and emit a failure status if `fileXio` fails.
- Deferred nonessential IOP module loads (pad/sound/USB/BDM stacks, `mmceman` probe handling moved) until after `initGraphics()` and displayed boot status around mass wait, graphics init, and subsequent IOP module initialization.

### Testing
- No automated tests were run for this change (no build/test executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847b7788c4832184452a89cca8c059)