### PR TITLE
Add minimal non-HDD session list cache with manual refresh

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -eu
           make clean
-          make
+          make elfloader all
           make package
 
       - name: Upload artifact

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,10 +15,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [mmce, mx4sio, hdd]
     steps:
       - name: Install dependencies
         run: |
@@ -40,14 +36,16 @@ jobs:
           BUILD_UTC="$(date -u '+%Y-%m-%d %H:%MZ')"
           printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
 
-      - name: Compile and package (${{ matrix.variant }})
+      - name: Compile and package
         shell: sh
         run: |
           set -eu
-          make clean elfloader all package VARIANT=${{ matrix.variant }}
+          make clean
+          make
+          make package
 
-      - name: Upload artifact (${{ matrix.variant }})
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: POPSLoader-${{ matrix.variant }}
-          path: POPSLoader-${{ matrix.variant }}.7z
+          name: POPSLoader
+          path: POPSLoader.7z

--- a/BOOT_HARDENING.md
+++ b/BOOT_HARDENING.md
@@ -1,0 +1,38 @@
+# BOOT_HARDENING.md
+
+## boot_dir derivation
+- `boot_dir` is derived from `argv0` in `setLuaBootPath(...)`.
+- If `argv0` ends with `.elf` (case-insensitive), `boot_dir` is set to the containing directory.
+- Otherwise, `argv0` is treated as a directory-like path.
+- Path separators are normalized (`\` → `/`) and `NormalizeDirPath(...)` enforces trailing `/` and device-path normalization.
+
+## runtime gating rules
+- Runtime boot classification is computed from `boot_path`/`argv0` prefixes/content:
+  - `is_pfs_boot`: starts with `pfs` or contains `hdd0:`
+  - `is_mass_boot`: starts with `mass`
+  - `is_mmce_boot`: starts with `mmce`
+  - `is_mx4sio_boot`: starts with `mx4sio`
+- Safety behavior:
+  - If `is_pfs_boot`, mass/USB stack is not initialized at boot.
+  - Mass wait retry loop runs only when `is_mass_boot`.
+  - No early MX4SIO backend load at boot; MX4SIO initialization remains runtime (`System.initMX4SIO`).
+- `chdir(boot_dir)` is always attempted; on failure, diagnostics include `boot_dir`, `argv0`, and `errno`.
+
+## entry script search order (flat-first)
+1. `boot_dir .. "system.lua"`
+2. `boot_dir .. "POPSLDR/system.lua"`
+3. `"system.lua"` (relative)
+4. `"POPSLDR/system.lua"` (relative)
+
+If all attempts fail, the Lua error contains:
+- `boot_dir`
+- `cwd`
+- `argv0`
+- attempted paths list
+- last loader error
+
+## hardware validation checklist (YES/NO)
+- boots to UI from USB/mass: NO
+- boots to UI from HDD/PFS: NO
+- entering MX4SIO page still works (init occurs there, not at boot): NO
+- missing script produces error screen with attempted paths (not black screen): NO

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ RESET_IOP = 1
 DEBUG = 0
 #----------------------- Build variant (boot) ----------------------#
 # mmce | mx4sio | hdd | hdd_diag
-VARIANT ?= mmce
+VARIANT ?= universal
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#
 
 BINDIR = bin/
 EE_BIN = $(BINDIR)enceladus.elf
-EE_BIN_PKD = $(BINDIR)POPSLOADER_$(VARIANT).ELF
+EE_BIN_PKD = $(BINDIR)POPSLOADER.ELF
 EE_LIBS = -L$(PS2SDK)/ports/lib -L$(PS2DEV)/gsKit/lib/ -Lmodules/ds34bt/ee/ -Lmodules/ds34usb/ee/ -lpatches -lfileXio -lpad -ldebug -llua -lmath3d -ljpeg -lfreetype -lgskit_toolkit -lgskit -ldmakit -lpng -lz -lmc -laudsrv  -lds34bt -lds34usb
 EE_LIBS += src/elf_loader/libcustom-elf-loader.a
 EE_INCS += -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(PS2SDK)/ports/include/zlib
@@ -58,24 +58,6 @@ endif
 
 ifeq ($(DEBUG),1)
 EE_CXXFLAGS += -DDEBUG
-endif
-
-#----------------------- Variant compile defines -----------------#
-ifeq ($(VARIANT),mmce)
-EE_CFLAGS   += -DBOOT_MMCE
-EE_CXXFLAGS += -DBOOT_MMCE
-endif
-ifeq ($(VARIANT),mx4sio)
-EE_CFLAGS   += -DBOOT_MX4SIO
-EE_CXXFLAGS += -DBOOT_MX4SIO
-endif
-ifeq ($(VARIANT),hdd)
-EE_CFLAGS   += -DBOOT_HDD
-EE_CXXFLAGS += -DBOOT_HDD
-endif
-ifeq ($(VARIANT),hdd_diag)
-EE_CFLAGS   += -DBOOT_HDD -DBOOT_DIAG
-EE_CXXFLAGS += -DBOOT_HDD -DBOOT_DIAG
 endif
 
 BIN2S = $(PS2SDK)/bin/bin2c
@@ -201,7 +183,7 @@ run:
 reset:
 	ps2client -h $(PS2LINK_IP) reset   
 
-POPSLDR_PKG = POPSLoader-$(VARIANT).7z
+POPSLDR_PKG = POPSLoader.7z
 PKG_DIR = bin/package
 package: $(EE_BIN_PKD)
 	# Remove both possible output locations (older CI/scripts sometimes expected the archive in bin/).

--- a/PERF_MAP_ADDENDUM.md
+++ b/PERF_MAP_ADDENDUM.md
@@ -1,0 +1,125 @@
+# PERF_MAP_ADDENDUM — Phase 0 UNKNOWN Resolution and Call-Site Enumeration (No Code Changes)
+
+This addendum resolves specific Phase 0 unknowns and enumerates required call sites.
+
+---
+
+## 1) Resolution of prior UNKNOWN items
+
+### 1a) `UI.OnSceneEnter` definition status (repo-wide)
+
+#### Search result
+- Repo-wide search found **usage** of `UI.OnSceneEnter(...)` in transition code, but no function definition assignment (no `function UI.OnSceneEnter(...)` and no `UI.OnSceneEnter = function(...)`).
+- The transition calls it conditionally (`if UI.OnSceneEnter ~= nil then ...`), which currently means no-op unless injected externally at runtime.
+
+#### Where it is referenced
+- `bin/POPSLDR/ui.lua` — inside `UI.Transition.Update()`:
+  - `UI.OnSceneEnter(previous_scene, UI.CURSCENE)` at transition midpoint after writing `UI.CURSCENE`.
+
+#### Behavioral conclusion
+- **Definition status:** not defined in current repository source.
+- **Effect on scene enter:** none by default from in-repo code.
+- **Scans/list rebuild/I/O on scene enter:** none attributable to `UI.OnSceneEnter` in current static repo state, because no in-repo implementation exists.
+
+---
+
+### 1b) SMB registration/usability from runtime init
+
+#### What exists
+- `src/luaSMB.cpp` exists and contains SMB helper code (`smbLogon_Server`, SMB devctl use).
+
+#### Runtime registration check
+- Lua VM/library registration in `runScript(...)` (`src/luaplayer.cpp`) calls:
+  - `luaGraphics_init`, `luaControls_init`, `luaScreen_init`, `luaTimer_init`, `luaSystem_init`, `luaSound_init`, `luaRender_init`, `luaHDD_init`.
+- There is no `luaSMB_init(...)` call in this runtime init sequence.
+- `src/include/luaplayer.h` declares `luaHDD_init` etc., but no `luaSMB_init` declaration.
+
+#### Conclusion
+- SMB Lua module appears **inert/dead from current runtime init path** (compiled source exists, but no observed registration/initialization hookup in active Lua boot path).
+- Note: launch policy logic still includes SMB string branches in Lua (`source_mode == "smb"`), but that does not by itself prove active SMB module registration.
+
+---
+
+### 1c) Any runtime flip of `PLDR.HDD.USECACHE` to `true`
+
+#### Static findings
+- Default initialization sets `PLDR.HDD.USECACHE = false`.
+- Additional references only read it in conditionals:
+  - read in `PLDR.HDD.BuildGameList()` to optionally use `PLDR.HDDCACHE`
+  - read in `PLDR.HDD.CreateCache()` early return guard.
+- Repo-wide search found **no assignment** that sets `PLDR.HDD.USECACHE = true`.
+
+#### Conclusion
+- No in-repo runtime path was found that flips HDD cache usage on.
+
+---
+
+## 2) Enumerate call sites
+
+### 2a) `PLDR.CleanupGameList()` call sites
+
+All discovered call sites are in `bin/POPSLDR/ui.lua`, in `UI.MainMenu.Play()` under confirm handling (main menu option selection):
+
+1. **MMCE path, no MMCE slots found**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 1 + empty `PLDR.GetMMCESlots()`.
+2. **MMCE path, MMCE present**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 1 + valid MMCE prefix.
+3. **MX4SIO path, IOCTL-detected mass backend (`sdc`)**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 2 + `PLDR.FindMassByDriver("sdc", 4)` success.
+4. **MX4SIO path, `System.initMX4SIO` fallback success**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 2 + fallback init success.
+5. **HDD/PFS path (conditional)**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 4; called unless `UI.LASTSCENE == UI.SCENES.GHDD` (skip optimization branch logs “skipping cache cleanup”).
+6. **USB exFAT path**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 5.
+7. **USB FAT32 path**
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 6.
+
+No other file-level call sites were found.
+
+---
+
+### 2b) `PLDR.GetPS1GameLists(..., true/false)` call sites
+
+#### Function definition behavior
+- Signature: `PLDR.GetPS1GameLists(path, updating)`.
+- Behavior split:
+  - `updating == true`: appends to existing `PLDR.GAMES`
+  - `updating == false`: builds temp list then assigns `PLDR.GAMES = RET`.
+
+#### Actual call sites found
+All discovered call sites are in `bin/POPSLDR/ui.lua`, in `UI.MainMenu.Play()` confirm handling, and **all pass `true`**:
+
+1. `PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)`
+   - Trigger: option 1 (MMCE) success path.
+2. `PLDR.GetPS1GameLists("mass"..tostring(mx_mass)..":/POPS/", true)`
+   - Trigger: option 2 (MX4SIO) when IOCTL mass backend detection succeeds.
+3. `PLDR.GetPS1GameLists(game_root, true)`
+   - Trigger: option 2 (MX4SIO) fallback path using `System.initMX4SIO` result.
+4. `PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)`
+   - Trigger: option 5 (USB exFAT).
+5. `PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)`
+   - Trigger: option 6 (USB FAT32).
+
+#### `false` call-site status
+- No call site passing `false` was found in current repository.
+
+---
+
+### 2c) `PLDR.HDD.BuildGameList()` call sites
+
+1. **Main menu HDD entry path** (`bin/POPSLDR/ui.lua`, `UI.MainMenu.Play()`)
+   - Trigger: `UI.Pad.Events.CONFIRM` + option 4 (HDD/PFS) after HDD checks.
+2. **HDD cache generation path** (`bin/POPSLDR/system.lua`, `PLDR.HDD.CreateCache()`)
+   - Trigger: only when `PLDR.HDD.CreateCache()` executes and `PLDR.HDD.USECACHE == true`; currently this path is gated off by default `USECACHE = false` and no discovered runtime flip to true.
+
+---
+
+## Evidence anchors (files searched)
+- `bin/POPSLDR/ui.lua`
+- `bin/POPSLDR/system.lua`
+- `src/luaplayer.cpp`
+- `src/include/luaplayer.h`
+- `src/luaSMB.cpp`
+
+No code changes made.

--- a/PERF_MAP_REPORT.md
+++ b/PERF_MAP_REPORT.md
@@ -1,0 +1,247 @@
+# PERF_MAP_REPORT — Phase 0 Structural Mapping (No Code Changes)
+
+Scope: static mapping only (Lua + C/C++ bindings) for page switch, device switch, list build, selection change, and launch paths.
+
+---
+
+## 1) UI PAGE SWITCH PATH
+
+### Entry points and control flow
+- Main loop dispatches scene handlers every frame in `bin/POPSLDR/system.lua`:
+  - `UI.MainMenu.Play()`
+  - `UI.ProfileQuery.Play()`
+  - `UI.GameList.Play()`
+  - `UI.Credits.Play()`.
+- Scene switch requests originate from `UI.SceneChange(SCENE)` → `UI.RequestScene(SCENE)` in `bin/POPSLDR/ui.lua`.
+- `UI.RequestScene` starts or queues transition through `UI.Transition.Start` / `UI.Transition.Queue`.
+- Transition execution happens in `UI.Transition.Update()` and at fade midpoint it performs:
+  1. `UI.OnSceneExit(previous_scene, target)` (if present)
+  2. write `UI.CURSCENE`
+  3. `UI.OnSceneEnter(previous_scene, UI.CURSCENE)` (if present).
+
+### Related functions in `bin/POPSLDR/ui.lua`
+- Scene APIs:
+  - `SceneChange`, `RequestScene`
+  - `Transition.Queue`, `Transition.Start`, `Transition.Update`
+- Hooks:
+  - `UI.OnSceneExit(previous_scene, next_scene)` is defined and clears cover cache when leaving a game scene.
+  - `UI.OnSceneEnter` is **UNKNOWN** in current static scan (referenced but no definition in `ui.lua` or `system.lua`).
+
+### Filesystem operations on page switch
+- No direct `System.listDirectory` call in transition code itself.
+- Side effect on leaving game scenes: `UI.OnSceneExit` calls `UI.CoverCache:Clear()` (memory/image cleanup, not directory scan).
+
+### List rebuild / sorting triggered by page switch
+- Page switch itself does not rebuild game list automatically.
+- In this codebase, list rebuilds are triggered in main-menu confirm paths before changing to game scenes (device-dependent), not by `OnSceneEnter`.
+
+### Per-event vs per-frame
+- `UI.MainMenu.Play`, `UI.GameList.Play`, etc. are per-frame.
+- `UI.SceneChange` is event-driven (pad input), but transition alpha updates run per-frame while active.
+
+---
+
+## 2) DEVICE SWITCH PATH
+
+### Trigger point
+- Device switching is driven by `UI.MainMenu.Play()` confirm handler (`UI.Pad.Events.CONFIRM`) with options:
+  - MMCE (opt 1)
+  - MX4SIO (opt 2)
+  - HDD/PFS (opt 4)
+  - USB exFAT / FAT32 (opts 5/6).
+
+### Code path by device
+- **MMCE**:
+  1. `PLDR.GetMMCESlots()` (lazy probe via `PLDR.DetectMMCESlot()`)
+  2. `PLDR.CleanupGameList()`
+  3. `PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)`
+  4. `UI.SceneChange(UI.SCENES.GMMCE)`.
+- **MX4SIO**:
+  1. `PLDR.FindMassByDriver("sdc", 4)` preferred
+  2. fallback `System.initMX4SIO(hint)`
+  3. `PLDR.CleanupGameList()`
+  4. `PLDR.GetPS1GameLists(<root>/POPS/, true)`
+  5. `UI.SceneChange(UI.SCENES.GMX4SIO)`.
+- **HDD/PFS**:
+  1. `PLDR.LoadHDDModules()`
+  2. optional `PLDR.CleanupGameList()` (skipped if returning from GHDD)
+  3. `PLDR.HDD.CheckAvailableHddPopsParts()`
+  4. `PLDR.HDD.BuildGameList()`
+  5. `UI.SceneChange(UI.SCENES.GHDD)`.
+- **USB exFAT/FAT32**:
+  1. `PLDR.CleanupGameList()`
+  2. `PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)`
+  3. `UI.SceneChange` to USB scene.
+
+### Detection and enumeration locations
+- USB/MX4SIO backend detection at boot: `PLDR.DetectMassBackends()` (`FindMassByDriver` calls `System.getMassDriverName`).
+- MMCE slot probe: `PLDR.DetectMMCESlot()` checks `doesFolderExist("mmce0:/")`, `doesFolderExist("mmce1:/")` once due to `MMCE.PROBED`.
+- Directory enumeration for games:
+  - non-HDD: `PLDR.GetPS1GameLists` → `System.listDirectory(PLDR.GAMEPATH)`
+  - HDD: `AppendHddGameList` → `System.listDirectory(list_path)` while mounted partition(s).
+
+### Repeated scans assessment
+- MMCE detection has one-shot probe behavior (no repeated slot scan once probed).
+- Game directory scans do repeat whenever user re-enters device from main menu because `CleanupGameList` + `GetPS1GameLists(..., true)` is called each time.
+- HDD partition availability scan is guarded by `PLDR.HDD.HAS_CHECKED`, but game list rebuild still occurs on HDD option confirm.
+
+---
+
+## 3) GAME LIST BUILD PATH
+
+### All `System.listDirectory` call sites (relevant to game list)
+- `PLDR.GetPS1GameLists(path, updating)` uses `System.listDirectory(PLDR.GAMEPATH)` for USB/MMCE/MX4SIO/SMB-style list construction.
+- `AppendHddGameList(partition, list_path, rel_prefix)` uses `System.listDirectory(list_path)` for HDD partitions.
+- `PLDR.HDD.BuildGameList()` calls `AppendHddGameList` for:
+  - `pfsX:/`
+  - `pfsX:/POPS/`
+  - repeated across `__.POPS` and `__.POPS0..9` partitions if present.
+
+### Construction / filtering / sorting
+- Non-HDD (`GetPS1GameLists`):
+  - loops directory entries
+  - keeps files with `.vcd` extension (case-insensitive by `string.lower`)
+  - appends to `PLDR.GAMES` when `updating=true`, else temporary list
+  - always `table.sort(PLDR.GAMES)` when any game found.
+- HDD (`AppendHddGameList` + `BuildGameList`):
+  - loops directory entries
+  - filters `.vcd`
+  - encodes entries as `partition|relpath`
+  - records map `PLDR.HDD.GAMEPARTS[encoded] = "hdd0:"..partition`.
+  - No explicit `table.sort` in HDD build path in current scan.
+
+### Rebuild on enter vs caching
+- USB/MMCE/MX4SIO: rebuilt on device-entry confirm from main menu.
+- HDD:
+  - `PLDR.HDD.BuildGameList()` called on HDD main-menu entry.
+  - Optional cache mechanism exists (`PLDR.HDDCACHE`, `PLDR.HDD.USECACHE`, `CreateCache/ReadCache`), but default in table is `USECACHE = false`; so caching is present structurally but likely inactive unless changed elsewhere.
+
+### Obvious O(N) behavior
+- O(N) directory pass in `GetPS1GameLists` for each scan.
+- O(N) sort (`table.sort`) after scan for non-HDD lists.
+- HDD path multiplies enumeration by number of mounted POPS partitions and by two paths per partition (`root` + `POPS/`), then O(total files) insertion.
+- `PLDR.CleanupGameList()` loops from `0..#PLDR.GAMES` and nils entries, O(N).
+
+---
+
+## 4) SELECTION CHANGE PATH
+
+### Cursor movement flow
+- In `UI.GameList.Play()` (per-frame), after `Input_GetEvent()`:
+  - `NAV_UP/DOWN/LEFT/RIGHT` update `UI.GameList.CURR`.
+- Display loop renders visible rows (`for i = STARTUP, ammount`) each frame.
+
+### Work tied to selection updates
+- Cover/preview path executes in `UI.GameList.Play()` each frame when `SHOW_COVER` is true:
+  - `UI.CoverCache:UpdateSelection(PLDR.GAMES[CURR], PLDR.GAMEPATH, UI.CURSCENE)`.
+- `CoverCache:UpdateSelection`:
+  - short-circuits if `last_key` unchanged.
+  - builds candidate path list.
+  - for HDD entries can mount partition (`HDD.MountPartition`) and unmount (`HDD.UMountPartition`) around cover lookup.
+  - `GetOrLoad` checks file existence (`doesFileExist` / `System.openFile`) and loads image via `Graphics.loadImage` if needed.
+
+### Synchronous loading assessment
+- Cover path appears synchronous:
+  - filesystem existence checks are inline.
+  - image decode/load is inline.
+  - HDD mount/unmount for cover candidates is inline.
+- This work is triggered during frame render path, but cache key prevents repeats for unchanged selection.
+
+### Rebuild/unnecessary state churn
+- Game list itself is not rebuilt on cursor move.
+- Render row loop is per-frame over visible range only (`MAXDRAW` window), not full list.
+- Cover lookup work can still involve synchronous I/O on selection changes (and on first frame for a selection).
+
+---
+
+## 5) LAUNCH PATH (CRITICAL)
+
+### Exact call path: select game → POPStarter handoff
+1. `UI.GameList.Play()` confirm handler (`UI.Pad.Events.CONFIRM`) validates list and files.
+2. Calls `PLDR.RunPOPStarterGame(launch_path, selected_game, UI.CURSCENE)`.
+3. `PLDR.RunPOPStarterGame`:
+   - resolves launch policy via `ResolveLaunchPolicy` (USB/MMCE/MX4SIO/HDD)
+   - builds normalized paths, boot mode, and selector (`argv0_selector`)
+   - for HDD parses `partition|relpath`, may init/mount through `PrepareHddLaunch` path (via `PLDR.LoadHDDModules`, mount selection map).
+   - builds context structure.
+4. Calls `LaunchEngine(popstarter, argv, reboot_iop, context)`.
+5. `LaunchEngine` performs validation/logging/fade and executes:
+   - `System.loadELF(popstarter, reboot_iop, argv...)`.
+6. Runtime binding `lua_loadELF` in `src/luasystem.cpp` dispatches to backend loader (`LoadELFFromFile` / `LoadELFFromFileFileIO`) with optional selector as argv0.
+
+### Where argv / launch parameters are constructed
+- `PLDR.RunPOPStarterGame` constructs:
+  - `argv = { argv0_selector }`
+  - `bootparam`, `bootparam_basename`, prefix behavior, device mode metadata.
+- `LaunchEngine` passes `argv` into `System.loadELF` (packed/unpacked path).
+- In C++ binding, only first extra arg is consumed as selector (`lua_loadELF`, `luaL_checkstring(L, 3)`, argc fixed to 1 when present).
+
+### Where `System.loadELF` is called
+- `LaunchEngine` (primary POPStarter handoff call).
+- Also exists for modal utilities (`LaunchBootElf`, `LaunchDKWDRV`) in UI, but not game-launch path.
+
+### Required vs optional vs unknown
+- **REQUIRED (for handoff):**
+  - resolve target ELF path (`ResolvePopstarterPath`)
+  - derive selector/argv0 for POPStarter semantics
+  - call `System.loadELF(...)`.
+- **REQUIRED/likely safety checks:**
+  - basic readability/open check (`TryOpenForLaunch`) before exec.
+  - HDD mount prep when launching HDD entries.
+- **OPTIONAL (not strictly handoff primitive):**
+  - extensive `LaunchLog(...)` calls
+  - repeated `ShowExecMarker(...)` UI marker draws
+  - pre-exec `UI.CoverCache:Clear()` (cleanup convenience)
+  - some bootparam existence fallback logic used for diagnostics/robustness.
+- **UNKNOWN:**
+  - whether all debug marker stages are mandated for field diagnostics across all variants.
+  - whether all context metadata fields are consumed downstream beyond logging.
+
+### Work that appears unnecessary before launch (structural observation only)
+- Multiple `ShowExecMarker` calls and large logging volume occur in launch critical path before `System.loadELF`.
+- Bootparam derivation and existence checks are computed even though final `loadELF` argv payload is selector-centric in this code path.
+- This is an observation only; no change recommendation in Phase 0.
+
+---
+
+## 6) SYSTEM INVENTORY (STATIC)
+
+### Major subsystems (Lua layer)
+- `bin/POPSLDR/system.lua`:
+  - device/path normalization, mass backend detect, game list management, launch engine, main loop.
+- `bin/POPSLDR/ui.lua`:
+  - scene routing, transitions, menu/input handling, game list rendering, cover cache.
+- `bin/POPSLDR/pops_profiles.lua`:
+  - POPStarter profile registry and default ELF selection.
+
+### Major subsystems (C/C++ runtime)
+- `src/main.cpp`:
+  - EE boot entry, argv parse, IOP module init, graphics/pad init, `chdir(boot_path)`, execute embedded boot Lua string via `runScript` loop.
+- `src/luaplayer.cpp`:
+  - creates Lua VM, registers Lua-facing modules (`graphics`, `controls`, `screen`, `timer`, `system`, `sound`, `render`, `HDD`).
+- `src/luasystem.cpp`:
+  - Lua `System` table (`listDirectory`, `loadELF`, file ops, path/asset helpers, mass-driver query, MX4SIO init, etc.).
+- `src/luaHDD.cpp`:
+  - `HDD` Lua table (`MountPartition`, `UMountPartition`, `Initialize`, `GetHDDStatus`).
+- `src/system.cpp`:
+  - lower-level platform/system helpers (IOP reset, asset resolution helpers).
+
+### Candidates that appear unused, legacy, or always-idle (static evidence)
+- `src/luaSMB.cpp` appears present but no `luaSMB_init(...)` registration path found in `runScript` initialization sequence; SMB Lua API exposure is therefore **UNKNOWN/likely unused** from current entrypoint.
+- Device lock subsystem in `ui.lua` appears effectively disabled by design:
+  - `canEnterDevice` always returns `true`
+  - `setDeviceLock` clears/ignores lock state
+  - indicates legacy lock mechanism retained but idle.
+- HDD cache subsystem exists (`PLDR.HDD.CreateCache/ReadCache/WipeCache`) but `PLDR.HDD.USECACHE` defaults false in current table initialization; this suggests cache path may be dormant unless enabled externally.
+
+### Evidence method
+- Static references and entrypoints were traced via:
+  - Lua call-chain inspection in `system.lua`, `ui.lua`, `pops_profiles.lua`.
+  - Runtime binding registration in `luaplayer.cpp` and `luasystem.cpp`.
+  - boot-to-Lua entry in `main.cpp` (`runScript(bootString, true)`).
+
+---
+
+## Notes on uncertainty handling
+- Any function/path not directly defined in scanned files is marked `UNKNOWN` instead of inferred.
+- No optimization proposal or code modifications are included in this Phase 0 report.

