### PR TITLE
Update credits scene text with fixed multiline copy

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1398,19 +1398,19 @@ if found == nil then return end
       Play = function ()
         local layout = UI.LAYOUT
         local currcol = UI.CCOL.GREY
+        local credits_text = [[POPSLoader for POPStarter
+based off v1.0.0 - rev3
+BETA - 6
+Coded by El_isra
+Based on Enceladus by Daniel Sant0s, Graphics by Berion, Modified by Ripto
+Special Thanks To:
+krHACKen for making POPStarter
+uyjulian, fjtrujy, HWC, and others for always helping
+This Program is FREE and OPEN-SOURCE
+If you bought it, you've been scammed.]]
 
-        Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 20, UI.SCR.X, 40, "POPStarter Loader\n"..tostring(POPSLDR_VER or ""), currcol)
-        Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 20, UI.SCR.X, 40, "Coded By El_isra", currcol)
-        Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 80, 20, UI.SCR.X, UI.SCR.Y, [[
-Based on Enceladus by Daniel santos
-
-Special thanks to:
-krHACKen: for making POPStarter
-uyjulian, fjtrujy, HWC and others for always helping me
-
-This program is free and open source
-if you bought it you\'ve been scammed
-]], currcol)
+        Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y, 22, UI.SCR.X, UI.SCR.Y, credits_text, currcol)
+        -- TODO: verify whether POPSLDR_VER should still be shown anywhere else after this copy change.
         if UI.BUILD_INFO ~= nil and UI.BUILD_INFO.stamp ~= nil then
           local stamp_y = Round(layout.FOOTER_LABEL_Y - 18)
           Font.ftPrint(SFONT, layout.SAFE.L, stamp_y, 0, UI.SCR.X, 16, UI.BUILD_INFO.stamp, UI.CCOL.GREY)


### PR DESCRIPTION
### Motivation
- The credits screen previously used multiple `Font.ftPrintMultiLineAligned` calls and included `POPSLDR_VER`, which allowed runtime wrapping to alter intended phrasing; the change consolidates the copy into a single multiline literal to preserve exact line breaks and capitalization.
- The request required an exact replacement of the title/body text and explicit line spacing so rendering does not reflow phrases unexpectedly.
- TODO: verify whether `POPSLDR_VER` should still be shown elsewhere after this copy change.

### Description
- Replaced the existing credits rendering in `UI.Credits.Play()` (file `bin/POPSLDR/ui.lua`) with a single Lua multiline string containing the exact requested copy and capitalization.\
- Switched to one `Font.ftPrintMultiLineAligned(...)` call (using spacing `22`) to render the full block so wrapping cannot change phrasing.\
- Removed the previous split title/body print calls and added a `TODO` comment to re-evaluate `POPSLDR_VER` placement.\
- The change is contained to `bin/POPSLDR/ui.lua` and preserves existing build/footer stamps logic.

### Testing
- Verified the modified block in `bin/POPSLDR/ui.lua` by inspecting the file and line-range (`nl`/`sed`) and reviewed the `git diff` showing the update (succeeded).\
- Searched for `POPSLDR_VER` usage with `rg` to confirm remaining references (succeeded).\
- Attempted a Lua parse/load check with `lua -e "assert(loadfile('bin/POPSLDR/ui.lua'))"`, but the `lua` interpreter is not installed in this environment so the parse check could not be performed (failed).\
- Committed the change (`git commit`) and confirmed the commit summary (`git show --stat`) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993708d5edc8321b0db14072dd79a9d)