### PR TITLE
HDD boot fixes: map HDD app_dir to pfs0, skip early chdir, add early HDD status probe, and restore legacy IOP ordering

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -62,10 +62,13 @@ if string.find(ARGV0, "^hdd0:") then
       LOG("ERROR", MODULE..".IRX", ID, RET)
     else
       System.sleep(2) -- lets give it time to get ready
-      if HDD.MountPartition(MNTPART, 1) then -- mount to "pfs1:" and NEVER USE IT FOR ANYTHING ELSE
+      if HDD.MountPartition(MNTPART, 0) then
         BOOTPATH, _, _ = string.match(BOOTPATH, "(.-)([^/]-([^%.]+))$")
+        BOOTPATH = string.gsub(BOOTPATH, "^pfs:", "pfs0:")
         System.currentDirectory(BOOTPATH)
-        LOGF("new bootpath: '%s'\n", BOOTPATH)
+        LOGF("new bootpath (pfs0): '%s'\n", BOOTPATH)
+      else
+        LOG("ERROR: HDD mount failed for", MNTPART)
       end
     end
   end

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,18 +38,19 @@ extern "C"{
 /*
  * EE-only early video probe.
  * Purpose: prove we reach main() when HDD-booted, without any SIF/IOP calls.
- * Draws a solid dark-red frame once, then continues.
+ * Draws a solid color frame once, then continues.
  */
-static void EarlyVideoProbe_HDD(void)
+static void EarlyVideoProbe_HDD(unsigned char r, unsigned char g, unsigned char b)
 {
     GSGLOBAL *gsGlobal = gsKit_init_global();
+    int mode = gsKit_check_rom();
 
     /* Safe defaults */
-    gsGlobal->Mode = GS_MODE_NTSC;
+    gsGlobal->Mode = mode;
     gsGlobal->Interlace = GS_INTERLACED;
     gsGlobal->Field = GS_FIELD;
     gsGlobal->Width = 640;
-    gsGlobal->Height = 448;
+    gsGlobal->Height = (mode == GS_MODE_PAL) ? 512 : 448;
     gsGlobal->PSM = GS_PSM_CT24;
     gsGlobal->ZBuffering = GS_SETTING_OFF;
 
@@ -58,8 +59,8 @@ static void EarlyVideoProbe_HDD(void)
 
     gsKit_init_screen(gsGlobal);
 
-    /* Solid dark-red clear */
-    gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(0x40, 0x00, 0x00, 0x80, 0x00));
+    /* Solid color clear */
+    gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(r, g, b, 0x80, 0x00));
     gsKit_sync_flip(gsGlobal);
     gsKit_queue_exec(gsGlobal);
     gsKit_finish();
@@ -129,6 +130,11 @@ char app_dir[255];
 int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
 static clock_t boot_start = 0;
+static int g_booted_from_hdd = 0;
+static int g_status_line = 2;
+static int g_status_inited = 0;
+static int g_status_allow_text = 0;
+static unsigned int g_status_stage = 0;
 
 static unsigned int boot_ms(void)
 {
@@ -228,6 +234,42 @@ static void BootStamp(const char *stage)
     DPRINTF("BOOT: %s %u\n", stage, boot_ms());
 }
 
+static void BootStatus(const char *stage)
+{
+    BootStamp(stage);
+#if defined(BOOT_HDD)
+    if (g_booted_from_hdd) {
+        g_status_stage++;
+        if (!g_status_allow_text) {
+            unsigned char r = 0x20;
+            unsigned char g = 0x20;
+            unsigned char b = 0x20;
+            switch (g_status_stage % 6) {
+            case 0: r = 0x80; g = 0x00; b = 0x00; break;
+            case 1: r = 0x00; g = 0x80; b = 0x00; break;
+            case 2: r = 0x00; g = 0x00; b = 0x80; break;
+            case 3: r = 0x80; g = 0x80; b = 0x00; break;
+            case 4: r = 0x00; g = 0x80; b = 0x80; break;
+            default: r = 0x80; g = 0x00; b = 0x80; break;
+            }
+            EarlyVideoProbe_HDD(r, g, b);
+            return;
+        }
+        if (!g_status_inited) {
+            init_scr();
+            scr_setfontcolor(0xffffff);
+            scr_clear();
+            scr_setXY(5, 1);
+            scr_printf("HDD boot status\n");
+            g_status_inited = 1;
+            g_status_line = 3;
+        }
+        scr_setXY(5, g_status_line++);
+        scr_printf("%s\n", stage);
+    }
+#endif
+}
+
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
     if (argc>=(idx+1))