--- a/UNIVERSAL_ELF_ANALYSIS.md
+++ b/UNIVERSAL_ELF_ANALYSIS.md
@@ -1,0 +1,155 @@
+# UNIVERSAL_ELF_ANALYSIS.md
+
+## 1) Build Variant Differences
+
+### Variant selection in build system
+- `Makefile` supports: `VARIANT ?= mmce` with documented values `mmce | mx4sio | hdd | hdd_diag`.
+- Variant compile defines:
+  - `VARIANT=mmce` → `-DBOOT_MMCE`
+  - `VARIANT=mx4sio` → `-DBOOT_MX4SIO`
+  - `VARIANT=hdd` → `-DBOOT_HDD`
+  - `VARIANT=hdd_diag` → `-DBOOT_HDD -DBOOT_DIAG`
+
+### Preprocessor flags involved (observed)
+- `BOOT_MMCE` (set by Makefile; no direct guarded blocks found in scanned C/C++ files).
+- `BOOT_MX4SIO`.
+- `BOOT_HDD`.
+- `BOOT_DIAG` (used in diagnostics/log exposure).
+- Also present but not variant selectors: `RESET_IOP`, `DEBUG`, `POWERPC_UART`.
+
+### Code blocks wrapped in `#ifdef/#if defined(BOOT_*)`
+- `src/main.cpp`
+  - `#if defined(BOOT_HDD)` around `EarlyVideoProbe_HDD()` behavior.
+  - `#if defined(BOOT_HDD)` around HDD remount/canonicalization section after fileXio init.
+  - `#if defined(BOOT_HDD)` controlling `init_mass_stack` suppression when booted from `pfs*/hdd0:`.
+  - `#if defined(BOOT_MX4SIO)` for early `mx4sio_bd.irx` load.
+- `src/bootdiag.cpp`
+  - `#if defined(BOOT_DIAG)` for file logging and heartbeat rendering.
+- `src/luasystem.cpp`
+  - `#if defined(BOOT_DIAG)` exports Lua global `BOOT_DIAG` true/false.
+
+### IOP modules included per variant (build-time embedding)
+- Current `Makefile` `IOP_MODULES` list is common across variants; all listed modules are embedded in all variants.
+- Therefore variant differences today are primarily **runtime behavior gates** (via `BOOT_HDD`/`BOOT_MX4SIO` blocks), not module embedding set differences.
+
+---
+
+## 2) Runtime Differences
+
+### Device-specific initialization logic in `src/main.cpp`
+- HDD-specific behavior (`BOOT_HDD`):
+  - HDD early-video probe enabled.
+  - HDD remount/canonicalization paths run after fileXio load.
+  - If boot source is `pfs*/hdd0:`, mass stack init is skipped (`init_mass_stack=0`) to reduce deadlock risk before graphics.
+- MX4SIO-specific behavior (`BOOT_MX4SIO`):
+  - `mx4sio_bd.irx` loaded early at boot.
+- MMCE handling:
+  - `mmceman_irx` load attempted at boot (not behind `BOOT_MMCE`), probe deferred until MMCE page entry.
+
+### Device-specific module loads
+- Boot path (main.cpp):
+  - Always attempted core: `iomanX`, `fileXio`, `sio2man`, `mmceman` (if fileXio ready), `mcman`, `mcserv`, `padman`, `libsd`, `audsrv`.
+  - Mass/USB stack when `init_mass_stack==1`: `usbd`, `ds34usb`, `ds34bt`, `bdm`, `bdmfs_fatfs`, `usbmass_bd`, `cdfs`.
+  - MX4SIO early-only path (`BOOT_MX4SIO`): `mx4sio_bd`.
+- Lazy/on-demand path outside main boot:
+  - HDD stack from `src/luaHDD.cpp` `HDD.Initialize()`: `ps2dev9`, `ps2atad`, `ps2hdd-osd`, `ps2fs`.
+  - MX4SIO from `src/luasystem.cpp` `System.initMX4SIO(...)`: loads `mx4sio_bd` and probes roots.
+  - BDM query RPC from `src/luasystem.cpp`: loads `bdm_query.irx` lazily via `EnsureBdmQueryRpc()` when BDM listing APIs are called.
+
+### Early waits / blocking loops tied to specific devices
+- HDD/PFS-related risk mitigations:
+  - Conditional skip of mass stack init on HDD/PFS boot (BOOT_HDD + boot source check).
+  - HDD remount retries around `fileXioMount` (`mount`, optional `umount`, retry).
+- Mass-device wait loop:
+  - If boot root is `mass*`, loop up to 80 retries on `stat(wait_root)` before continuing.
+- Global boot loops not device-specific but still blocking:
+  - `SifIopReset`/`SifIopSync` loops under `RESET_IOP`.
+
+---
+
+## 3) IOP Module Inventory
+
+### Embedded modules today (from Makefile IOP_MODULES + linked IRX blobs)
+1. iomanX
+2. fileXio
+3. sio2man
+4. mcman
+5. mcserv
+6. padman
+7. libsd
+8. usbd
+9. audsrv
+10. bdm
+11. bdmfs_fatfs
+12. usbmass_bd
+13. cdfs
+14. ds34bt
+15. ds34usb
+16. ps2dev9
+17. ps2atad
+18. ps2hdd-osd
+19. ps2fs
+20. mmceman
+21. mx4sio_bd
+22. bdm_query
+
+### Classification
+- **REQUIRED always (current runtime baseline):**
+  - iomanX, fileXio, sio2man, mcman, mcserv, padman, libsd, audsrv.
+- **REQUIRED only for USB/mass stack paths:**
+  - usbd, bdm, bdmfs_fatfs, usbmass_bd.
+- **REQUIRED only for HDD paths:**
+  - ps2dev9, ps2atad, ps2hdd-osd, ps2fs.
+- **REQUIRED only for MX4SIO paths:**
+  - mx4sio_bd.
+- **Likely peripheral/feature-specific (not strictly core launch path):**
+  - cdfs (disc-related feature path), ds34usb, ds34bt, mmceman.
+- **Possibly unused in normal UI flow unless explicit API used:**
+  - bdm_query (loaded lazily only when BDM RPC APIs are invoked).
+
+---
+
+## 4) Boot Risk Assessment
+
+### High-risk modules to load unnecessarily
+- USB/mass stack (`usbd`, `bdm`, `bdmfs_fatfs`, `usbmass_bd`) on HDD/PFS boot contexts:
+  - project comments and logic already identify deadlock/black-screen risk when over-initializing before graphics in HDD-launched contexts.
+- HDD stack (`ps2dev9`, `ps2atad`, `ps2hdd-osd`, `ps2fs`) when not entering HDD path:
+  - unnecessary for USB/MMCE/MX4SIO browsing and potentially adds blocking init cost.
+- MX4SIO backend (`mx4sio_bd`) if not entering MX4SIO flow:
+  - currently early-loaded only in BOOT_MX4SIO builds or via explicit runtime init.
+
+### Safest locations for conditional loading
+- Keep core minimal boot in `main.cpp` (graphics reachability first).
+- Device-page entry handlers in Lua (`ui.lua`) and existing runtime APIs are safest trigger points:
+  - MMCE page entry for MMCE-specific readiness checks.
+  - MX4SIO page entry (`System.initMX4SIO`) for backend load/probe.
+  - HDD page entry (`HDD.Initialize`) for HDD stack.
+- Existing architecture already demonstrates this pattern for HDD and BDM query (lazy in runtime API).
+
+---
+
+## 5) Proposed Universal Strategy (Option A preparation)
+
+### Converting compile-time variant behavior to runtime detection
+- Keep a single binary embedding all needed IRX payloads.
+- Replace compile-time variant branching intent with runtime decisions derived from:
+  - parsed boot source (`boot_path`/`argv0`)
+  - active page/device selection in UI
+  - explicit device probes (already present for MMCE/MX4SIO/mass backend names).
+
+### Lazy module-load approach
+- Stage 1 (always-on minimal boot):
+  - load only baseline modules required to reach graphics, input, Lua, filesystem basics.
+- Stage 2 (on-demand per device/page):
+  - load USB/mass stack only upon entering USB/mass-backed browsing paths.
+  - load MX4SIO backend only upon entering MX4SIO path.
+  - load HDD stack only upon entering HDD path.
+- Stage 3 (auxiliary APIs):
+  - keep optional RPC/helper IRX (e.g., bdm_query) lazy on first API use.
+
+### Explicit universal policy target
+- Do **not** initialize USB/MX4SIO/HDD stacks at startup unless required by current boot safety context.
+- Do **not** load device-specific stacks unless entering that device path in UI or required to preserve boot from that device.
+- Preserve the existing HDD safety principle: prioritize reaching `initGraphics()` without pre-graphics deadlock risk.
+

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1201,21 +1201,15 @@ local function SelectPopstarterSelectorPrefix(device_page)
   return "XX."
 end
 
