### PR TITLE
boot: deterministic resolution of POPSLDR/system.lua with compatibility probe

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -125,9 +125,79 @@ function RunScript(S)
   end
 end
 
-local SYS = System.resolveAsset("system.lua")
+local function IsReadableFile(path)
+  if path == nil or path == "" then
+    return false
+  end
+  if type(doesFileExist) == "function" then
+    local ok_exists, exists = pcall(doesFileExist, path)
+    if ok_exists and not exists then
+      return false
+    end
+  end
+  local ok_open, fd = pcall(System.openFile, path, FREAD)
+  if not ok_open or fd == nil then
+    return false
+  end
+  System.closeFile(fd)
+  return true
+end
+
+local function ResolveSystemScript()
+  -- Deterministic boot probe order:
+  -- 1) APP_ROOT/POPSLDR/system.lua
+  -- 2) APP_ROOT/system.lua
+  -- 3) APP_ROOT/*/POPSLDR/system.lua (one level deep)
+  -- 4) System.resolveAsset("system.lua") compatibility probe
+  local candidates = {
+    BASE_DIR.."POPSLDR/system.lua",
+    BASE_DIR.."system.lua"
+  }
+
+  local ok_list, entries = pcall(System.listDirectory, BASE_DIR)
+  if ok_list and entries ~= nil then
+    local child_dirs = {}
+    for i = 1, #entries do
+      local entry = entries[i]
+      if entry ~= nil and entry.directory and entry.name ~= nil then
+        local name = entry.name
+        if name ~= "." and name ~= ".." then
+          child_dirs[#child_dirs + 1] = name
+        end
+      end
+    end
+    table.sort(child_dirs)
+    for i = 1, #child_dirs do
+      candidates[#candidates + 1] = BASE_DIR..child_dirs[i].."/POPSLDR/system.lua"
+    end
+  end
+
+  local compat = System.resolveAsset("system.lua")
+  if compat ~= nil and compat ~= "" then
+    candidates[#candidates + 1] = compat
+  end
+
+  local checked = {}
+  local seen = {}
+  for i = 1, #candidates do
+    local candidate = candidates[i]
+    if candidate ~= nil and candidate ~= "" and not seen[candidate] then
+      seen[candidate] = true
+      checked[#checked + 1] = candidate
+      if IsReadableFile(candidate) then
+        return candidate, checked
+      end
+    end
+  end
+  return nil, checked
+end
+
+local SYS, checked_candidates = ResolveSystemScript()
 if SYS ~= nil then
-	RunScript(SYS);
+  RunScript(SYS)
 else
-  error("Cant access POPSLDR/system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory())
+  error(
+    "Cant access POPSLDR/system.lua\n\n\tcurrent_bootpath: "..System.currentDirectory()..
+    "\n\tchecked_candidates: "..table.concat(checked_candidates, ", ")
+  )
 end


### PR DESCRIPTION
### Motivation
- Make boot-time selection of `system.lua` deterministic and prefer assets colocated with the ELF while preserving legacy compatibility and diagnostics.
- Avoid nondeterministic discovery order and add explicit readability checks before attempting to execute a candidate script.

### Description
- Replace the single `System.resolveAsset("system.lua")` probe with an ordered candidate search that checks `APP_ROOT/POPSLDR/system.lua`, then `APP_ROOT/system.lua`, then a one-level shallow scan of `APP_ROOT/*/POPSLDR/system.lua` (directory names sorted for deterministic probing), and finally `System.resolveAsset("system.lua")` as a compatibility probe.
- Add `IsReadableFile(path)` which uses existing utilities (`doesFileExist` when available and `System.openFile(..., FREAD)`) to verify readability before loading.
- Keep the legacy boot-failure class/message (`Cant access POPSLDR/system.lua`) but extend the error diagnostics to include the list of `checked_candidates` that were probed.
- Ensure no permanent absolute paths were introduced and the probe order is deterministic by sorting child directory names before probing.

### Testing
- Inspected the change with `git diff -- etc/boot.lua` and validated the candidate-order logic by reading the updated `etc/boot.lua` contents (success).
- Attempted Lua syntax check with `luac -p etc/boot.lua`, but the environment lacks `luac` so the check could not be executed (tool not installed).
- Verified the modified file was staged and committed locally (commit recorded) and inspected lines with `nl`/`sed` to confirm insertion points (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699342790cc48321bd9a4a2472098ece)