@@ -271,6 +313,10 @@ static void setAppDirFromPath(const char *path)
         if (*p == '\\') {
             *p = '/';
         }
+    }
+    if (strstr(tmp, "hdd0:") != NULL && strstr(tmp, ":pfs:") != NULL) {
+        snprintf(app_dir, sizeof(app_dir), "pfs0:/");
+        return;
     }
 
     char *p = strrchr(tmp, '/');
@@ -382,21 +428,7 @@ int main(int argc, char * argv[])
      * Must not call SIF/IOP routines (no SifInitRpc, no fileXio, no stat).
      * If this does not show when launching from HDD, we are not reaching main().
      */
-    init_scr();
-    scr_setfontcolor(0xffffff);
-    scr_clear();
-    scr_setXY(5, 1);
-    scr_printf("Entered main() (BOOT_HDD)\n");
-    if (ARGV0) {
-        scr_printf("ARGV0: %s\n", ARGV0);
-    }
-    /*
-     * Optional EE-only GS probe (dark red) when launched from pfs/hdd.
-     * Kept after init_scr so we always get some visible output first.
-     */
-    if (ARGV0 && (!strncmp(ARGV0, "pfs", 3) || !strncmp(ARGV0, "hdd", 3))) {
-        EarlyVideoProbe_HDD();
-    }
+    EarlyVideoProbe_HDD(0x10, 0x10, 0x40);
 #endif
     boot_start = clock();
     BootStamp("EE init start");
@@ -420,34 +452,32 @@ int main(int argc, char * argv[])
      */
     const int booted_from_hdd =
         (boot_path[0] && (!strncmp(boot_path, "pfs", 3) || !strncmp(boot_path, "hdd0:", 5)));
+    g_booted_from_hdd = booted_from_hdd ? 1 : 0;
 
 #if defined(BOOT_HDD)
     if (booted_from_hdd) {
-        init_scr();
-        scr_setfontcolor(0xffffff);
-        scr_clear();
-        scr_setXY(5, 2);
-        scr_printf("HDD boot: starting...\n");
-        scr_printf("boot_path: %s\n", boot_path);
-        scr_printf("(If this hangs, last line indicates stage)\n");
+        BootStatus("HDD boot: starting");
+        BootStatus(boot_path);
+        BootStatus("(If this hangs, last line indicates stage)");
     }
 #endif
 
 
 #ifdef RESET_IOP
     /*
-     * If launched from HDD/PFS, do NOT reset the IOP (would drop the loader-owned PFS mount).
-     * But we MUST still initialize SIF RPC before any module loads / RPC subsystems.
+     * Always reset the IOP to match the legacy HDD boot flow.
+     * HDD boot.lua will remount based on argv0 if needed.
      */
+    BootStatus("SIF RPC init (begin)");
     SifInitRpc(0);
-    if (!booted_from_hdd) {
-        while (!SifIopReset("", 0)){};
-        while (!SifIopSync()){};
-        SifInitRpc(0);
-        BootStamp("IOP reset");
-    } else {
-        BootStamp("IOP reset (skipped: HDD boot)");
-    }
+    while (!SifIopReset("", 0)){};
+    while (!SifIopSync()){};
+    SifInitRpc(0);
+    BootStatus("IOP reset");
+#else
+    BootStatus("SIF RPC init (begin)");
+    SifInitRpc(0);
+    BootStatus("SIF RPC init (done)");
 #endif
     
     // install sbv patch fix