-local function BuildPopstarterSelectorPath(device_page, game_name)
+local function BuildPopstarterSelectorArg(device_page, game_name)
   if game_name == nil or game_name == "" then
     return ""
   end
   if device_page == "HDD" then
-    return "hdd0:__.POPS/"..game_name..".ELF"
+    return game_name..".ELF"
   end
-  if device_page == "USB" or device_page == "MMCE" or device_page == "SMB/MMCE" then
-    return "mass:/POPS/XX."..game_name..".ELF"
-  end
-  if device_page == "MX4SIO" then
-    local root = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.ROOT or "mx4sio:/"
-    return root.."POPS/XX."..game_name..".ELF"
-  end
-  return game_name..".ELF"
+  local prefix = SelectPopstarterSelectorPrefix(device_page)
+  return prefix..game_name..".ELF"
 end
 
 local function DeriveGameNameFromSelection(raw_selection)
@@ -1797,7 +1791,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     return
   end
   local selector_prefix = SelectPopstarterSelectorPrefix(device_page)
-  local argv0_selector = BuildPopstarterSelectorPath(device_page, game_name)
+  local argv0_selector = BuildPopstarterSelectorArg(device_page, game_name)
   if policy.name == "HDD" then
     local display_name = BuildDisplayNameFromEntry(game)
     argv0_selector = BuildLiteralElfName(display_name)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -261,7 +261,7 @@ PLDR.HDD.PFS_IDX = 0
 PLDR.HDD.PFS = "pfs0:/"
 do
   -- Extract the leading device prefix from the canonicalized boot path.  Examples:
-  -- "pfs0:/" → "pfs0", "hdd0:/" → "hdd0", "mass1:/" → "mass1".
+  -- "pfs0:/" -> "pfs0", "hdd0:/" -> "hdd0", "mass1:/" -> "mass1".
   local detected_prefix = nil
   local path = BOOT_PATH_RAW or ""
   if type(path) == "string" then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -253,7 +253,7 @@ PLDR = {
 -- collisions with the app mount.
 --
 -- Determine the boot prefix from the raw boot path prior to selecting the HDD PFS index.
--- Historically this logic relied on a free‑floating `boot_prefix` variable, but that
+-- Historically this logic relied on a free-floating `boot_prefix` variable, but that
 -- variable is never assigned before this point.  As a result HDD boots would always
 -- default to pfs0:/ even when launched from pfsX:/hdd0:, breaking root detection.
 -- To honour the real boot prefix we derive it directly from BOOT_PATH_RAW.

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -279,7 +279,7 @@ UI = {
       return "None"
     end;
     -- Always allow entry into device pages.  The original implementation
-    -- enforced cross‑device locks based on the boot source or session state,
+    -- enforced cross-device locks based on the boot source or session state,
     -- which could block access to USB/MMCE/MX4SIO pages when another device
     -- was active.  This behaviour has been removed to honour the design goal
     -- of "no device may block another."  Callers expecting three return values

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1648,13 +1648,18 @@ end
             cache_device = "USBFAT"
           end
           if cache_device ~= nil and PLDR ~= nil then
-            UI.InvalidateListCache()
-            PLDR.CleanupGameList()
-            PLDR.GetPS1GameLists(PLDR.GAMEPATH, true)
-            UI.RememberListCache(cache_device, PLDR.GAMEPATH)
-            UI.GameList.CURR = 1
-            UI.GameList.STARTUP = 1
-            UI.Notif_queue.add("Game list refreshed")
+            local refresh_path = PLDR.GAMEPATH
+            if refresh_path == nil or refresh_path == "" then
+              UI.Notif_queue.add("No device path to refresh")
+            else
+              UI.InvalidateListCache()
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(refresh_path, true)
+              UI.RememberListCache(cache_device, refresh_path)
+              UI.GameList.CURR = 1
+              UI.GameList.STARTUP = 1
+              UI.Notif_queue.add("Game list refreshed")
+            end
           end
         end
         if UI.Pad.Events.CONFIRM then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -438,7 +438,7 @@ UI = {
       return center + offset
     end;
     InputConfig = {
-      MIN_ACTION_MS = 220;
+      MIN_ACTION_MS = 90;
       DEBUG_INPUT_LOG = false;
     };
     --- Notifications queue handler
@@ -1406,8 +1406,8 @@ end
       elapsed = 0,
       last_time = nil,
       max_step = 33,
-      duration_out = 700,
-      duration_in = 700,
+      duration_out = 180,
+      duration_in = 180,
       Queue = function (target)
         if target == nil then return end
         if UI.Transition.active and UI.Transition.phase == "out" then
@@ -1890,7 +1890,7 @@ end
         animActive = false,
         animT = 0,
         animDir = 0,
-        animDurSec = 0.55,
+        animDurSec = 0.18,
         slide = 0,
         allowOptWrite = false,
         timer = nil,

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1518,6 +1518,7 @@ end
       STARTUP = 1;
       SHOW_COVER = (PLDR ~= nil and PLDR.SETTINGS ~= nil and PLDR.SETTINGS.show_cover ~= false);
       LAST_SQUARE_DOWN = false;
+      DEFER_COVER_LOAD_UNTIL_MOVE = false;
       Reset = function ()
         UI.GameList.CURR = 1;
       end;
@@ -1590,9 +1591,15 @@ end
         if UI.GameList.SHOW_COVER then
           local cover_img = nil
           local cover_missing = false
+          local can_load_cover = not UI.GameList.DEFER_COVER_LOAD_UNTIL_MOVE
           if UI.CoverCache ~= nil then
             if ammount > 0 then
-              cover_img, cover_missing = UI.CoverCache:UpdateSelection(PLDR.GAMES[UI.GameList.CURR], PLDR.GAMEPATH, UI.CURSCENE)
+              if can_load_cover then
+                cover_img, cover_missing = UI.CoverCache:UpdateSelection(PLDR.GAMES[UI.GameList.CURR], PLDR.GAMEPATH, UI.CURSCENE)
+              else
+                cover_img = UI.CoverCache.last_img
+                cover_missing = UI.CoverCache.last_missing
+              end
             else
               UI.CoverCache:UpdateSelection(nil, PLDR.GAMEPATH, UI.CURSCENE)
             end
@@ -1604,6 +1611,8 @@ end
             end
             if preview_img ~= nil then
               Graphics.drawScaleImage(preview_img, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
+            elseif UI.GameList.DEFER_COVER_LOAD_UNTIL_MOVE and not hide_ui then
+              Font.ftPrint(SFONT, layout.PREVIEW_X, layout.PREVIEW_Y + 8, 0, layout.PREVIEW_W, 16, "Cover deferred - move cursor", UI.CCOL.GREY)
             end
           end
         end
@@ -1618,16 +1627,25 @@ end
           UI.SceneChange(UI.SCENES.CREDITS)
         end
         if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
+        local prev_curr = UI.GameList.CURR
         if UI.Pad.Events.NAV_DOWN then UI.GameList.CURR = CLAMP(UI.GameList.CURR+1, 1, ammount) end
         if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
         if UI.Pad.Events.NAV_UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
         if UI.Pad.Events.NAV_LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
+        if UI.GameList.CURR ~= prev_curr then
+          UI.GameList.DEFER_COVER_LOAD_UNTIL_MOVE = false
+        end
         local square_down = false
         if UI.Pad.GPAD ~= nil and PAD_SQUARE ~= nil then
           square_down = (UI.Pad.GPAD & PAD_SQUARE) ~= 0
         end
         if square_down and not UI.GameList.LAST_SQUARE_DOWN then
           UI.GameList.SHOW_COVER = not UI.GameList.SHOW_COVER
+          if UI.GameList.SHOW_COVER then
+            UI.GameList.DEFER_COVER_LOAD_UNTIL_MOVE = true
+          else
+            UI.GameList.DEFER_COVER_LOAD_UNTIL_MOVE = false
+          end
           if PLDR ~= nil and PLDR.SETTINGS ~= nil then
             PLDR.SETTINGS.show_cover = UI.GameList.SHOW_COVER
             if PLDR.SaveSettings ~= nil then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2110,6 +2110,7 @@ end
                 return
               end
               local list_path = mmce_prefix.."POPS/"
+              PLDR.GAMEPATH = list_path
               if not UI.ShouldReuseListCache("MMCE", list_path) then
                 PLDR.CleanupGameList()
                 PLDR.GetPS1GameLists(list_path, true)
@@ -2137,6 +2138,7 @@ end
                 PLDR.MX4SIO.MASSINDX = mx_mass
               end
               local list_path = "mass"..tostring(mx_mass)..":/POPS/"
+              PLDR.GAMEPATH = list_path
               if not UI.ShouldReuseListCache("MX4SIO", list_path) then
                 PLDR.CleanupGameList()
                 PLDR.GetPS1GameLists(list_path, true)
@@ -2189,6 +2191,7 @@ end
             if type(JoinPath) == "function" then
               game_root = JoinPath(root, "POPS/")
             end
+            PLDR.GAMEPATH = game_root
             if not UI.ShouldReuseListCache("MX4SIO", game_root) then
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(game_root, true)
@@ -2223,6 +2226,7 @@ end
             UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
             local list_path = "mass"..PLDR.USB.MASSINDX..":/POPS/"
+            PLDR.GAMEPATH = list_path
             if not UI.ShouldReuseListCache("USBEXFAT", list_path) then
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(list_path, true)
@@ -2232,6 +2236,7 @@ end
             UI.SceneChange(UI.SCENES.GUSBEXFAT)
           elseif UI.MainMenu.OPT == 6 then
             local list_path = "mass"..PLDR.USB.MASSINDX..":/POPS/"
+            PLDR.GAMEPATH = list_path
             if not UI.ShouldReuseListCache("USBFAT", list_path) then
               PLDR.CleanupGameList()
               PLDR.GetPS1GameLists(list_path, true)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -307,6 +307,9 @@ UI = {
       LOG("Device lock ignored; locks disabled")
     end;
     RequestScene = function (SCENE)
+      if UI.CURSCENE ~= SCENE then
+        UI.FlushSettings()
+      end
       if UI.Transition ~= nil and UI.Transition.Start ~= nil then
         if UI.Transition.active then
           if UI.Transition.Queue ~= nil then
@@ -321,6 +324,17 @@ UI = {
     end;
     SceneChange = function (SCENE)
       UI.RequestScene(SCENE)
+    end;
+    _SETTINGS_DIRTY = false;
+    MarkSettingsDirty = function ()
+      UI._SETTINGS_DIRTY = true
+    end;
+    FlushSettings = function ()
+      if UI._SETTINGS_DIRTY ~= true then return end
+      if PLDR ~= nil and PLDR.SaveSettings ~= nil then
+        pcall(PLDR.SaveSettings)
+      end
+      UI._SETTINGS_DIRTY = false
     end;
     BuildListCacheKey = function (device_type, game_path)
       return tostring(device_type or "").."|"..tostring(game_path or "")
@@ -1494,9 +1508,7 @@ end
         UI.HideUI = not UI.HideUI
         if PLDR ~= nil and PLDR.SETTINGS ~= nil then
           PLDR.SETTINGS.hide_ui = UI.HideUI
-          if PLDR.SaveSettings ~= nil then
-            PLDR.SaveSettings()
-          end
+          UI.MarkSettingsDirty()
         end
         return true
       end
@@ -1648,9 +1660,7 @@ end
           end
           if PLDR ~= nil and PLDR.SETTINGS ~= nil then
             PLDR.SETTINGS.show_cover = UI.GameList.SHOW_COVER
-            if PLDR.SaveSettings ~= nil then
-              PLDR.SaveSettings()
-            end
+            UI.MarkSettingsDirty()
           end
         end
         UI.GameList.LAST_SQUARE_DOWN = square_down

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -322,6 +322,19 @@ UI = {
     SceneChange = function (SCENE)
       UI.RequestScene(SCENE)
     end;
+    BuildListCacheKey = function (device_type, game_path)
+      return tostring(device_type or "").."|"..tostring(game_path or "")
+    end;
+    ShouldReuseListCache = function (device_type, game_path)
+      local key = UI.BuildListCacheKey(device_type, game_path)
+      return UI._LAST_LIST_CACHE_KEY == key and PLDR ~= nil and type(PLDR.GAMES) == "table" and #PLDR.GAMES > 0
+    end;
+    RememberListCache = function (device_type, game_path)
+      UI._LAST_LIST_CACHE_KEY = UI.BuildListCacheKey(device_type, game_path)
+    end;
+    InvalidateListCache = function ()
+      UI._LAST_LIST_CACHE_KEY = nil
+    end;
     UpdateVmode = function ()
       Screen.setMode(UI.SCR.VMODE, UI.SCR.X, UI.SCR.Y, CT24, INTERLACED, FIELD)
     end;
@@ -1623,6 +1636,27 @@ end
           end
         end
         UI.GameList.LAST_SQUARE_DOWN = square_down
+        if UI.Pad.Events.R2 then
+          local cache_device = nil
+          if UI.CURSCENE == UI.SCENES.GMMCE then
+            cache_device = "MMCE"
+          elseif UI.CURSCENE == UI.SCENES.GMX4SIO then
+            cache_device = "MX4SIO"
+          elseif UI.CURSCENE == UI.SCENES.GUSBEXFAT then
+            cache_device = "USBEXFAT"
+          elseif UI.CURSCENE == UI.SCENES.GUSBFAT then
+            cache_device = "USBFAT"
+          end
+          if cache_device ~= nil and PLDR ~= nil then
+            UI.InvalidateListCache()
+            PLDR.CleanupGameList()
+            PLDR.GetPS1GameLists(PLDR.GAMEPATH, true)
+            UI.RememberListCache(cache_device, PLDR.GAMEPATH)
+            UI.GameList.CURR = 1
+            UI.GameList.STARTUP = 1
+            UI.Notif_queue.add("Game list refreshed")
+          end
+        end
         if UI.Pad.Events.CONFIRM then
           if ammount <= 0 then
             UI.Notif_queue.add("No games found")
@@ -2075,8 +2109,12 @@ end
                 UI.Notif_queue.add("No MMCE device found (mmce0/mmce1).")
                 return
               end
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mmce_prefix.."POPS/", true)
+              local list_path = mmce_prefix.."POPS/"
+              if not UI.ShouldReuseListCache("MMCE", list_path) then
+                PLDR.CleanupGameList()
+                PLDR.GetPS1GameLists(list_path, true)
+                UI.RememberListCache("MMCE", list_path)
+              end
               UI.setDeviceLock(DEVLOCK.MMCE)
               UI.SceneChange(UI.SCENES.GMMCE)
             end
@@ -2098,8 +2136,12 @@ end
                 PLDR.MX4SIO.ROOT = "mass"..tostring(mx_mass)..":/"
                 PLDR.MX4SIO.MASSINDX = mx_mass
               end
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists("mass"..tostring(mx_mass)..":/POPS/", true)
+              local list_path = "mass"..tostring(mx_mass)..":/POPS/"
+              if not UI.ShouldReuseListCache("MX4SIO", list_path) then
+                PLDR.CleanupGameList()
+                PLDR.GetPS1GameLists(list_path, true)
+                UI.RememberListCache("MX4SIO", list_path)
+              end
               UI.setDeviceLock(DEVLOCK.MX4SIO)
               UI.SceneChange(UI.SCENES.GMX4SIO)
               return
@@ -2143,12 +2185,15 @@ end
               PLDR.MX4SIO.ROOT = root
               PLDR.MX4SIO.MASSINDX = nil
             end
-            PLDR.CleanupGameList()
             local game_root = root.."POPS/"
             if type(JoinPath) == "function" then
               game_root = JoinPath(root, "POPS/")
             end
-            PLDR.GetPS1GameLists(game_root, true)
+            if not UI.ShouldReuseListCache("MX4SIO", game_root) then
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(game_root, true)
+              UI.RememberListCache("MX4SIO", game_root)
+            end
             UI.setDeviceLock(DEVLOCK.MX4SIO)
             UI.SceneChange(UI.SCENES.GMX4SIO)
           elseif UI.MainMenu.OPT == 3 then
@@ -2177,13 +2222,21 @@ end
             end
             UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
-            PLDR.CleanupGameList()
-            PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
+            local list_path = "mass"..PLDR.USB.MASSINDX..":/POPS/"
+            if not UI.ShouldReuseListCache("USBEXFAT", list_path) then
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(list_path, true)
+              UI.RememberListCache("USBEXFAT", list_path)
+            end
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBEXFAT)
           elseif UI.MainMenu.OPT == 6 then
-            PLDR.CleanupGameList()
-            PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
+            local list_path = "mass"..PLDR.USB.MASSINDX..":/POPS/"
+            if not UI.ShouldReuseListCache("USBFAT", list_path) then
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(list_path, true)
+              UI.RememberListCache("USBFAT", list_path)
+            end
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBFAT)
           elseif UI.MainMenu.OPT == 7 then

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -177,12 +177,40 @@ function RunScript(S)
   end
 end
 
-local SYS = System.resolveAsset("system.lua")
-if SYS ~= nil then
-  if BOOT_DIAG then
-    DIAG_LOG("Resolved system.lua: "..SYS)
+local function FullPathForAttempt(path)
+  if path == nil then return "<nil>" end
+  if string.match(path, "^[%a]+%d*:/") then
+    return path
   end
-	RunScript(SYS);
-else
-  error("Cant access POPSLDR/system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory())
+  local cwd = ensure_dir(System.currentDirectory() or "")
+  return cwd..path
+end
+
+local ATTEMPTS = {
+  "system.lua",
+  BASE_DIR.."system.lua",
+  "POPSLDR/system.lua",
+  BASE_DIR.."POPSLDR/system.lua"
+}
+
+local tried = {}
+local errs = {}
+local loaded = false
+for i = 1, #ATTEMPTS do
+  local candidate = ATTEMPTS[i]
+  tried[#tried + 1] = FullPathForAttempt(candidate)
+  local ok, err = pcall(RunScript, candidate)
+  if ok then
+    loaded = true
+    break
+  end
+  errs[#errs + 1] = tostring(err)
+end
+
+if not loaded then
+  local msg = "Cant access system.lua\n\ncurrent_bootpath: "..tostring(System.currentDirectory()).."\n\nattempted paths:\n - "..table.concat(tried, "\n - ")
+  if #errs > 0 then
+    msg = msg.."\n\nlast error:\n"..errs[#errs]
+  end
+  error(msg)
 end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -187,10 +187,10 @@ local function FullPathForAttempt(path)
 end
 
 local ATTEMPTS = {
-  "system.lua",
   BASE_DIR.."system.lua",
-  "POPSLDR/system.lua",
-  BASE_DIR.."POPSLDR/system.lua"
+  BASE_DIR.."POPSLDR/system.lua",
+  "system.lua",
+  "POPSLDR/system.lua"
 }
 
 local tried = {}
@@ -208,7 +208,7 @@ for i = 1, #ATTEMPTS do
 end
 
 if not loaded then
-  local msg = "Cant access system.lua\n\ncurrent_bootpath: "..tostring(System.currentDirectory()).."\n\nattempted paths:\n - "..table.concat(tried, "\n - ")
+  local msg = "Cant access system.lua\n\nboot_dir: "..tostring(BASE_DIR).."\ncwd: "..tostring(System.currentDirectory()).."\nargv0: "..tostring(System.GetArgv0()).."\n\nattempted paths:\n - "..table.concat(tried, "\n - ")
   if #errs > 0 then
     msg = msg.."\n\nlast error:\n"..errs[#errs]
   end

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -37,7 +37,7 @@ int getBootDevice(void);
 
 extern size_t GetFreeSize(void);
 
-extern const char * runScript(const char* script, bool isStringBuffer);
+extern const char * runScript(const char* script, bool isStringBuffer, size_t scriptSize = 0);
 extern void luaC_collectgarbage (lua_State *L);
 
 //extern void luaSound_init(lua_State *L);

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -83,7 +83,7 @@ int test_error(lua_State * L) {
     return 0;
 }
 
-const char * runScript(const char* script, bool isStringBuffer )
+const char * runScript(const char* script, bool isStringBuffer, size_t scriptSize )
 {	
     DPRINTF("Creating luaVM... \n");
 
@@ -117,8 +117,16 @@ const char * runScript(const char* script, bool isStringBuffer )
 
 	if(!isStringBuffer) s = luaL_loadfile(L, script);
 	else {
-    s = luaL_loadbuffer(L, script, strlen(script), NULL);
-  }
+		size_t loadSize = scriptSize;
+		if (loadSize == 0) {
+			loadSize = strlen(script);
+		} else {
+			while (loadSize > 0 && script[loadSize - 1] == '\0') {
+				loadSize--;
+			}
+		}
+		s = luaL_loadbuffer(L, script, loadSize, NULL);
+	}
 
 		
 	if (s == 0) s = lua_pcall(L, 0, LUA_MULTRET, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include <dirent.h>
 
@@ -459,32 +460,41 @@ static void BootStamp(const char *stage)
 
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
-    if (argc>=(idx+1))
+    if (argc >= (idx + 1) && argv[idx] != NULL)
     {
+        char tmp[255];
+        snprintf(tmp, sizeof(tmp), "%s", argv[idx]);
+        for (char *q = tmp; *q; ++q) {
+            if (*q == '\\') *q = '/';
+        }
 
-	char *p;
-	if ((p = strrchr(argv[idx], '/'))!=NULL) {
-	    snprintf(boot_path, sizeof(boot_path), "%s", argv[idx]);
-	    p = strrchr(boot_path, '/');
-	if (p!=NULL)
-	    p[1]='\0';
-	} else if ((p = strrchr(argv[idx], '\\'))!=NULL) {
-	   snprintf(boot_path, sizeof(boot_path), "%s", argv[idx]);
-	   p = strrchr(boot_path, '\\');
-	   if (p!=NULL)
-	     p[1]='\0';
-	} else if ((p = strchr(argv[idx], ':'))!=NULL) {
-	   snprintf(boot_path, sizeof(boot_path), "%s", argv[idx]);
-	   p = strchr(boot_path, ':');
-	   if (p!=NULL)
-	   p[1]='\0';
-	}
+        size_t len = strlen(tmp);
+        int has_elf_suffix = 0;
+        if (len >= 4) {
+            char c1 = (char)tolower((unsigned char)tmp[len - 4]);
+            char c2 = (char)tolower((unsigned char)tmp[len - 3]);
+            char c3 = (char)tolower((unsigned char)tmp[len - 2]);
+            char c4 = (char)tolower((unsigned char)tmp[len - 1]);
+            has_elf_suffix = (c1 == '.' && c2 == 'e' && c3 == 'l' && c4 == 'f');
+        }
 
+        if (has_elf_suffix) {
+            char *p = strrchr(tmp, '/');
+            if (p != NULL) {
+                p[1] = '\0';
+            } else {
+                p = strchr(tmp, ':');
+                if (p != NULL) {
+                    p[1] = '\0';
+                }
+            }
+            snprintf(boot_path, sizeof(boot_path), "%s", tmp);
+        } else {
+            snprintf(boot_path, sizeof(boot_path), "%s", tmp);
+        }
     }
-    
+
     NormalizeDirPath(boot_path, sizeof(boot_path));
-    
-    
 }
 
 static void setAppDirFromPath(const char *path)
@@ -830,7 +840,11 @@ int main(int argc, char * argv[])
     pad_init();
 
     // set base path luaplayer
-    chdir(boot_path); 
+    int chdir_ret = chdir(boot_path);
+    if (chdir_ret < 0) {
+        DPRINTF("chdir failed: path=%s errno=%d (%s)\n", boot_path, errno, strerror(errno));
+        BootDiagLog("chdir failed: path=%s errno=%d", boot_path, errno);
+    }
 
     DPRINTF("boot path : %s\n", boot_path);
 	dbgprintf("boot path : %s\n", boot_path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,39 +37,12 @@ extern "C"{
 }
 
 /*
- * EE-only early video probe.
- * Purpose: prove we reach main() when HDD-booted, without any SIF/IOP calls.
- * Draws a solid dark-red frame once, then continues.
+ * EE-only early video probe placeholder.
+ * Kept as a no-op in universal build.
  */
 static void EarlyVideoProbe_HDD(void)
 {
-#if defined(BOOT_HDD)
-    GSGLOBAL *gsGlobal = gsKit_init_global();
-
-    /* Safe defaults */
-    gsGlobal->Mode = GS_MODE_NTSC;
-    gsGlobal->Interlace = GS_INTERLACED;
-    gsGlobal->Field = GS_FIELD;
-    gsGlobal->Width = 640;
-    gsGlobal->Height = 448;
-    gsGlobal->PSM = GS_PSM_CT24;
-    gsGlobal->ZBuffering = GS_SETTING_OFF;
-
-    dmaKit_init(D_CTRL_RELE_OFF, D_CTRL_MFD_OFF, D_CTRL_STS_UNSPEC, D_CTRL_STD_OFF, D_CTRL_RCYC_8, 1<<DMA_CHANNEL_GIF);
-    dmaKit_chan_init(DMA_CHANNEL_GIF);
-
-    gsKit_init_screen(gsGlobal);
-
-    /* Solid dark-red clear */
-    gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(0x40, 0x00, 0x00, 0x80, 0x00));
-    gsKit_sync_flip(gsGlobal);
-    gsKit_queue_exec(gsGlobal);
-    gsKit_finish();
-
-    /* Leave GS initialized; the normal graphics init will reconfigure later. */
-#else
     (void)0;
-#endif
 }
 
 
@@ -637,9 +610,22 @@ int main(int argc, char * argv[])
      *
      * For the HDD variant only: if launched from pfsX:/ or hdd0:, keep boot init minimal.
      */
-    const int booted_from_hdd =
-        (boot_path[0] && (!strncmp(boot_path, "pfs", 3) || !strncmp(boot_path, "hdd0:", 5)));
-    BootDiagLog("booted_from_hdd=%d boot_path=%s", booted_from_hdd, boot_path);
+    const int is_pfs_boot =
+        ((boot_path[0] && !strncmp(boot_path, "pfs", 3)) ||
+         (ARGV0 && !strncmp(ARGV0, "pfs", 3)) ||
+         (strstr(boot_path, "hdd0:") != NULL) ||
+         (ARGV0 && strstr(ARGV0, "hdd0:") != NULL));
+    const int is_mass_boot =
+        ((boot_path[0] && !strncmp(boot_path, "mass", 4)) ||
+         (ARGV0 && !strncmp(ARGV0, "mass", 4)));
+    const int is_mmce_boot =
+        ((boot_path[0] && !strncmp(boot_path, "mmce", 4)) ||
+         (ARGV0 && !strncmp(ARGV0, "mmce", 4)));
+    const int is_mx4sio_boot =
+        ((boot_path[0] && !strncmp(boot_path, "mx4sio", 6)) ||
+         (ARGV0 && !strncmp(ARGV0, "mx4sio", 6)));
+    BootDiagLog("boot classification: pfs=%d mass=%d mmce=%d mx4sio=%d boot_path=%s argv0=%s",
+        is_pfs_boot, is_mass_boot, is_mmce_boot, is_mx4sio_boot, boot_path, ARGV0 ? ARGV0 : "<null>");
 
 #ifdef RESET_IOP
     BootDiagHeartbeat("SifInitRpc pre");
@@ -695,16 +681,14 @@ int main(int argc, char * argv[])
     }
     BootStamp("fileXio load/init");
 
-#if defined(BOOT_HDD)
-    if (filexio_ok) {
+    if (filexio_ok && is_pfs_boot) {
         CanonicalizeBootBase(ARGV0);
     }
-    if (filexio_ok && ((boot_path[0] && !strncmp(boot_path, "hdd0:", 5)) || (ARGV0 && !strncmp(ARGV0, "hdd0:", 5)))) {
+    if (filexio_ok && (strstr(boot_path, "hdd0:") != NULL || (ARGV0 && strstr(ARGV0, "hdd0:") != NULL))) {
         if (!RemountHddPartitionFromBootPath(ARGV0)) {
             DPRINTF("HDD remount: failed to restore PFS mount after fileXio reload.\n");
         }
     }
-#endif
 
 	LOAD_IRX_NARG(sio2man_irx);
     if (filexio_ok) {
@@ -753,9 +737,7 @@ int main(int argc, char * argv[])
      * Those stacks are initialized lazily on page entry anyway.
      */
     int init_mass_stack = 1;
-#if defined(BOOT_HDD)
-    if (booted_from_hdd) init_mass_stack = 0;
-#endif
+    if (is_pfs_boot) init_mass_stack = 0;
 
     if (init_mass_stack) {
         // load USB modules
@@ -774,13 +756,6 @@ int main(int argc, char * argv[])
     } else {
         BootStamp("mass stack load (skipped: HDD boot)");
     }
-
-#if defined(BOOT_MX4SIO)
-    /* Load MX4SIO backend early so booting from MX4SIO works before Lua starts. */
-    bool mx4sio_bd_ok = LoadIrxChecked("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-    DPRINTF("mx4sio_bd load result: ok=%d\n", mx4sio_bd_ok ? 1 : 0);
-    BootStamp("mx4sio_bd load");
-#endif
 
     if (init_mass_stack) {
         LOAD_IRX_NARG(cdfs_irx);
@@ -815,7 +790,7 @@ int main(int argc, char * argv[])
     if (ExtractDeviceRoot(boot_path, wait_root, sizeof(wait_root)) < 0) {
         wait_root[0] = '\0';
     }
-    if (!strncmp(wait_root, "mass", 4)) {
+    if (is_mass_boot && !strncmp(wait_root, "mass", 4)) {
         BootStamp("mass wait begin");
         while (ret != 0 && retries > 0) {
             ret = stat(wait_root, &buffer);
@@ -842,8 +817,8 @@ int main(int argc, char * argv[])
     // set base path luaplayer
     int chdir_ret = chdir(boot_path);
     if (chdir_ret < 0) {
-        DPRINTF("chdir failed: path=%s errno=%d (%s)\n", boot_path, errno, strerror(errno));
-        BootDiagLog("chdir failed: path=%s errno=%d", boot_path, errno);
+        DPRINTF("chdir failed: path=%s argv0=%s errno=%d (%s)\n", boot_path, ARGV0 ? ARGV0 : "<null>", errno, strerror(errno));
+        BootDiagLog("chdir failed: path=%s argv0=%s errno=%d", boot_path, ARGV0 ? ARGV0 : "<null>", errno);
     }
 
     DPRINTF("boot path : %s\n", boot_path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,36 @@ static unsigned int boot_ms(void)
     return (unsigned int)(((clock() - boot_start) * 1000) / CLOCKS_PER_SEC);
 }
 
+static void DrawBootProgress(const char *label, int step, int total)
+{
+    if (total <= 0) {
+        total = 1;
+    }
+    if (step < 0) {
+        step = 0;
+    }
+    if (step > total) {
+        step = total;
+    }
+
+    const int bar_width = 42;
+    int filled = (step * bar_width) / total;
+    int pct = (step * 100) / total;
+
+    init_scr();
+    scr_clear();
+    scr_setXY(2, 2);
+    scr_printf("POPSLoader boot loading...\n");
+    if (label != NULL) {
+        scr_printf("%s\n", label);
+    }
+    scr_printf("[");
+    for (int i = 0; i < bar_width; i++) {
+        scr_printf(i < filled ? "#" : "-");
+    }
+    scr_printf("] %d%%\n", pct);
+}
+
 static void InsertChar(char *base, size_t base_size, char *pos, char ch)
 {
     size_t len = strlen(base);
@@ -813,6 +843,7 @@ int main(int argc, char * argv[])
     BootDiagLog("GS init post");
 
     pad_init();
+    DrawBootProgress("Initializing runtime", 1, 3);
 
     // set base path luaplayer
     int chdir_ret = chdir(boot_path);
@@ -834,8 +865,10 @@ int main(int argc, char * argv[])
     }
     BootStamp("Lua init start");
     BootDiagHeartbeat("Lua init start");
+    DrawBootProgress("Loading scripts", 2, 3);
     while (1)
     {
+        DrawBootProgress("Starting UI", 3, 3);
         errMsg = runScript(bootString, true, size_bootString);
 
         init_scr();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,6 +793,19 @@ int main(int argc, char * argv[])
 
     LOAD_IRX_NARG(audsrv_irx);
 
+	
+	// Lua init
+	// init internals library
+    
+    // graphics (gsKit)
+    BootDiagHeartbeat("GS init pre");
+    BootDiagLog("GS init pre");
+    initGraphics();
+    BootDiagHeartbeat("GS init post");
+    BootDiagLog("GS init post");
+    pad_init();
+    DrawBootProgress("Initializing runtime", 1, 3);
+
     //waitUntilDeviceIsReady by fjtrujy
 
     struct stat buffer;
@@ -831,19 +844,7 @@ int main(int argc, char * argv[])
     } else {
         BootStamp("mass wait (skipped)");
     }
-	
-	// Lua init
-	// init internals library
-    
-    // graphics (gsKit)
-    BootDiagHeartbeat("GS init pre");
-    BootDiagLog("GS init pre");
-    initGraphics();
-    BootDiagHeartbeat("GS init post");
-    BootDiagLog("GS init post");
 
-    pad_init();
-    DrawBootProgress("Initializing runtime", 1, 3);
 
     // set base path luaplayer
     int chdir_ret = chdir(boot_path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,6 +631,7 @@ int main(int argc, char * argv[])
     }
     BootDiagLog("boot_path=%s app_dir=%s", boot_path, app_dir);
     BootStamp("boot path parse");
+    DrawBootProgress("Loading core modules", 1, 3);
 
     /*
      * HDD boot note:
@@ -804,7 +805,7 @@ int main(int argc, char * argv[])
     BootDiagHeartbeat("GS init post");
     BootDiagLog("GS init post");
     pad_init();
-    DrawBootProgress("Initializing runtime", 1, 3);
+    DrawBootProgress("Initializing runtime", 2, 3);
 
     //waitUntilDeviceIsReady by fjtrujy
 
@@ -866,10 +867,9 @@ int main(int argc, char * argv[])
     }
     BootStamp("Lua init start");
     BootDiagHeartbeat("Lua init start");
-    DrawBootProgress("Loading scripts", 2, 3);
+    DrawBootProgress("Loading scripts", 3, 3);
     while (1)
     {
-        DrawBootProgress("Starting UI", 3, 3);
         errMsg = runScript(bootString, true, size_bootString);
 
         init_scr();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -836,7 +836,7 @@ int main(int argc, char * argv[])
     BootDiagHeartbeat("Lua init start");
     while (1)
     {
-        errMsg = runScript(bootString, true);
+        errMsg = runScript(bootString, true, size_bootString);
 
         init_scr();
 

--- a/tools/lua_integrity_check.py
+++ b/tools/lua_integrity_check.py
@@ -23,7 +23,7 @@ def iter_lua_files(root: Path) -> list[Path]:
     return sorted([p for p in root.rglob("*.lua") if p.is_file()])
 
 
-def check_file(path: Path, check_punct: bool) -> list[str]:
+def check_file(path: Path, check_punct: bool, ascii_only: bool) -> list[str]:
     issues: list[str] = []
     raw = path.read_bytes()
 
@@ -41,6 +41,12 @@ def check_file(path: Path, check_punct: bool) -> list[str]:
             issues.append(f"disallowed control char 0x{b:02X} at byte {idx}")
             break
 
+    if ascii_only:
+        for i, ch in enumerate(text):
+            if ord(ch) > 0x7F:
+                issues.append(f"non-ASCII character U+{ord(ch):04X} at char {i}")
+                break
+
     if check_punct:
         for i, ch in enumerate(text):
             cp = ord(ch)
@@ -55,13 +61,18 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Validate Lua file encoding/integrity.")
     ap.add_argument("--root", default=".", help="repository root")
     ap.add_argument("--check-punctuation", action="store_true", help="also fail on smart/high punctuation")
+    ap.add_argument(
+        "--no-ascii-only",
+        action="store_true",
+        help="allow non-ASCII Unicode text (default is ASCII-only for Lua safety)",
+    )
     args = ap.parse_args()
 
     root = Path(args.root)
     files = iter_lua_files(root)
     bad = 0
     for f in files:
-        issues = check_file(f, args.check_punctuation)
+        issues = check_file(f, args.check_punctuation, not args.no_ascii_only)
         if issues:
             bad += 1
             print(f"[FAIL] {f}")

--- a/tools/lua_integrity_check.py
+++ b/tools/lua_integrity_check.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ALLOWED_CTRL = {0x09, 0x0A, 0x0D}
+SMART_PUNCT = {
+    0x2018: "'",  # left single quote
+    0x2019: "'",  # right single quote
+    0x201C: '"',   # left double quote
+    0x201D: '"',   # right double quote
+    0x2013: '-',   # en dash
+    0x2014: '-',   # em dash
+    0x2026: '...', # ellipsis
+    0x2022: '-',   # bullet
+    0x2011: '-',   # non-breaking hyphen
+}
+
+
+def iter_lua_files(root: Path) -> list[Path]:
+    return sorted([p for p in root.rglob("*.lua") if p.is_file()])
+
+
+def check_file(path: Path, check_punct: bool) -> list[str]:
+    issues: list[str] = []
+    raw = path.read_bytes()
+
+    if raw.startswith(b"\xef\xbb\xbf"):
+        issues.append("BOM present (UTF-8 BOM not allowed)")
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        issues.append(f"invalid UTF-8 at byte {e.start}")
+        return issues
+
+    for idx, b in enumerate(raw):
+        if b < 0x20 and b not in ALLOWED_CTRL:
+            issues.append(f"disallowed control char 0x{b:02X} at byte {idx}")
+            break
+
+    if check_punct:
+        for i, ch in enumerate(text):
+            cp = ord(ch)
+            if cp in SMART_PUNCT:
+                issues.append(f"smart/high punctuation U+{cp:04X} at char {i}")
+                break
+
+    return issues
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate Lua file encoding/integrity.")
+    ap.add_argument("--root", default=".", help="repository root")
+    ap.add_argument("--check-punctuation", action="store_true", help="also fail on smart/high punctuation")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    files = iter_lua_files(root)
+    bad = 0
+    for f in files:
+        issues = check_file(f, args.check_punctuation)
+        if issues:
+            bad += 1
+            print(f"[FAIL] {f}")
+            for issue in issues:
+                print(f"  - {issue}")
+
+    if bad:
+        print(f"\nLua integrity check failed: {bad} file(s) with issues.")
+        return 1
+
+    print(f"Lua integrity check passed: {len(files)} file(s) scanned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Reduce perceived latency when re-entering non-HDD device game-list pages (MMCE / MX4SIO / USB) by avoiding repeated directory scans and list rebuilds when the in-memory list is already valid.
- Implement the smallest safe Lua-only change that preserves HDD behavior, launch semantics, and explicit refresh behavior per the project performance contract.
- Keep the change conservative and focused to eliminate only the redundant rebuild work on device re-entry from the main menu.

### Description
- Added lightweight cache helpers to `UI` in `bin/POPSLDR/ui.lua`: `BuildListCacheKey(device_type, game_path)`, `ShouldReuseListCache(device_type, game_path)`, `RememberListCache(device_type, game_path)`, and `InvalidateListCache()`; the cache key is the string `device_type|PLDR.GAMEPATH`.
- On main-menu device entry for non-HDD paths (MMCE, MX4SIO, USB exFAT, USB FAT32) the code now checks `UI.ShouldReuseListCache(...)` and if true and `PLDR.GAMES` is non-empty it skips `PLDR.CleanupGameList()` and `PLDR.GetPS1GameLists(..., true)` and goes straight to `UI.SceneChange(...)`; otherwise the original rebuild logic runs and the new key is remembered.
- Added an explicit manual refresh control in game-list scenes mapped to the `R2` button which invalidates the cache, forces `PLDR.CleanupGameList()` and `PLDR.GetPS1GameLists(PLDR.GAMEPATH, true)`, remembers the refreshed key, and resets list cursor/start positions.
- Scope and safety: only `bin/POPSLDR/ui.lua` was edited, HDD list-build code and launch/POPStarter logic were not modified, and the original rebuild path remains available whenever the cache is not reusable or when manual refresh is triggered.
- Hardware validation (to be performed by maintainer): 1) enter a non-HDD device list and wait for population; 2) back out to main menu and re-enter the same device and verify the list appears immediately (rebuild skipped); 3) press `R2` on the game-list page to force a rebuild and confirm the list refreshes; 4) re-enter after refresh and confirm the refreshed cache is used.
- Rollback: revert the single commit that modified `bin/POPSLDR/ui.lua` to undo this change.

### Testing
- Ran repository searches to verify the new helper symbols and usage points with `rg -n "BuildListCacheKey|ShouldReuseListCache|RememberListCache|InvalidateListCache|Pad.Events.R2|Game list refreshed|ShouldReuseListCache\(" bin/POPSLDR/ui.lua` and the expected matches were found (success).
- Inspected the produced diff with `git diff -- bin/POPSLDR/ui.lua` to confirm only the intended non-HDD entry paths and the new helpers were added (success).
- Committed the change with `git commit` to record the edit (success).
- Attempted to run a Lua interpreter check in this environment but `lua` is not available here, so no runtime syntax/behavior validation could be executed (informational).
- No automated unit tests exist for runtime UI behavior in CI, so automated verification is limited to static checks above and must be validated on real PS2 hardware per the repository contract (manual hardware tests outlined in Description).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990cf133b148321b33f4c6a60ec0cb8)