### PR TITLE
docs: update USB UI/device/runtime docs for merged mass root flow

### DIFF
--- a/docs/RUNTIME_LAYOUT.md
+++ b/docs/RUNTIME_LAYOUT.md
@@ -32,8 +32,15 @@ Legacy subfolders (`POPSLDR/`, `IMG/`, `IRX/`) are **fallback only** and should 
 ## Device support (path prefixes used in code)
 POPSLoader uses these device prefixes in its runtime paths:
 - Memory card: `mc0:/`, `mc1:/`
-- USB mass storage: `mass:/` and `mass0:/`–`mass4:/` (the game list path is built as `mass{MASSINDX}:/`, default `MASSINDX = 0`)
+- USB mass storage: `mass:/` and indexed roots (`mass0:/`...`massN:/`) for multi-device scanning/launch
 - MMCE: `mmce0:/`, `mmce1:/`
+
+## USB runtime behavior (current)
+- **Single USB UI page:** USB games are displayed in one scene/page (`GUSB`); FAT32/exFAT split UX should not be treated as current behavior in this branch.【F:bin/POPSLDR/ui.lua†L11-L15】【F:bin/POPSLDR/ui.lua†L1237-L1240】
+- **Aggregated scan roots:** USB game discovery merges entries from multiple `mass*:/POPS/` roots returned by classifier + metadata + probing fallback paths.【F:bin/POPSLDR/system.lua†L639-L757】
+- **Per-entry launch source:** Launch uses the selected game entry's stored source root (`source_root`) so POPStarter handoff is built from that specific root, not a single global mass index.【F:bin/POPSLDR/system.lua†L726-L757】【F:bin/POPSLDR/system.lua†L1548-L1619】
+- **Fallback when classifier data is unavailable:** runtime probes known `massN:/POPS/` roots and keeps partial list results when only some roots respond; failures on one root do not block other roots from being listed/launchable.【F:bin/POPSLDR/system.lua†L621-L637】【F:bin/POPSLDR/system.lua†L668-L757】
+- **TODO: verify:** BDM classification contract details are still provisional; confirm expected field semantics and mapping between `src/luasystem.cpp` and `iop/bdm_query/bdm_query.c` before tightening strict matching assumptions in docs or logic.【F:src/luasystem.cpp†L186-L223】【F:src/luasystem.cpp†L359-L429】【F:iop/bdm_query/bdm_query.c†L45-L65】
 
 ## Not handled here
 This document does **not** define POPStarter’s own `POPS/` folder expectations (e.g., `mass:/POPS/` or `pfs1:/POPS/`). Those remain POPStarter responsibilities and are validated elsewhere in the runtime.

--- a/docs/ai/DEVICE_DETECT.md
+++ b/docs/ai/DEVICE_DETECT.md
@@ -6,11 +6,18 @@
 3. **Marker fallback:** `.boot_mx4sio` / `.boot_usb` in app dir are used if RPC data is unavailable/incomplete.【F:src/luasystem.cpp†L413-L425】
 4. **Final fallback:** return `UNKNOWN` without hard failure.【F:src/luasystem.cpp†L428-L429】
 
+## USB root discovery + fallback policy
+- **Primary goal:** USB content is resolved from potentially multiple `mass*:/POPS/` roots (not a single global root).【F:bin/POPSLDR/system.lua†L639-L757】
+- **Classifier-assisted scan:** runtime iterates candidate `massN:/` roots and includes those classified as `USB` by `ClassifyMassDevice`.【F:bin/POPSLDR/system.lua†L647-L652】
+- **RPC metadata enrichment:** when available, `System.bdmList()` contributes additional `massN:/` roots via metadata index values to improve coverage.【F:bin/POPSLDR/system.lua†L642-L666】
+- **Fallback when classifier/RPC data is unavailable:** runtime probes known roots (`mass0:/`..`mass8:/`) for existing `POPS/` folders and merges any positives; partial results are valid and should still be shown in UI.【F:bin/POPSLDR/system.lua†L621-L637】【F:bin/POPSLDR/system.lua†L668-L757】
+
 ## Boot/device routing policy (current)
 - Lua `ClassifyMassDevice()` calls `System.classifyMassDevice(pathHint, APP_DIR_LOCAL, false)` to keep boot and UI routing non-blocking and avoid module autoload during sensitive early runtime on hardware.【F:bin/POPSLDR/system.lua†L120-L129】
 - `DetectBootDevice()` and `ResolveLaunchPolicy()` both use that single helper (plus explicit MMCE/HDD scene logic), so mass-family decisions share one source of truth while preserving compatibility fallback behavior.【F:bin/POPSLDR/system.lua†L131-L151】【F:bin/POPSLDR/system.lua†L1261-L1290】
 
 ## TODO: verify
 - Verify whether enabling `allowRpcLoad=true` for boot-time classification is safe across all PS2 hardware/device combinations (potential startup stability impact). Confirm in `src/luasystem.cpp` RPC bind/load path and IRX/module init ordering in `src/main.cpp`.【F:src/luasystem.cpp†L48-L89】【F:src/main.cpp†L327-L379】
