### PR TITLE
Implement deterministic splash→credits→main startup flow

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1757,21 +1757,8 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, selected_root)
   LaunchEngine(popstarter, argv, reboot_iop, context)
 end
 
-function Touch(FILE)
-  if not doesFileExist(FILE) then
-    local FD = System.openFile(FILE, FCREATE)
-    System.closeFile(FD)
-    return true
-  else
-    return false
-  end
-end
-
 ---MAIN PROGRAM BEHAVIOUR BEGINS
-local initial_scene = UI.SCENES.MMAIN
-if Touch(ResolveWritablePath(".pldrs")) then
-  initial_scene = UI.SCENES.CREDITS
-end
+local initial_scene = UI.SCENES.CREDITS
 UI.WelcomeDraw.Play(initial_scene)
 if UI.Transition ~= nil then
   UI.Transition.allowSceneWrite = true

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -57,7 +57,7 @@ UI = {
     BOOT_SOUND = {
       ENABLED = true,
       PATH = "boot.adp",      -- relative to CWD (same folder as ui.lua on HostFS)
-      SECONDS = 3.0,          -- splash minimum hold to cover audio (adjust to match boot.adp)
+      SECONDS = 4.0,          -- splash minimum hold to cover audio (adjust to match boot.adp)
       CHANNEL = 0,
       VOLUME = 90,            -- master volume (0-100 typical)
       ADPCM_VOLUME = 90       -- per-channel ADPCM volume
@@ -1387,6 +1387,9 @@ if found == nil then return end
       end;
     };
     Credits = {
+      AUTO_EXIT_MS = 3000;
+      Timer = nil;
+      StartTime = 0;
       DrawOnly = function ()
         UI.Credits._draw_only = true
         UI.Credits.Play()
@@ -1414,9 +1417,21 @@ if you bought it you\'ve been scammed
         end
 
         if not UI.Credits._draw_only then
+          if UI.Credits.Timer == nil then
+            UI.Credits.Timer = Timer.new()
+            UI.Credits.StartTime = Timer.getTime(UI.Credits.Timer)
+          end
+          local now = Timer.getTime(UI.Credits.Timer)
+          if (now - UI.Credits.StartTime) >= UI.Credits.AUTO_EXIT_MS then
+            UI.Credits.Timer = nil
+            UI.SceneChange(UI.SCENES.MMAIN)
+            return
+          end
+
           Input_GetEvent()
           if UI.HandleGlobalInput(false) then return end
           if UI.Pad.Events.EXIT or UI.Pad.Events.BACK or UI.Pad.Events.ANY then
+            UI.Credits.Timer = nil
             UI.SceneChange(UI.SCENES.MMAIN)
           end
         end


### PR DESCRIPTION
### Motivation
- Make the startup timeline deterministic so boots always follow: splash → credits → main menu, and ensure the splash hold covers the boot audio.
- Ensure credits automatically advance after a short, predictable interval while preserving existing manual-skip input behavior.
- Remove first-run-only gating that made credit startup non-deterministic and introduced dead/conditional startup branches.
- TODO: verify whether the 4s splash baseline should be hold-only or include fade durations on target hardware/emulator.

### Description
- Set the splash hold baseline to 4.0 seconds by changing `UI.BOOT_SOUND.SECONDS = 4.0` in `bin/POPSLDR/ui.lua` (keeps existing fade-in/fade-out behavior unchanged).
- Added deterministic credits auto-exit using a timer in `UI.Credits` with `AUTO_EXIT_MS = 3000`, created via `Timer.new()` and sampled with `Timer.getTime()` to call `UI.SceneChange(UI.SCENES.MMAIN)` on timeout, and clear the timer on manual exit.
- Preserved and wired existing manual-skip behavior so input (`EXIT/BACK/ANY`) still transitions to the main menu and also resets the credits timer state.
- Simplified startup path in `bin/POPSLDR/system.lua` to always start at the credits scene by setting `initial_scene = UI.SCENES.CREDITS`, and removed the first-run `.pldrs` gate and its `Touch()` helper as dead behavior under the always-credits startup model.

### Testing
- Ran repository symbol searches for `BOOT_SOUND`, `CREDITS`, and `Touch` to verify the changes exist in `bin/POPSLDR/ui.lua` and `bin/POPSLDR/system.lua` (succeeded).
- Inspected the file diffs of the modified files to confirm the intended edits were applied (succeeded).
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/ui.lua && luac -p bin/POPSLDR/system.lua`, but `luac` is not available in the execution environment so the syntax check could not be completed (failed); recommend running Lua syntax checks or CI.
- Recommend running the full CI/build target `make clean elfloader all package` on CI or a developer machine to validate the runtime build and perform hardware/emulator verification (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936fba15788321ba5b03c23ed8bd46)