### PR TITLE
ui: remove footer legend from credits scene

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1436,15 +1436,6 @@ If you bought it, you've been scammed.]]
           end
         end
 
-        local labels, order = UI.Footer.ResolveLegend({
-          order = UI.Footer.order_with_start_r2,
-          order_id = "start_r2",
-          circle = UI.Footer.labels.circle_other,
-          cross = UI.Footer.labels.cross_confirm,
-          square = "Cover Art",
-          start = UI.Footer.labels.start_profiles
-        })
-        UI.Footer.Draw(labels, order)
       end
     };
   }


### PR DESCRIPTION
### Motivation
- The credits scene should render without the footer legend so the credits view is visually uncluttered while preserving footer behavior everywhere else.

### Description
- Removed the `UI.Footer.ResolveLegend(...)` + `UI.Footer.Draw(...)` call from `UI.Credits.Play()` in `bin/POPSLDR/ui.lua`, keeping all footer-system logic intact and scoped to the credits scene only.

### Testing
- Verified remaining footer usage sites via `rg -n "ResolveLegend\(|Footer\.Draw\(" bin/POPSLDR/ui.lua` to ensure other scenes still draw the footer (succeeded).
- Inspected the credits block with `nl -ba bin/POPSLDR/ui.lua | sed -n '1400,1465p'` to confirm the legend/draw lines were removed from `UI.Credits.Play()` (succeeded).
- Attempted `luac -p bin/POPSLDR/ui.lua` for a syntax check but `luac` is not installed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993714fb7ec8321b2304c550d6e238c)