### PR TITLE
Add HDD boot diagnostics instrumentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ RESET_IOP = 1
 #---------------------- enable DEBUGGING MODE ---------------------#
 DEBUG = 0
 #----------------------- Build variant (boot) ----------------------#
-# mmce | mx4sio | hdd
+# mmce | mx4sio | hdd | hdd_diag
 VARIANT ?= mmce
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
@@ -73,13 +73,17 @@ ifeq ($(VARIANT),hdd)
 EE_CFLAGS   += -DBOOT_HDD
 EE_CXXFLAGS += -DBOOT_HDD
 endif
+ifeq ($(VARIANT),hdd_diag)
+EE_CFLAGS   += -DBOOT_HDD -DBOOT_DIAG
+EE_CXXFLAGS += -DBOOT_HDD -DBOOT_DIAG
+endif
 
 BIN2S = $(PS2SDK)/bin/bin2c
 
 #-------------------------- App Content ---------------------------#
 EXT_LIBS = modules/ds34usb/ee/libds34usb.a modules/ds34bt/ee/libds34bt.a
 
-APP_CORE = main.o system.o pad.o graphics.o render.o \
+APP_CORE = main.o system.o pad.o graphics.o render.o bootdiag.o \
 		   calc_3d.o gsKit3d_sup.o atlas.o fntsys.o md5.o \
 		   sound.o #strUtils.o
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -13,6 +13,12 @@ function LOGF(S, ...)
   print_uart(string.format(S, ...))
 end
 