+- **TODO: verify:** BDM classification contract details (`class`, `driver`, `port`, `index` and how they map to `massN:/`) are still provisional; confirm behavior at the producer/consumer boundaries in `src/luasystem.cpp` and `iop/bdm_query/bdm_query.c` before enforcing stricter matching logic.【F:src/luasystem.cpp†L186-L223】【F:src/luasystem.cpp†L359-L429】【F:iop/bdm_query/bdm_query.c†L45-L65】
 - Verify exact BDM driver-name mapping contract for USB vs MX4SIO (`bdm_dev_info.name`) against `iop/bdm_query/bdm_query.c` + ps2sdk BDM headers before tightening matching rules.【F:iop/bdm_query/bdm_query.c†L54-L59】【F:src/luasystem.cpp†L282-L285】
 - Verify `devNr`/`parNr` semantics (port/index mapping) across drivers/hardware; current metadata exposure is best-effort only.【F:iop/bdm_query/bdm_query.c†L57-L59】【F:src/luasystem.cpp†L406-L411】

--- a/docs/ai/UI_MAP.md
+++ b/docs/ai/UI_MAP.md
@@ -9,6 +9,7 @@
 - **Scene table:** `UI.SCENES = {GUSB, GSMB, GMX4SIO, GHDD, MMAIN, MPROFILE, CREDITS}` in `ui.lua`.【F:bin/POPSLDR/ui.lua†L11-L15】
 - **Scene dispatch:** In the main loop, `MMAIN` → main menu, `MPROFILE` → profile picker, `<= GHDD` → game list, `CREDITS` → credits screen.【F:bin/POPSLDR/system.lua†L1304-L1314】
 - **Main menu options:** UI presents `USB`, `MMCE`, `MX4SIO`, `HDD` and routes to the corresponding device pages and game list population logic.【F:bin/POPSLDR/ui.lua†L330-L428】
+- **USB page model:** There is one USB game-list scene (`GUSB`) and it is fed by merged USB roots; do not document or design separate FAT32/exFAT USB pages in this branch.
 
 ## Input mapping (Pads → UI events)
 - **Event mapping:** `Pad.Listen()` translates pad state into events:
@@ -32,8 +33,8 @@
 
 ## UI behaviors & pages (high-level)
 - **Exit modal:** `UI.Modal.OpenExit()` shows a confirmation box and `System.exitToBrowser()` is called on confirm.【F:bin/POPSLDR/ui.lua†L135-L176】
-- **Game list page:** `UI.GameList.Play()` renders the list, handles navigation, and calls `PLDR.RunPOPStarterGame` on confirm when a game is selected.【F:bin/POPSLDR/ui.lua†L242-L303】
-- **Main menu routing:** Selecting a device option triggers device detection and game list population (`PLDR.GetPS1GameLists` for USB/MMCE/MX4SIO; HDD module init + list build for HDD).【F:bin/POPSLDR/ui.lua†L365-L451】
+- **Game list page:** `UI.GameList.Play()` renders the list, handles navigation, and calls `PLDR.RunPOPStarterGame` on confirm when a game is selected; for USB this launch now uses per-entry source metadata instead of a single global `mass` index.【F:bin/POPSLDR/ui.lua†L242-L303】【F:bin/POPSLDR/ui.lua†L1185-L1240】【F:bin/POPSLDR/system.lua†L1548-L1619】
+- **Main menu routing:** Selecting USB triggers merged USB list population via `PLDR.GetMergedUsbGameList`, which aggregates games from detected `mass*:/POPS/` roots into the single USB page. MMCE/MX4SIO keep dedicated detection/list logic; HDD uses HDD module init and list build.【F:bin/POPSLDR/ui.lua†L1185-L1240】【F:bin/POPSLDR/system.lua†L639-L757】
 
 ## UNKNOWNs (not found in repo)
 - **Exact meaning of alignment constants at the Lua call sites** beyond the `ALIGN_*` bitmask definitions is not described in docs; to confirm usage, inspect `fntRenderString` and call sites.


### PR DESCRIPTION
### Motivation
- Align project docs with the current runtime behavior where USB content is presented as a single merged list rather than split FAT32/exFAT pages. 
- Clarify how USB roots are discovered and used so UI/launch behavior matches actual `mass*:/POPS/` aggregation implemented in the Lua runtime. 
- Call out remaining classifier/BDM contract uncertainty so follow-up verification is directed at the correct producer/consumer code.

### Description
- Updated `docs/ai/UI_MAP.md` to document the single USB page (`GUSB`) model, the merged-root USB list, and that USB launches use per-entry source metadata rather than a single global `mass` index. 
- Added `USB root discovery + fallback policy` to `docs/ai/DEVICE_DETECT.md` describing classifier-assisted scanning, optional `System.bdmList()` metadata enrichment, and probing fallback of `mass0:/`..`mass8:/` with partial-list tolerance. 
- Updated `docs/RUNTIME_LAYOUT.md` (runtime SOT) with the same USB behavior notes: aggregated `mass*:/POPS/` roots, per-entry launch source, fallback probing, and a short `TODO: verify` pointing to `src/luasystem.cpp` and `iop/bdm_query/bdm_query.c`. 
- This is a docs-only change and does not modify runtime code.

### Testing
- Ran `git diff --check` which completed with no issues. 
- Ran `rg -n "FAT32|exFAT|USBEXFAT|single global mass index|GetMergedUsbGameList|source_root|partial"` across the three modified docs which found and verified the intended phrases. 
- Changes were committed (`git commit`) as a docs-only update; no build or runtime tests were required for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936477098c8321ac7806259dc110f1)