@@ -460,11 +490,12 @@ int main(int argc, char * argv[])
 	LOAD_IRX_NARG(ppctty_irx);
 #endif
 
+    BootStatus("iomanX load");
     bool ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
-    BootStamp("iomanX load");
     bool filexio_ok = false;
     int filexio_ret = -1;
     if (ioman_ok) {
+        BootStatus("fileXio load");
         filexio_ok = LoadIrxChecked("fileXio_irx", fileXio_irx, size_fileXio_irx, NULL, NULL);
         if (filexio_ok) {
             filexio_ret = fileXioInit();
@@ -476,57 +507,71 @@ int main(int argc, char * argv[])
     } else {
         DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
     }
-    BootStamp("fileXio load/init");
-
-	LOAD_IRX_NARG(sio2man_irx);
-    if (filexio_ok) {
-        int mmceman_id = -1;
-        int mmceman_ret = -1;
-        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
-        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
-#ifdef DEBUG
-        if (mmceman_ok) {
-            smod_mod_info_t info;
-            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
-            if (lookup_ret < 0) {
-                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
-                DumpLoadedModules();
+    if (!ioman_ok || !filexio_ok) {
+        BootStatus("fileXio init failed");
+#if defined(BOOT_HDD)
+        if (g_booted_from_hdd) {
+            if (!g_status_allow_text) {
+                EarlyVideoProbe_HDD(0x80, 0x00, 0x00);
+            } else {
+                scr_setfontcolor(0x0000ff);
+                scr_printf("Fatal: fileXio unavailable\n");
+                scr_printf("Check iomanX/fileXio IRX\n");
+                scr_printf("Restart required\n");
+            }
+            for (;;) {
+                nopdelay();
             }
         }
 #endif
-        BootStamp("mmceman load/init");
-        if (mmceman_ok) {
-            mmce_slot0_ready = -1;
-            mmce_slot1_ready = -1;
-            DPRINTF("MMCE probe deferred until MMCE page entry.\n");
+    } else {
+        BootStatus("fileXio init ok");
+    }
+
+    bool legacy_hdd_boot = booted_from_hdd ? true : false;
+    bool mass_stack_loaded = false;
+
+    /*
+     * Legacy HDD boot flow: load full IOP stack before graphics, matching the
+     * known working popstarter branch behavior.
+     */
+    if (legacy_hdd_boot) {
+        BootStatus("IOP modules (HDD legacy) init");
+        LOAD_IRX_NARG(sio2man_irx);
+        if (filexio_ok) {
+            int mmceman_id = -1;
+            int mmceman_ret = -1;
+            bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+            DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+#ifdef DEBUG
+            if (mmceman_ok) {
+                smod_mod_info_t info;
+                int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+                if (lookup_ret < 0) {
+                    DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                    DumpLoadedModules();
+                }
+            }
+#endif
+            if (mmceman_ok) {
+                mmce_slot0_ready = -1;
+                mmce_slot1_ready = -1;
+                DPRINTF("MMCE probe deferred until MMCE page entry.\n");
+            } else {
+                mmce_slot0_ready = 0;
+                mmce_slot1_ready = 0;
+            }
         } else {
+            DPRINTF("Skipping mmceman init; fileXio not ready.\n");
             mmce_slot0_ready = 0;
             mmce_slot1_ready = 0;
         }
-    } else {
-        DPRINTF("Skipping mmceman init; fileXio not ready.\n");
-        mmce_slot0_ready = 0;
-        mmce_slot1_ready = 0;
-        BootStamp("mmceman load/init (skipped)");
-    }
-    LOAD_IRX_NARG(mcman_irx);
-    LOAD_IRX_NARG(mcserv_irx);
-    initMC();
-    LOAD_IRX_NARG(padman_irx);
+        LOAD_IRX_NARG(mcman_irx);
+        LOAD_IRX_NARG(mcserv_irx);
+        initMC();
+        LOAD_IRX_NARG(padman_irx);
+        LOAD_IRX_NARG(libsd_irx);
 
-    LOAD_IRX_NARG(libsd_irx);
-
-    /*
-     * Avoid mass/USB/BDM stack initialization when we were launched from HDD/PFS.
-     * Those stacks are initialized lazily on page entry anyway.
-     */
-    int init_mass_stack = 1;
-#if defined(BOOT_HDD)
-    if (booted_from_hdd) init_mass_stack = 0;
-#endif
-
-    if (init_mass_stack) {
-        // load USB modules
         LOAD_IRX_NARG(usbd_irx);
 
         int ds3pads = 1;
@@ -538,23 +583,34 @@ int main(int argc, char * argv[])
         LOAD_IRX_NARG(bdm_irx);
         LOAD_IRX_NARG(bdmfs_fatfs_irx);
         LOAD_IRX_NARG(usbmass_bd_irx);
-        BootStamp("mass stack load");
-    } else {
-        BootStamp("mass stack load (skipped: HDD boot)");
+        LOAD_IRX_NARG(cdfs_irx);
+
+        LOAD_IRX_NARG(audsrv_irx);
+        mass_stack_loaded = true;
+        BootStatus("HDD legacy IOP init done");
+    }
+
+    /*
+     * Avoid mass/USB/BDM stack initialization when we were launched from HDD/PFS.
+     * Those stacks are initialized lazily on page entry anyway.
+     */
+    int init_mass_stack = 1;
+#if defined(BOOT_HDD)
+    if (booted_from_hdd) init_mass_stack = 0;
+#endif
+
+    if (init_mass_stack) {
+        BootStatus("mass stack deferred");
+    } else if (!mass_stack_loaded) {
+        BootStatus("mass stack skipped (HDD boot)");
     }
 
 #if defined(BOOT_MX4SIO)
     /* Load MX4SIO backend early so booting from MX4SIO works before Lua starts. */
     bool mx4sio_bd_ok = LoadIrxChecked("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
     DPRINTF("mx4sio_bd load result: ok=%d\n", mx4sio_bd_ok ? 1 : 0);
-    BootStamp("mx4sio_bd load");
+    BootStatus("mx4sio_bd load");
 #endif
-
-    if (init_mass_stack) {
-        LOAD_IRX_NARG(cdfs_irx);
-    }
-
-    LOAD_IRX_NARG(audsrv_irx);
 
     //waitUntilDeviceIsReady by fjtrujy
 
@@ -584,27 +640,88 @@ int main(int argc, char * argv[])
         wait_root[0] = '\0';
     }
     if (!strncmp(wait_root, "mass", 4)) {
-        BootStamp("mass wait begin");
+        BootStatus("mass wait begin");
         while (ret != 0 && retries > 0) {
             ret = stat(wait_root, &buffer);
             nopdelay();
             retries--;
         }
-        BootStamp("mass wait end");
+        BootStatus("mass wait end");
     } else {
-        BootStamp("mass wait (skipped)");
+        BootStatus("mass wait skipped");
     }
 	
 	// Lua init
 	// init internals library
     
     // graphics (gsKit)
+    BootStatus("graphics init");
     initGraphics();
+    g_status_allow_text = 1;
+    BootStatus("graphics init done");
 
+    if (!legacy_hdd_boot) {
+        BootStatus("IOP modules (pad/sound/usb) init");
+        LOAD_IRX_NARG(sio2man_irx);
+        if (filexio_ok) {
+            int mmceman_id = -1;
+            int mmceman_ret = -1;
+            bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+            DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+#ifdef DEBUG
+            if (mmceman_ok) {
+                smod_mod_info_t info;
+                int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+                if (lookup_ret < 0) {
+                    DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                    DumpLoadedModules();
+                }
+            }
+#endif
+            if (mmceman_ok) {
+                mmce_slot0_ready = -1;
+                mmce_slot1_ready = -1;
+                DPRINTF("MMCE probe deferred until MMCE page entry.\n");
+            } else {
+                mmce_slot0_ready = 0;
+                mmce_slot1_ready = 0;
+            }
+        } else {
+            DPRINTF("Skipping mmceman init; fileXio not ready.\n");
+            mmce_slot0_ready = 0;
+            mmce_slot1_ready = 0;
+        }
+        LOAD_IRX_NARG(mcman_irx);
+        LOAD_IRX_NARG(mcserv_irx);
+        initMC();
+        LOAD_IRX_NARG(padman_irx);
+        LOAD_IRX_NARG(libsd_irx);
+        LOAD_IRX_NARG(audsrv_irx);
+
+        if (init_mass_stack) {
+            // load USB modules
+            LOAD_IRX_NARG(usbd_irx);
+
+            int ds3pads = 1;
+            LOAD_IRX(ds34usb_irx, 4, (char *)&ds3pads);
+            LOAD_IRX(ds34bt_irx, 4, (char *)&ds3pads);
+            ds34usb_init();
+            ds34bt_init();
+
+            LOAD_IRX_NARG(bdm_irx);
+            LOAD_IRX_NARG(bdmfs_fatfs_irx);
+            LOAD_IRX_NARG(usbmass_bd_irx);
+            LOAD_IRX_NARG(cdfs_irx);
+        }
+    }
+
+    BootStatus("pad init");
     pad_init();
 
     // set base path luaplayer
-    chdir(boot_path); 
+    if (!booted_from_hdd) {
+        chdir(boot_path);
+    }
 
     DPRINTF("boot path : %s\n", boot_path);
 	dbgprintf("boot path : %s\n", boot_path);


### PR DESCRIPTION
### Motivation
- Prevent persistent black-screen hangs on HDD boot by avoiding operations that assume the HDD partition is already mounted and by aligning runtime asset resolution with the remounted partition.
- Provide early visual feedback before full graphics are available so boot stages and stalls are observable on HDD boots.
- Restore a legacy IOP/module initialization ordering for HDD boots to match the known-working POPStarter flow and reduce deadlocks.

### Description
- Map HDD `argv0` paths containing `hdd0:` and `:pfs:` to `pfs0:/` for `app_dir` via `setAppDirFromPath(...)` so asset resolution points at the remounted partition instead of the original pre-mount path (changed in `src/main.cpp`).
- Avoid calling `chdir(boot_path)` before Lua when `booted_from_hdd` to prevent changing into an unmounted `hdd0:...:pfs:` directory that can hang early boot (changed in `src/main.cpp`).
- Add `BootStatus(...)` and stages to emit early colored frames via `EarlyVideoProbe_HDD(r,g,b)` and later text lines once graphics are initialized so the boot stage is visible during pre-graphics failures (changed `src/main.cpp`).
- Make `EarlyVideoProbe_HDD` accept an RGB triple and choose a safe height/mode via `gsKit_check_rom()` to avoid incorrect GS modes on PAL/NTSC (changed `src/main.cpp`).
- Rework SIF/IOP handling and module loading: perform `SifIopReset`/`SifIopSync` and reinitialize RPC, add guarded `fileXio` initialization with a visible fatal path for HDD boots, and restore legacy pre-graphics module loads (e.g. `sio2man`, `mmceman`, `mcman`, `mcserv`, `padman`, `libsd`, USB/BDM modules) when `booted_from_hdd` so the IOP ordering matches the known-working flow (changed `src/main.cpp`).
- Defer or skip heavy mass/USB stack initialization on HDD boot and add `FixupMassGenericPath(...)` behavior to rewrite `mass:/` to `massN:/` when present (changed `src/main.cpp`).
- Improve Lua bootstrap robustness in `etc/boot.lua` by normalizing `APP_DIR` and `package.path`, adding `BOOT_PROF` timing stamps, remounting the detected HDD partition to `pfs0` and normalizing `BOOTPATH`, providing `ReadWholeFile` / `LoadLuaFile` with sanitization fallback, and switching `RunScript` to use the safer loader flow; also switch to `System.resolveAsset("system.lua")` when locating the app entry.
- Miscellaneous build/packaging tweaks and IRX embedding adjustments were made in the `Makefile` (variant-aware output paths and embedded IRX entries). 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847b7788c4832184452a89cca8c059)