+local function DIAG_LOG(msg)
+  if BOOT_DIAG and System.bootLog ~= nil then
+    System.bootLog(msg)
+  end
+end
+
 BOOT_PROF = {
   timer = Timer.new(),
   stamp = function (label)
@@ -21,6 +27,7 @@ BOOT_PROF = {
   end
 }
 BOOT_PROF.stamp("Lua init start")
+DIAG_LOG("Lua init start")
 
 POPSLDR_VER = "v1.0.0 - rev3"
 
@@ -99,12 +106,27 @@ BOOT_PROF.stamp("UI assets init (fonts)")
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end
 
 local function ReadWholeFile(path)
+  if BOOT_DIAG then
+    DIAG_LOG("ReadWholeFile start: "..path)
+  end
+  local timeout_ms = 3000
+  local timer = nil
+  if BOOT_DIAG then
+    timer = Timer.new()
+  end
   local fd = System.openFile(path, FREAD)
   if fd == nil then
     return nil, "open failed"
   end
   local chunks = {}
   while true do
+    if BOOT_DIAG and timer ~= nil then
+      if Timer.getTime(timer) > timeout_ms then
+        DIAG_LOG("HANG AT: ReadWholeFile("..path..")")
+        System.closeFile(fd)
+        return nil, "read timeout"
+      end
+    end
     local buffer = System.readFile(fd, 4096)
     if buffer == nil or buffer == "" then
       break
@@ -112,12 +134,21 @@ local function ReadWholeFile(path)
     chunks[#chunks + 1] = buffer
   end
   System.closeFile(fd)
+  if BOOT_DIAG then
+    DIAG_LOG("ReadWholeFile done: "..path)
+  end
   return table.concat(chunks)
 end
 
 local function LoadLuaFile(path)
+  if BOOT_DIAG then
+    DIAG_LOG("LoadLuaFile start: "..path)
+  end
   local loader, load_err = loadfile(path)
   if loader ~= nil then
+    if BOOT_DIAG then
+      DIAG_LOG("LoadLuaFile loadfile ok: "..path)
+    end
     return loader
   end
   LOG("Lua load failed:", load_err)
@@ -128,6 +159,9 @@ local function LoadLuaFile(path)
   local sanitized, count = string.gsub(data, "[\128-\255]", "?")
   if count > 0 then
     LOGF("Sanitized %d non-ASCII bytes in %s", count, path)
+  end
+  if BOOT_DIAG then
+    DIAG_LOG("LoadLuaFile loadstring: "..path)
   end
   return loadstring(sanitized, "@"..path)
 end
@@ -145,6 +179,9 @@ end
 
 local SYS = System.resolveAsset("system.lua")
 if SYS ~= nil then
+  if BOOT_DIAG then
+    DIAG_LOG("Resolved system.lua: "..SYS)
+  end
 	RunScript(SYS);
 else
   error("Cant access POPSLDR/system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory())

--- a/src/bootdiag.cpp
+++ b/src/bootdiag.cpp
@@ -1,0 +1,73 @@
+#include "include/bootdiag.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <debug.h>
+
+static int boot_log_slot = -1;
+static char boot_log_path[32] = {0};
+
+static int BootDiagOpenLog(void)
+{
+	if (boot_log_slot >= 0 && boot_log_path[0]) {
+		return open(boot_log_path, O_WRONLY | O_CREAT | O_APPEND, 0666);
+	}
+
+	const char *paths[] = {"mc0:/POPSLDR.LOG", "mc1:/POPSLDR.LOG"};
+	for (size_t i = 0; i < (sizeof(paths) / sizeof(paths[0])); ++i) {
+		int fd = open(paths[i], O_WRONLY | O_CREAT | O_APPEND, 0666);
+		if (fd >= 0) {
+			boot_log_slot = (int)i;
+			snprintf(boot_log_path, sizeof(boot_log_path), "%s", paths[i]);
+			return fd;
+		}
+	}
+	return -1;
+}
+
+void BootDiagLog(const char *fmt, ...)
+{
+#if defined(BOOT_DIAG)
+	char buffer[256];
+	va_list args;
+	va_start(args, fmt);
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
+	va_end(args);
+
+	size_t len = strnlen(buffer, sizeof(buffer));
+	if (len + 1 < sizeof(buffer)) {
+		buffer[len] = '\n';
+		buffer[len + 1] = '\0';
+		len += 1;
+	}
+
+	int fd = BootDiagOpenLog();
+	if (fd < 0) {
+		return;
+	}
+	write(fd, buffer, len);
+	close(fd);
+#else
+	(void)fmt;
+#endif
+}
+
+void BootDiagHeartbeat(const char *stage)
+{
+#if defined(BOOT_DIAG)
+	static int stage_index = 0;
+	init_scr();
+	scr_setfontcolor(0x00ff00);
+	scr_clear();
+	scr_setXY(2, 1);
+	scr_printf("BOOT DIAG %d\n", stage_index++);
+	if (stage) {
+		scr_printf("%s\n", stage);
+	}
+#else
+	(void)stage;
+#endif
+}

--- a/src/include/bootdiag.h
+++ b/src/include/bootdiag.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void BootDiagLog(const char *fmt, ...);
+void BootDiagHeartbeat(const char *stage);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -9,6 +9,7 @@
 #include "include/luaplayer.h"
 #include "include/graphics.h"
 #include "include/dprintf.h"
+#include "include/bootdiag.h"
 
 #ifndef FORBID_LUA_ATPANIC_TEXTDUMP
 #define LOGDUMP(x...) if (LOG != NULL) fprintf(x)
@@ -37,6 +38,7 @@ int test_error(lua_State * L) {
     int i;
         scr_printf("\t");
     TPRINTF("LUA ERR.\n");
+    BootDiagLog("LUA panic handler invoked");
 
     if (n == 0) {
         scr_printf("\t");
@@ -121,9 +123,10 @@ const char * runScript(const char* script, bool isStringBuffer )
 		
 	if (s == 0) s = lua_pcall(L, 0, LUA_MULTRET, 0);
 
-	if (s) {
+    if (s) {
 		sprintf((char*)errMsg, "%s\n", lua_tostring(L, -1));
     DPRINTF("%s\n", lua_tostring(L, -1));
+		BootDiagLog("Lua error: %s", lua_tostring(L, -1));
 		lua_pop(L, 1); // remove error message
 	}
 	lua_close(L);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -17,6 +17,7 @@
 
 #include "include/system.h"
 #include "include/dprintf.h"
+#include "include/bootdiag.h"
 
 #define MAX_DIR_FILES 512
 
@@ -638,14 +639,27 @@ static int lua_getmcinfo(lua_State *L){
 }
 
 static int lua_openfile(lua_State *L){
+	static bool first_open_logged = false;
 	int argc = lua_gettop(L);
 	if (argc != 2) return luaL_error(L, "wrong number of arguments");
 	const char *file_tbo = luaL_checkstring(L, 1);
 	int type = luaL_checkinteger(L, 2);
+	if (!first_open_logged) {
+		BootDiagLog("System.openFile first: %s mode=%d", file_tbo ? file_tbo : "<null>", type);
+		first_open_logged = true;
+	}
 	int fileHandle = open(file_tbo, type, 0777);
 	if (fileHandle < 0) return luaL_error(L, "cannot open '%s'\n\tfd:%d.", file_tbo, fileHandle);
 	lua_pushinteger(L,fileHandle);
 	return 1;
+}
+
+static int lua_bootlog(lua_State *L){
+	int argc = lua_gettop(L);
+	if (argc < 1) return 0;
+	const char *msg = luaL_checkstring(L, 1);
+	BootDiagLog("LUA: %s", msg ? msg : "<null>");
+	return 0;
 }
 
 
@@ -1071,6 +1085,7 @@ static const luaL_Reg System_functions[] = {
 	{"removeFile",               lua_removeFile},
 	{"rename",                       lua_rename},
 	{"md5sum",                       lua_md5sum},
+	{"bootLog",                    lua_bootlog},
 	{"sleep",                         lua_sleep},
 	{"getFreeMemory",         lua_getFreeMemory},
 	{"exitToBrowser",                  lua_exit},
@@ -1213,6 +1228,13 @@ void luaSystem_init(lua_State *L) {
 
 	lua_pushinteger(L, SEEK_CUR);
 	lua_setglobal(L, "CUR");
+
+#if defined(BOOT_DIAG)
+	lua_pushboolean(L, 1);
+#else
+	lua_pushboolean(L, 0);
+#endif
+	lua_setglobal(L, "BOOT_DIAG");
 
 	lua_pushinteger(L, 1);
 	lua_setglobal(L, "READ_ONLY");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "include/luaplayer.h"
 #include "include/pad.h"
 #include "include/dprintf.h"
+#include "include/bootdiag.h"
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
@@ -272,6 +273,7 @@ static bool RemountHddPartitionFromBootPath(const char *argv0)
     if (!ExtractHddPartitionPath(boot_path, hdd_part, sizeof(hdd_part))) {
         if (!ExtractHddPartitionPath(argv0, hdd_part, sizeof(hdd_part))) {
             DPRINTF("HDD remount: unable to derive partition from boot path.\n");
+            BootDiagLog("HDD remount: unable to derive partition (boot_path=%s argv0=%s)", boot_path, argv0 ? argv0 : "<null>");
             return false;
         }
     }
@@ -281,11 +283,17 @@ static bool RemountHddPartitionFromBootPath(const char *argv0)
     char pfs_root[6] = "pfs0:";
     pfs_root[3] = '0' + pfs_index;
 
+    BootDiagHeartbeat("HDD mount pre");
+    BootDiagLog("HDD remount: mount %s -> %s", hdd_part, pfs_root);
     int mount_ret = fileXioMount(pfs_root, hdd_part, FIO_MT_RDWR);
+    BootDiagHeartbeat("HDD mount post");
+    BootDiagLog("HDD remount: mount ret=%d", mount_ret);
     if (mount_ret < 0) {
         DPRINTF("HDD remount: mount failed (%d), retrying after unmount.\n", mount_ret);
+        BootDiagLog("HDD remount: retry after umount ret=%d", mount_ret);
         fileXioUmount(pfs_root);
         mount_ret = fileXioMount(pfs_root, hdd_part, FIO_MT_RDWR);
+        BootDiagLog("HDD remount: mount retry ret=%d", mount_ret);
     }
 
     if (mount_ret < 0) {
@@ -296,6 +304,7 @@ static bool RemountHddPartitionFromBootPath(const char *argv0)
     RewritePathWithPfsRoot(pfs_root, boot_path, sizeof(boot_path));
     RewritePathWithPfsRoot(pfs_root, app_dir, sizeof(app_dir));
     DPRINTF("HDD remount: %s mounted to %s (boot_path=%s, app_dir=%s).\n", hdd_part, pfs_root, boot_path, app_dir);
+    BootDiagLog("HDD remount ok: %s -> %s boot_path=%s app_dir=%s", hdd_part, pfs_root, boot_path, app_dir);
     return true;
 }
 
@@ -475,6 +484,8 @@ int main(int argc, char * argv[])
         EarlyVideoProbe_HDD();
     }
 #endif
+    BootDiagHeartbeat("Entered main()");
+    BootDiagLog("Entered main() argv0=%s argc=%d", ARGV0 ? ARGV0 : "<null>", argc);
     boot_start = clock();
     BootStamp("EE init start");
 
@@ -485,6 +496,7 @@ int main(int argc, char * argv[])
     } else {
         setAppDirFromPath(boot_path);
     }
+    BootDiagLog("boot_path=%s app_dir=%s", boot_path, app_dir);
     BootStamp("boot path parse");
 
     /*
@@ -497,6 +509,7 @@ int main(int argc, char * argv[])
      */
     const int booted_from_hdd =
         (boot_path[0] && (!strncmp(boot_path, "pfs", 3) || !strncmp(boot_path, "hdd0:", 5)));
+    BootDiagLog("booted_from_hdd=%d boot_path=%s", booted_from_hdd, boot_path);
 
 #if defined(BOOT_HDD)
     if (booted_from_hdd) {
@@ -516,14 +529,23 @@ int main(int argc, char * argv[])
      * If launched from HDD/PFS, do NOT reset the IOP (would drop the loader-owned PFS mount).
      * But we MUST still initialize SIF RPC before any module loads / RPC subsystems.
      */
+    BootDiagHeartbeat("SifInitRpc pre");
+    BootDiagLog("SifInitRpc pre");
     SifInitRpc(0);
+    BootDiagHeartbeat("SifInitRpc post");
+    BootDiagLog("SifInitRpc post");
     if (!booted_from_hdd) {
+        BootDiagHeartbeat("SifIopReset pre");
+        BootDiagLog("SifIopReset pre");
         while (!SifIopReset("", 0)){};
         while (!SifIopSync()){};
+        BootDiagHeartbeat("SifIopReset post");
+        BootDiagLog("SifIopReset post");
         SifInitRpc(0);
         BootStamp("IOP reset");
     } else {
         BootStamp("IOP reset (skipped: HDD boot)");
+        BootDiagLog("IOP reset skipped (HDD boot)");
     }
 #endif
     
@@ -546,12 +568,16 @@ int main(int argc, char * argv[])
     }
 
     bool ioman_ok = false;
+    BootDiagHeartbeat("iomanX load pre");
+    BootDiagLog("iomanX load pre");
     if (ioman_loaded) {
         ioman_ok = true;
         DPRINTF("iomanX already loaded; skipping reload to preserve PFS mount.\n");
     } else {
         ioman_ok = LoadIrxChecked("iomanX_irx", iomanX_irx, size_iomanX_irx, NULL, NULL);
     }
+    BootDiagHeartbeat("iomanX load post");
+    BootDiagLog("iomanX load post ok=%d", ioman_ok ? 1 : 0);
     BootStamp("iomanX load");
     bool filexio_ok = false;
     int filexio_ret = -1;
@@ -560,6 +586,8 @@ int main(int argc, char * argv[])
             filexio_ok = true;
             DPRINTF("fileXio already loaded; skipping reload/init to preserve PFS mount.\n");
         } else {
+            BootDiagHeartbeat("fileXio load pre");
+            BootDiagLog("fileXio load pre");
             filexio_ok = LoadIrxChecked("fileXio_irx", fileXio_irx, size_fileXio_irx, NULL, NULL);
             if (filexio_ok) {
                 filexio_ret = fileXioInit();
@@ -568,9 +596,12 @@ int main(int argc, char * argv[])
                     filexio_ok = false;
                 }
             }
+            BootDiagHeartbeat("fileXio load post");
+            BootDiagLog("fileXio load post ok=%d ret=%d", filexio_ok ? 1 : 0, filexio_ret);
         }
     } else {
         DPRINTF("Skipping fileXio init; iomanX failed to load.\n");
+        BootDiagLog("Skipping fileXio init (iomanX failed)");
     }
     BootStamp("fileXio load/init");
 
@@ -615,7 +646,11 @@ int main(int argc, char * argv[])
     }
     LOAD_IRX_NARG(mcman_irx);
     LOAD_IRX_NARG(mcserv_irx);
+    BootDiagHeartbeat("initMC pre");
+    BootDiagLog("initMC pre");
     initMC();
+    BootDiagHeartbeat("initMC post");
+    BootDiagLog("initMC post");
     LOAD_IRX_NARG(padman_irx);
 
     LOAD_IRX_NARG(libsd_irx);
@@ -703,7 +738,11 @@ int main(int argc, char * argv[])
 	// init internals library
     
     // graphics (gsKit)
+    BootDiagHeartbeat("GS init pre");
+    BootDiagLog("GS init pre");
     initGraphics();
+    BootDiagHeartbeat("GS init post");
+    BootDiagLog("GS init post");
 
     pad_init();
 
@@ -715,7 +754,14 @@ int main(int argc, char * argv[])
     DPRINTF("app dir : %s\n", app_dir);
 	dbgprintf("app dir : %s\n", app_dir);
     
+    {
+        char cwd[256];
+        if (getcwd(cwd, sizeof(cwd)) != NULL) {
+            BootDiagLog("cwd=%s", cwd);
+        }
+    }
     BootStamp("Lua init start");
+    BootDiagHeartbeat("Lua init start");
     while (1)
     {
         errMsg = runScript(bootString, true);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -10,6 +10,7 @@
 #include "include/system.h"
 #include "include/luaplayer.h"
 #include "include/dprintf.h"
+#include "include/bootdiag.h"
 
 //extern int size_loader_elf;
 
@@ -79,12 +80,22 @@ char* __ps2_normalize_path(char *path_name)
 
 int ResolveAssetPath(char* out, size_t outsz, const char* relativeName)
 {
+	static bool first_asset_logged = false;
 	if (!out || outsz == 0 || !relativeName) return 0;
+
+	if (!first_asset_logged) {
+		BootDiagLog("asset resolve start: %s", relativeName);
+	}
 
 	if (strchr(relativeName, ':') != NULL) {
 		snprintf(out, outsz, "%s", relativeName);
 		struct stat st;
-		return (stat(out, &st) == 0);
+		int ok = (stat(out, &st) == 0);
+		if (!first_asset_logged) {
+			BootDiagLog("asset resolve direct: %s ok=%d", out, ok);
+			first_asset_logged = true;
+		}
+		return ok;
 	}
 
 	char candidate[255];
@@ -94,6 +105,10 @@ int ResolveAssetPath(char* out, size_t outsz, const char* relativeName)
 	if (stat(candidate, &st) == 0) {
 		DPRINTF("ResolveAssetPath: %s\n", candidate);
 		snprintf(out, outsz, "%s", candidate);
+		if (!first_asset_logged) {
+			BootDiagLog("asset resolve ok: %s", candidate);
+			first_asset_logged = true;
+		}
 		return 1;
 	}
 
@@ -101,6 +116,10 @@ int ResolveAssetPath(char* out, size_t outsz, const char* relativeName)
 	if (stat(candidate, &st) == 0) {
 		DPRINTF("ResolveAssetPath: %s\n", candidate);
 		snprintf(out, outsz, "%s", candidate);
+		if (!first_asset_logged) {
+			BootDiagLog("asset resolve ok: %s", candidate);
+			first_asset_logged = true;
+		}
 		return 1;
 	}
 
@@ -116,16 +135,28 @@ int ResolveAssetPath(char* out, size_t outsz, const char* relativeName)
 		if (stat(candidate, &st) == 0) {
 			DPRINTF("ResolveAssetPath: %s\n", candidate);
 			snprintf(out, outsz, "%s", candidate);
+			if (!first_asset_logged) {
+				BootDiagLog("asset resolve ok: %s", candidate);
+				first_asset_logged = true;
+			}
 			return 1;
 		}
 		snprintf(candidate, sizeof(candidate), "%sPOPSLDR/%s", cwd, relativeName);
 		if (stat(candidate, &st) == 0) {
 			DPRINTF("ResolveAssetPath: %s\n", candidate);
 			snprintf(out, outsz, "%s", candidate);
+			if (!first_asset_logged) {
+				BootDiagLog("asset resolve ok: %s", candidate);
+				first_asset_logged = true;
+			}
 			return 1;
 		}
 	}
 
+	if (!first_asset_logged) {
+		BootDiagLog("asset resolve failed: %s", relativeName);
+		first_asset_logged = true;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
### Motivation
- The HDD boot case still yields a black screen and we need deterministic, early visibility into whether the EE reaches main(), if SIF/IOP is dead, or if a blocking HDD I/O is hanging the process. 
- Add minimal, non-invasive instrumentation that works even when HDD/PFS is broken so failure stage can be recorded from a single test run.

### Description
- Add a small diagnostics helper exposing `BootDiagLog(...)` and `BootDiagHeartbeat(...)` that writes append-only breadcrumbs to `mc0:/POPSLDR.LOG` (fallback `mc1:`) and can draw an on-screen heartbeat; files added: `src/include/bootdiag.h` and `src/bootdiag.cpp` and wired into the app. 
- Wire diagnostics into EE early boot checkpoints in `src/main.cpp` to record `main()` entry, `SifInitRpc`/`SifIopReset` boundaries, IOP IRX loads (`iomanX`/`fileXio`), HDD mount attempts and results, `initMC()` and GS init stages, and emit `BootDiagHeartbeat` updates for on-screen visibility. 
- Add asset-resolution and first-file-access instrumentation in `src/system.cpp` and `src/luasystem.cpp`, exposing a new Lua-callable `System.bootLog` (`System.bootLog` / `System.bootLog` via `lua_bootlog`) and logging the first `System.openFile` seen from Lua. 
- Add Lua-side diagnostics in `etc/boot.lua` including `DIAG_LOG` wrappers, a watchdog timeout around `ReadWholeFile` (3s) that logs `HANG AT: ReadWholeFile(...)`, and diagnostic logs around `LoadLuaFile` and the resolved `system.lua` path. 
- Surface Lua panic and runtime errors to the boot log via `src/luaplayer.cpp` so Lua crashes also yield a breadcrumb. 
- Introduce a dedicated build variant `hdd_diag` and `BOOT_DIAG` compile flag in the `Makefile` and add `bootdiag.o` to `APP_CORE` so diagnostics can be enabled without other behavioral changes by building `VARIANT=hdd_diag`.

### Testing
- No automated tests were executed for these changes; the PR contains diagnostic-only instrumentation and no functional boot-path logic was altered beyond logging/timeouts. 
- The changes were compiled into the tree (committed) but no build or runtime validation was run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ca7961388321a8757ea87389751c)