### PR TITLE
Unify POPS Profiles into Settings page; add persisted settings and deferred BDMA apply

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -33,16 +33,16 @@ local IMGS = {
   "circle.png",
   "cross.png",
   "R2.png",
-  --"down.png",
+  "down.png",
   --"L1.png",
   --"L2.png",
   --"L3.png",
-  --"left.png",
+  "left.png",
   --"R1.png",
   --"R3.png",
-  --"right.png",
+  "right.png",
   "square.png",
-  --"up.png",
+  "up.png",
 }
 local IMG_SOURCES = {}
 for x=1, #IMGS do

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -458,7 +458,7 @@ local function EnsureDirectory(path)
   return ok
 end
 
-local function RemoveDirectoryRecursive(path, progress)
+local function RemoveDirectoryRecursive(path)
   local normalized = NormalizeDirPath(path)
   if not doesFolderExist(normalized) then
     return true
@@ -474,7 +474,7 @@ local function RemoveDirectoryRecursive(path, progress)
       if name ~= "." and name ~= ".." then
         local child = JoinPath(normalized, name)
         if entry.directory then
-          local child_ok, child_err = RemoveDirectoryRecursive(child, progress)
+          local child_ok, child_err = RemoveDirectoryRecursive(child)
           if not child_ok then
             return false, child_err
           end
@@ -490,42 +490,8 @@ local function RemoveDirectoryRecursive(path, progress)
         end
       end
     end
-    if progress ~= nil then
-      progress.current = progress.current + 1
-      if progress.tick ~= nil then
-        progress.tick()
-      end
-    end
   end
   return true
-end
-
-function PLDR.CountPopstarterEntries()
-  local function count_entries(path)
-    local normalized = NormalizeDirPath(path)
-    if not doesFolderExist(normalized) then
-      return 0
-    end
-    local ok, entries = pcall(System.listDirectory, normalized)
-    if not ok or entries == nil then
-      return 0
-    end
-    local total = 0
-    for i = 1, #entries do
-      local entry = entries[i]
-      if entry ~= nil and entry.name ~= nil then
-        local name = entry.name
-        if name ~= "." and name ~= ".." then
-          total = total + 1
-          if entry.directory then
-            total = total + count_entries(JoinPath(normalized, name))
-          end
-        end
-      end
-    end
-    return total
-  end
-  return count_entries(POPSTARTER_PACK_ROOT)
 end
 
 function PLDR.ApplyBdmaMode(mode_key, progress_cb)
@@ -541,12 +507,11 @@ function PLDR.ApplyBdmaMode(mode_key, progress_cb)
     return false, "unknown mode"
   end
 
-  local total_delete = PLDR.CountPopstarterEntries()
   local total_copy = 0
   if mode.suffix ~= nil then
     total_copy = #BDMA_PAYLOAD_INVENTORY
   end
-  local total = total_delete + total_copy + 2
+  local total = total_copy + 3
   if total < 1 then total = 1 end
 
   local state = {
@@ -564,16 +529,15 @@ function PLDR.ApplyBdmaMode(mode_key, progress_cb)
   end
   tick()
 
-  local ok, err = RemoveDirectoryRecursive(POPSTARTER_PACK_ROOT, {current = 0, tick = function()
-    state.current = state.current + 1
-    tick()
-  end})
+  local ok, err = RemoveDirectoryRecursive(POPSTARTER_PACK_ROOT)
   if not ok then
     state.stage = "Error"
     state.message = tostring(err)
     tick()
     return false, err
   end
+  state.stage = "Deleting/Preparing"
+  tick()
   if doesFolderExist(POPSTARTER_PACK_ROOT) then
     local rm_ok, rm_err = pcall(System.removeDirectory, POPSTARTER_PACK_ROOT)
     if not rm_ok then
@@ -1943,18 +1907,23 @@ end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.CREDITS
-if UI.Credits ~= nil then
-  UI.Credits.is_boot_sequence = true
-  if UI.Credits.ResetTimer ~= nil then
-    UI.Credits.ResetTimer()
-  end
-end
 UI.WelcomeDraw.Play(initial_scene)
 if UI.Transition ~= nil then
   UI.Transition.allowSceneWrite = true
 end
 UI.CURSCENE = initial_scene
 UI.LASTSCENE = initial_scene
+if UI.Transition ~= nil then
+  UI.Transition.allowSceneWrite = false
+end
+if UI.Credits ~= nil and UI.Credits.PlayBootSequence ~= nil then
+  UI.Credits.PlayBootSequence(4000)
+end
+if UI.Transition ~= nil then
+  UI.Transition.allowSceneWrite = true
+end
+UI.CURSCENE = UI.SCENES.MMAIN
+UI.LASTSCENE = UI.SCENES.MMAIN
 if UI.Transition ~= nil then
   UI.Transition.allowSceneWrite = false
 end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1927,6 +1927,9 @@ UI.LASTSCENE = UI.SCENES.MMAIN
 if UI.Transition ~= nil then
   UI.Transition.allowSceneWrite = false
 end
+if UI.BootFadeInScene ~= nil then
+  UI.BootFadeInScene(UI.SCENES.MMAIN, 24)
+end
 
 while true do
   UI.BottomDraw.Play()

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -273,6 +273,12 @@ function PLDR.GetDefaultDkwdrvPath()
   return "mc0:/PS1_DKWDRV/DKWDRV.ELF"
 end
 
+local function ClampValue(value, min_val, max_val)
+  if value < min_val then return min_val end
+  if value > max_val then return max_val end
+  return value
+end
+
 local function LoadSettingsFile()
   local path = ResolveWritablePath(SETTINGS_FILE)
   if not doesFileExist(path) then
@@ -305,7 +311,7 @@ function PLDR.LoadSettings()
     mode = defaults.BDMA_MODE
   end
   local profile = tonumber(cfg.PROFILE_INDEX) or defaults.PROFILE_INDEX
-  profile = CLAMP(profile, 1, math.max(#PLDR.PROFILES, 1))
+  profile = ClampValue(profile, 1, math.max(#PLDR.PROFILES, 1))
   local dkwdrv = tostring(cfg.DKWDRV_PATH or defaults.DKWDRV_PATH)
   if dkwdrv == "" then
     dkwdrv = defaults.DKWDRV_PATH

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -214,6 +214,11 @@ PLDR = {
   GAMES = {};
   HDDCACHE = nil;
   PROFILES = {};
+  SETTINGS = {
+    BDMA_MODE = "NONE",
+    PROFILE_INDEX = 1,
+    DKWDRV_PATH = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+  };
   HDD = {
     USECACHE = false;
     LOADSTATE = 0; -- 0:NOT_LOADED, 1:LOADED, -1:LOADED_BUT_FAILED
@@ -243,6 +248,95 @@ PLDR = {
     INDEX = 1
   }
 }
+
+local SETTINGS_FILE = "settings.lua"
+local BDMA_MODES = {
+  { key = "NONE", label = "None", suffix = nil },
+  { key = "USBEXFAT", label = "USB exFAT", suffix = ".usbexfat" },
+  { key = "MMCE", label = "MMCE", suffix = ".mmce" },
+  { key = "MX4SIO", label = "MX4SIO", suffix = ".mx4sio" }
+}
+local BDMA_MODE_INDEX = {}
+for i = 1, #BDMA_MODES do
+  BDMA_MODE_INDEX[BDMA_MODES[i].key] = i
+end
+
+function PLDR.GetBdmaModes()
+  return BDMA_MODES
+end
+
+function PLDR.GetBdmaModeIndex(mode_key)
+  return BDMA_MODE_INDEX[mode_key] or 1
+end
+
+function PLDR.GetDefaultDkwdrvPath()
+  return "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+end
+
+local function LoadSettingsFile()
+  local path = ResolveWritablePath(SETTINGS_FILE)
+  if not doesFileExist(path) then
+    return nil
+  end
+  local loader, err = loadfile(path)
+  if loader == nil then
+    LOG("Settings load failed:", err)
+    return nil
+  end
+  local ok, data = pcall(loader)
+  if not ok then
+    LOG("Settings run failed:", data)
+    return nil
+  end
+  if type(data) == "table" then
+    return data
+  end
+  return nil
+end
+
+function PLDR.LoadSettings()
+  local cfg = LoadSettingsFile()
+  local defaults = PLDR.SETTINGS
+  if type(cfg) ~= "table" then
+    cfg = {}
+  end
+  local mode = tostring(cfg.BDMA_MODE or defaults.BDMA_MODE)
+  if BDMA_MODE_INDEX[mode] == nil then
+    mode = defaults.BDMA_MODE
+  end
+  local profile = tonumber(cfg.PROFILE_INDEX) or defaults.PROFILE_INDEX
+  profile = CLAMP(profile, 1, math.max(#PLDR.PROFILES, 1))
+  local dkwdrv = tostring(cfg.DKWDRV_PATH or defaults.DKWDRV_PATH)
+  if dkwdrv == "" then
+    dkwdrv = defaults.DKWDRV_PATH
+  end
+  PLDR.SETTINGS = {
+    BDMA_MODE = mode,
+    PROFILE_INDEX = profile,
+    DKWDRV_PATH = dkwdrv
+  }
+  if #PLDR.PROFILES > 0 and PLDR.PROFILES[profile] ~= nil then
+    PLDR.POPSTARTER_PATH = PLDR.PROFILES[profile].ELF
+  end
+end
+
+local function SaveSettingsFile(settings)
+  local path = ResolveWritablePath(SETTINGS_FILE)
+  local payload = string.format(
+    "return {\n  BDMA_MODE = %q,\n  PROFILE_INDEX = %d,\n  DKWDRV_PATH = %q\n}\n",
+    settings.BDMA_MODE,
+    settings.PROFILE_INDEX,
+    settings.DKWDRV_PATH
+  )
+  local ok, fd = pcall(System.openFile, path, FCREATE)
+  if not ok or fd == nil or fd < 0 then
+    LOG("Settings save open failed:", path, fd)
+    return false
+  end
+  System.writeFile(fd, payload, #payload)
+  System.closeFile(fd)
+  return true
+end
 local function DetectMX4SIOPrefixHint()
   local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
   if doesFileExist(mx_marker) then
@@ -278,6 +372,7 @@ if MMCE_SLOT0_READY ~= nil and MMCE_SLOT0_READY >= 0 then
 end
 
 require("pops_profiles")
+PLDR.LoadSettings()
 LOG("system.lua: before require('ui')")
 local ok_ui, ui_or_err = pcall(require, "ui")
 LOG("system.lua: after require('ui')")
@@ -328,39 +423,21 @@ end
 require("images")
 
 local POPSTARTER_PACK_ROOT = "mc0:/POPSTARTER"
-local POPSTARTER_PACK_FILES = {
+local BDMA_PAYLOAD_SOURCE_DIR = "POPSLDR"
+local BDMA_PAYLOAD_INVENTORY = {
   "usbd.irx",
   "usbhdfsd.irx",
   "icon.sys",
   "list.icn",
   "del.icn"
 }
-local POPSTARTER_PACKS = {
-  USBEXFAT = {
-    label = "USB exFAT",
-    folder = "USBEXFAT"
-  },
-  MMCE = {
-    label = "MMCE",
-    folder = "MMCE"
-  },
-  MX4SIO = {
-    label = "MX4SIO",
-    folder = "MX4SIO"
-  }
-}
-for key, pack in pairs(POPSTARTER_PACKS) do
-  pack.files = {}
-  for i = 1, #POPSTARTER_PACK_FILES do
-    local name = POPSTARTER_PACK_FILES[i]
-    pack.files[i] = {
-      dest = name,
-      source = string.format("POPSTARTER/%s/%s", pack.folder, name)
-    }
-  end
-end
 
-local function ResolvePackSource(rel)
+local function ResolveBdmaSource(name, mode)
+  local suffix = mode.suffix
+  if suffix == nil then
+    return nil
+  end
+  local rel = BDMA_PAYLOAD_SOURCE_DIR.."/"..name..suffix
   return ResolveAsset(rel) or JoinPath(APP_DIR_LOCAL, rel)
 end
 
@@ -375,7 +452,7 @@ local function EnsureDirectory(path)
   return ok
 end
 
-local function RemoveDirectoryRecursive(path)
+local function RemoveDirectoryRecursive(path, progress)
   local normalized = NormalizeDirPath(path)
   if not doesFolderExist(normalized) then
     return true
@@ -391,7 +468,7 @@ local function RemoveDirectoryRecursive(path)
       if name ~= "." and name ~= ".." then
         local child = JoinPath(normalized, name)
         if entry.directory then
-          local child_ok, child_err = RemoveDirectoryRecursive(child)
+          local child_ok, child_err = RemoveDirectoryRecursive(child, progress)
           if not child_ok then
             return false, child_err
           end
@@ -407,61 +484,162 @@ local function RemoveDirectoryRecursive(path)
         end
       end
     end
-  end
-  return true
-end
-
-function PLDR.ApplyPopstarterPack(pack_key)
-  local pack = POPSTARTER_PACKS[pack_key]
-  if pack == nil then
-    UI.Notif_queue.add("Unknown POPSTARTER pack: "..tostring(pack_key))
-    return false
-  end
-  if not EnsureDirectory(POPSTARTER_PACK_ROOT) then
-    UI.Notif_queue.add("Failed to create "..POPSTARTER_PACK_ROOT)
-    return false
-  end
-  local failures = {}
-  for i = 1, #pack.files do
-    local file = pack.files[i]
-    local source = ResolvePackSource(file.source)
-    local dest = POPSTARTER_PACK_ROOT.."/"..file.dest
-    if source == nil or not doesFileExist(source) then
-      failures[#failures + 1] = file.dest
-    else
-      local ok, err = pcall(System.copyFile, source, dest)
-      if not ok then
-        LOG("Copy failed:", source, dest, err)
-        failures[#failures + 1] = file.dest
+    if progress ~= nil then
+      progress.current = progress.current + 1
+      if progress.tick ~= nil then
+        progress.tick()
       end
     end
   end
-  if #failures > 0 then
-    UI.Notif_queue.add("Failed to install "..pack.label.." pack")
-    return false
-  end
-  UI.Notif_queue.add("Installed "..pack.label.." pack to "..POPSTARTER_PACK_ROOT)
   return true
 end
 
-function PLDR.ResetPopstarterPack()
-  if not doesFolderExist(POPSTARTER_PACK_ROOT) then
-    UI.Notif_queue.add("POPSTARTER reset: folder not found")
-    return true
+function PLDR.CountPopstarterEntries()
+  local function count_entries(path)
+    local normalized = NormalizeDirPath(path)
+    if not doesFolderExist(normalized) then
+      return 0
+    end
+    local ok, entries = pcall(System.listDirectory, normalized)
+    if not ok or entries == nil then
+      return 0
+    end
+    local total = 0
+    for i = 1, #entries do
+      local entry = entries[i]
+      if entry ~= nil and entry.name ~= nil then
+        local name = entry.name
+        if name ~= "." and name ~= ".." then
+          total = total + 1
+          if entry.directory then
+            total = total + count_entries(JoinPath(normalized, name))
+          end
+        end
+      end
+    end
+    return total
   end
-  local ok, err = RemoveDirectoryRecursive(POPSTARTER_PACK_ROOT)
+  return count_entries(POPSTARTER_PACK_ROOT)
+end
+
+function PLDR.ApplyBdmaMode(mode_key, progress_cb)
+  local mode = nil
+  local modes = PLDR.GetBdmaModes()
+  for i = 1, #modes do
+    if modes[i].key == mode_key then
+      mode = modes[i]
+      break
+    end
+  end
+  if mode == nil then
+    return false, "unknown mode"
+  end
+
+  local total_delete = PLDR.CountPopstarterEntries()
+  local total_copy = 0
+  if mode.suffix ~= nil then
+    total_copy = #BDMA_PAYLOAD_INVENTORY
+  end
+  local total = total_delete + total_copy + 2
+  if total < 1 then total = 1 end
+
+  local state = {
+    stage = "Deleting/Preparing",
+    current = 0,
+    total = total,
+    copied = 0,
+    copy_total = total_copy,
+    message = ""
+  }
+  local function tick()
+    if progress_cb ~= nil then
+      progress_cb(state)
+    end
+  end
+  tick()
+
+  local ok, err = RemoveDirectoryRecursive(POPSTARTER_PACK_ROOT, {current = 0, tick = function()
+    state.current = state.current + 1
+    tick()
+  end})
   if not ok then
-    UI.Notif_queue.add("POPSTARTER reset failed")
-    LOG("Reset POPSTARTER failed:", err)
-    return false
+    state.stage = "Error"
+    state.message = tostring(err)
+    tick()
+    return false, err
   end
-  local rm_ok, rm_err = pcall(System.removeDirectory, POPSTARTER_PACK_ROOT)
-  if not rm_ok then
-    UI.Notif_queue.add("POPSTARTER reset failed")
-    LOG("Remove POPSTARTER dir failed:", rm_err)
-    return false
+  if doesFolderExist(POPSTARTER_PACK_ROOT) then
+    local rm_ok, rm_err = pcall(System.removeDirectory, POPSTARTER_PACK_ROOT)
+    if not rm_ok then
+      state.stage = "Error"
+      state.message = tostring(rm_err)
+      tick()
+      return false, rm_err
+    end
   end
-  UI.Notif_queue.add("POPSTARTER reset: mc0:/POPSTARTER removed")
+
+  state.current = state.current + 1
+  tick()
+
+  if mode.suffix ~= nil then
+    if not EnsureDirectory(POPSTARTER_PACK_ROOT) then
+      state.stage = "Error"
+      state.message = "create directory failed"
+      tick()
+      return false, state.message
+    end
+    state.stage = "Copying"
+    tick()
+    for i = 1, #BDMA_PAYLOAD_INVENTORY do
+      local name = BDMA_PAYLOAD_INVENTORY[i]
+      local source = ResolveBdmaSource(name, mode)
+      local dest = JoinPath(POPSTARTER_PACK_ROOT, name)
+      if source == nil or not doesFileExist(source) then
+        state.stage = "Error"
+        state.message = "missing payload "..name..mode.suffix
+        tick()
+        return false, state.message
+      end
+      local cp_ok, cp_err = pcall(System.copyFile, source, dest)
+      if not cp_ok then
+        state.stage = "Error"
+        state.message = tostring(cp_err)
+        tick()
+        return false, cp_err
+      end
+      state.copied = i
+      state.current = state.current + 1
+      tick()
+    end
+  end
+
+  state.stage = "Finalizing"
+  state.current = total - 1
+  tick()
+  state.stage = "Done"
+  state.current = total
+  tick()
+  return true
+end
+
+function PLDR.SaveSettings(settings, opts)
+  local previous_mode = PLDR.SETTINGS.BDMA_MODE
+  PLDR.SETTINGS = {
+    BDMA_MODE = settings.BDMA_MODE,
+    PROFILE_INDEX = settings.PROFILE_INDEX,
+    DKWDRV_PATH = settings.DKWDRV_PATH
+  }
+  local ok = SaveSettingsFile(PLDR.SETTINGS)
+  if not ok then
+    return false, "save failed"
+  end
+  if #PLDR.PROFILES > 0 and PLDR.PROFILES[settings.PROFILE_INDEX] ~= nil then
+    PLDR.POPSTARTER_PATH = PLDR.PROFILES[settings.PROFILE_INDEX].ELF
+  end
+  local apply_bdma = opts ~= nil and opts.apply_bdma == true
+  if apply_bdma and previous_mode ~= settings.BDMA_MODE then
+    return PLDR.ApplyBdmaMode(settings.BDMA_MODE, opts.progress_cb)
+  end
   return true
 end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1943,6 +1943,12 @@ end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.CREDITS
+if UI.Credits ~= nil then
+  UI.Credits.is_boot_sequence = true
+  if UI.Credits.ResetTimer ~= nil then
+    UI.Credits.ResetTimer()
+  end
+end
 UI.WelcomeDraw.Play(initial_scene)
 if UI.Transition ~= nil then
   UI.Transition.allowSceneWrite = true

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -494,13 +494,38 @@ if found == nil then return end
           -- no-op placeholder for future custom splash text
         end
 
-        -- Exact target: 3.0s splash at 60Hz = 180 frames.
-        local splash_frames = 180
+        -- Exact boot splash timing: 3.0 seconds total at 60Hz.
+        local splash_total_frames = 180
+        local splash_fade_in_frames = 24
+        local splash_fade_out_frames = 24
+        local splash_hold_frames = splash_total_frames - splash_fade_in_frames - splash_fade_out_frames
+        if splash_hold_frames < 0 then splash_hold_frames = 0 end
+
         TryBootSound()
-        for _ = 1, splash_frames do
+        for i = 1, splash_fade_in_frames do
           DrawBackground()
           DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
-          Screen.flip() -- keep rendering during timed wait
+          local t = i / splash_fade_in_frames
+          local overlay_alpha = Round(128 * (1 - t))
+          if overlay_alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+          end
+          Screen.flip()
+        end
+        for _ = 1, splash_hold_frames do
+          DrawBackground()
+          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
+          Screen.flip()
+        end
+        for i = 1, splash_fade_out_frames do
+          DrawBackground()
+          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
+          local t = i / splash_fade_out_frames
+          local overlay_alpha = Round(128 * t)
+          if overlay_alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+          end
+          Screen.flip()
         end
         DrawTargetScene(next_scene)
         Screen.flip()
@@ -1537,15 +1562,8 @@ if found == nil then return end
     Credits = {
       BOOT_AUTO_EXIT_MS = 4000;
       is_boot_sequence = false;
-      Timer = nil;
-      StartTime = 0;
-      ResetTimer = function ()
-        UI.Credits.Timer = nil
-        UI.Credits.StartTime = 0
-      end;
       Open = function (is_boot_sequence)
         UI.Credits.is_boot_sequence = (is_boot_sequence == true)
-        UI.Credits.ResetTimer()
         UI.SceneChange(UI.SCENES.CREDITS)
       end;
       DrawOnly = function ()
@@ -1558,15 +1576,42 @@ if found == nil then return end
         if total_ms < 0 then total_ms = 0 end
         local total_frames = math.floor((total_ms / 1000) * 60 + 0.5)
         if total_frames < 1 then total_frames = 1 end
+        local fade_in_frames = 24
+        local fade_out_frames = 24
+        local hold_frames = total_frames - fade_in_frames - fade_out_frames
+        if hold_frames < 0 then hold_frames = 0 end
+
         UI.Credits.is_boot_sequence = true
-        UI.Credits.ResetTimer()
-        for _ = 1, total_frames do
+
+        for i = 1, fade_in_frames do
+          UI.BottomDraw.Play()
+          UI.Credits.DrawOnly()
+          local t = i / fade_in_frames
+          local overlay_alpha = Round(128 * (1 - t))
+          if overlay_alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+          end
+          UI.flip()
+        end
+
+        for _ = 1, hold_frames do
           UI.BottomDraw.Play()
           UI.Credits.DrawOnly()
           UI.flip()
         end
+
+        for i = 1, fade_out_frames do
+          UI.BottomDraw.Play()
+          UI.Credits.DrawOnly()
+          local t = i / fade_out_frames
+          local overlay_alpha = Round(128 * t)
+          if overlay_alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+          end
+          UI.flip()
+        end
+
         UI.Credits.is_boot_sequence = false
-        UI.Credits.ResetTimer()
       end;
       Play = function ()
         local layout = UI.LAYOUT
@@ -1592,26 +1637,10 @@ youtube.com/@hugopocked6695]]
         end
 
         if not UI.Credits._draw_only then
-          if UI.Credits.Timer == nil then
-            UI.Credits.Timer = Timer.new()
-            UI.Credits.StartTime = Timer.getTime(UI.Credits.Timer)
-          end
-
-          if UI.Credits.is_boot_sequence then
-            local now = Timer.getTime(UI.Credits.Timer)
-            if (now - UI.Credits.StartTime) >= UI.Credits.BOOT_AUTO_EXIT_MS then
-              UI.Credits.is_boot_sequence = false
-              UI.Credits.ResetTimer()
-              UI.SceneChange(UI.SCENES.MMAIN)
-              return
-            end
-          end
-
           Input_GetEvent()
           if UI.HandleGlobalInput(false) then return end
           if UI.Pad.Events.EXIT or UI.Pad.Events.BACK then
             UI.Credits.is_boot_sequence = false
-            UI.Credits.ResetTimer()
             UI.SceneChange(UI.SCENES.MMAIN)
           end
         end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -942,19 +942,61 @@ if found == nil then return end
         UI.ProfileQuery.init_done = true
       end;
       EditDkwdrvPath = function ()
-        -- TODO: verify the intended external path editor entrypoint in this branch.
-        if type(ExternalPathEditor) == "table" and type(ExternalPathEditor.Edit) == "function" then
-          local ok, value = pcall(ExternalPathEditor.Edit, UI.ProfileQuery.dkwdrv_path)
+        local current = UI.ProfileQuery.dkwdrv_path
+        local function try_editor(fn)
+          local ok, value = pcall(fn, current)
           if ok and type(value) == "string" and value ~= "" then
             UI.ProfileQuery.dkwdrv_path = value
             UI.Notif_queue.add("DKWDRV path updated")
+            return true
           end
+          return false
+        end
+        if type(ExternalPathEditor) == "table" and type(ExternalPathEditor.Edit) == "function" and try_editor(ExternalPathEditor.Edit) then
           return
         end
-        UI.Notif_queue.add("Path editor unavailable\nTODO: verify external editor hook")
+        if type(PathEditor) == "table" and type(PathEditor.Edit) == "function" and try_editor(PathEditor.Edit) then
+          return
+        end
+        if type(OSK) == "table" then
+          if type(OSK.EditPath) == "function" and try_editor(OSK.EditPath) then return end
+          if type(OSK.Edit) == "function" and try_editor(OSK.Edit) then return end
+        end
+        if type(System) == "table" then
+          if type(System.editPath) == "function" and try_editor(System.editPath) then return end
+          if type(System.openOSK) == "function" and try_editor(System.openOSK) then return end
+        end
+        UI.Notif_queue.add("Path editor unavailable")
+      end;
+      DrawHintWithIcons = function (left_key, right_key, text, y)
+        local cx = UI.SCR.X_MID
+        local left_icon = IMG[left_key]
+        local right_icon = IMG[right_key]
+        local gap = 10
+        local max_w = 0
+        if left_icon ~= nil then
+          local w = Graphics.getImageWidth(left_icon)
+          if w ~= nil and w > max_w then max_w = w end
+        end
+        if right_icon ~= nil then
+          local w = Graphics.getImageWidth(right_icon)
+          if w ~= nil and w > max_w then max_w = w end
+        end
+        local text_half = 130
+        local left_x = cx - text_half - gap - max_w
+        local right_x = cx + text_half + gap
+        if left_icon ~= nil then
+          local w = Graphics.getImageWidth(left_icon)
+          local h = Graphics.getImageHeight(left_icon)
+          Graphics.drawImage(left_icon, left_x, y - (h / 2), UI.CCOL.GREY)
+        end
+        if right_icon ~= nil then
+          local h = Graphics.getImageHeight(right_icon)
+          Graphics.drawImage(right_icon, right_x, y - (h / 2), UI.CCOL.GREY)
+        end
+        Font.ftPrint(BFONT, cx, y - 9, 8, UI.SCR.X, 16, text, UI.CCOL.GREY)
       end;
       DrawProgress = function (info)
-        local layout = UI.LAYOUT
         local box_w = 360
         local box_h = 130
         local box_x = UI.SCR.X_MID - (box_w / 2)
@@ -988,7 +1030,7 @@ if found == nil then return end
         end
         Screen.flip()
       end;
-      SaveAndExit = function (target_scene)
+      Save = function (target_scene)
         local modes = PLDR.GetBdmaModes()
         local selected_mode = modes[UI.ProfileQuery.bdma_mode_index] or modes[1]
         local profcnt = #PLDR.PROFILES
@@ -997,13 +1039,6 @@ if found == nil then return end
           BDMA_MODE = selected_mode.key,
           PROFILE_INDEX = profile_index,
           DKWDRV_PATH = UI.ProfileQuery.dkwdrv_path
-        }
-        UI.ProfileQuery.progress = {
-          stage = "Deleting/Preparing",
-          current = 0,
-          total = 1,
-          copied = 0,
-          copy_total = 0
         }
         local ok, err = PLDR.SaveSettings(payload, {
           apply_bdma = true,
@@ -1015,8 +1050,14 @@ if found == nil then return end
         if not ok then
           UI.Notif_queue.add("Settings save failed")
           LOG("Settings save failed:", err)
-          return
+          return false
         end
+        UI.ProfileQuery.progress = nil
+        UI.SceneChange(target_scene)
+        return true
+      end;
+      Cancel = function (target_scene)
+        UI.ProfileQuery.init_done = false
         UI.ProfileQuery.progress = nil
         UI.SceneChange(target_scene)
       end;
@@ -1031,19 +1072,22 @@ if found == nil then return end
         local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
 
         Font.ftPrint(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 8, UI.SCR.X, 16, "Settings", UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 30, 8, UI.SCR.X, 16, "LEFT/RIGHT BDMA MODE: "..mode.label, UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 8, UI.SCR.X, 16, "UP/DOWN PROFILE: "..UI.ProfileQuery.curopt.."/"..math.max(profcnt, 1), UI.CCOL.GREY)
 
+        UI.ProfileQuery.DrawHintWithIcons("left", "right", "BDMA MODE", layout.TITLE_Y + 40)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 58, 8, UI.SCR.X, 16, mode.label, UI.CCOL.GREY)
+
+        UI.ProfileQuery.DrawHintWithIcons("up", "down", "POPS PROFILE", layout.TITLE_Y + 98)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 116, 8, UI.SCR.X, 16, tostring(UI.ProfileQuery.curopt).."/"..tostring(math.max(profcnt, 1)), UI.CCOL.GREY)
         if profile ~= nil then
-          Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 92, 8, UI.SCR.X, 16, profile.DESC, UI.CCOL.GREY)
-          Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 116, 8, UI.SCR.X, 16, profile.ELF, Color.new(128,128,128, 110))
+          Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 136, 8, UI.SCR.X, 16, profile.DESC, UI.CCOL.GREY)
         end
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 156, 8, UI.SCR.X, 16, "X: Edit DKWDRV Path", UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 180, 8, UI.SCR.X, 16, UI.ProfileQuery.dkwdrv_path, Color.new(128,128,128, 110))
+
+        UI.ProfileQuery.DrawHintWithIcons("cross", "cross", "DKWDRV PATH", layout.TITLE_Y + 176)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 194, 8, UI.SCR.X, 16, UI.ProfileQuery.dkwdrv_path, Color.new(128,128,128, 110))
 
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-        if UI.Pad.Events.EXIT then UI.ProfileQuery.SaveAndExit(UI.SCENES.CREDITS) end
+
         if UI.Pad.Events.NAV_RIGHT then
           UI.ProfileQuery.bdma_mode_index = UI.ProfileQuery.bdma_mode_index + 1
           if UI.ProfileQuery.bdma_mode_index > #modes then UI.ProfileQuery.bdma_mode_index = 1 end
@@ -1054,23 +1098,25 @@ if found == nil then return end
         end
         if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, math.max(profcnt, 1)) end
         if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, math.max(profcnt, 1)) end
-        if UI.Pad.Events.START then
-          UI.ProfileQuery._reset_from_defaults()
-          UI.Notif_queue.add("Settings defaults restored")
-        end
+
         if UI.Pad.Events.CONFIRM then
           UI.ProfileQuery.EditDkwdrvPath()
         end
+        if UI.Pad.Events.START then
+          UI.ProfileQuery.Save(UI.SCENES.MMAIN)
+        end
         if UI.Pad.Events.BACK then
-          UI.ProfileQuery.SaveAndExit(UI.SCENES.MMAIN)
+          UI.ProfileQuery.Cancel(UI.SCENES.MMAIN)
+        end
+        if UI.Pad.Events.EXIT then
+          UI.ProfileQuery.Cancel(UI.SCENES.CREDITS)
         end
 
         local labels, order = UI.Footer.ResolveLegend({
-          order = UI.Footer.order_with_start,
-          order_id = "start",
-          circle = UI.Footer.labels.circle_other,
-          cross = "Edit DKWDRV",
-          start = UI.Footer.labels.start_reset
+          order = {"circle", "start"},
+          order_id = "settings_save_cancel",
+          circle = "Cancel",
+          start = "Save"
         })
         UI.Footer.Draw(labels, order)
       end;

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -781,6 +781,9 @@ if found == nil then return end
       end
       if UI.LAUNCHING then return false end
       if UI.Pad.Events.START and UI.CURSCENE ~= UI.SCENES.MPROFILE then
+        if UI.ProfileQuery ~= nil then
+          UI.ProfileQuery.init_done = false
+        end
         UI.SceneChange(UI.SCENES.MPROFILE)
         return true
       end
@@ -914,44 +917,159 @@ if found == nil then return end
       end;
     };
     ProfileQuery = {
-      lastopt = 1;
       curopt = 1;
+      bdma_mode_index = 1;
+      dkwdrv_path = "";
+      init_done = false;
+      progress = nil;
+      _reset_from_defaults = function ()
+        local profcnt = #PLDR.PROFILES
+        local default_profile = tonumber(PLDR.DEFAULT_PROFILE) or 1
+        UI.ProfileQuery.curopt = CLAMP(default_profile, 1, math.max(profcnt, 1))
+        UI.ProfileQuery.bdma_mode_index = PLDR.GetBdmaModeIndex("NONE")
+        UI.ProfileQuery.dkwdrv_path = PLDR.GetDefaultDkwdrvPath()
+      end;
+      Init = function ()
+        local profcnt = #PLDR.PROFILES
+        local settings = PLDR.SETTINGS or {}
+        local profile_index = tonumber(settings.PROFILE_INDEX) or tonumber(PLDR.DEFAULT_PROFILE) or 1
+        UI.ProfileQuery.curopt = CLAMP(profile_index, 1, math.max(profcnt, 1))
+        UI.ProfileQuery.bdma_mode_index = PLDR.GetBdmaModeIndex(settings.BDMA_MODE)
+        UI.ProfileQuery.dkwdrv_path = tostring(settings.DKWDRV_PATH or PLDR.GetDefaultDkwdrvPath())
+        if UI.ProfileQuery.dkwdrv_path == "" then
+          UI.ProfileQuery.dkwdrv_path = PLDR.GetDefaultDkwdrvPath()
+        end
+        UI.ProfileQuery.init_done = true
+      end;
+      EditDkwdrvPath = function ()
+        -- TODO: verify the intended external path editor entrypoint in this branch.
+        if type(ExternalPathEditor) == "table" and type(ExternalPathEditor.Edit) == "function" then
+          local ok, value = pcall(ExternalPathEditor.Edit, UI.ProfileQuery.dkwdrv_path)
+          if ok and type(value) == "string" and value ~= "" then
+            UI.ProfileQuery.dkwdrv_path = value
+            UI.Notif_queue.add("DKWDRV path updated")
+          end
+          return
+        end
+        UI.Notif_queue.add("Path editor unavailable\nTODO: verify external editor hook")
+      end;
+      DrawProgress = function (info)
+        local layout = UI.LAYOUT
+        local box_w = 360
+        local box_h = 130
+        local box_x = UI.SCR.X_MID - (box_w / 2)
+        local box_y = UI.SCR.Y_MID - (box_h / 2)
+        local cur = tonumber(info.current) or 0
+        local total = tonumber(info.total) or 1
+        if total < 1 then total = 1 end
+        if cur < 0 then cur = 0 end
+        if cur > total then cur = total end
+        local pct = math.floor((cur / total) * 100)
+        local bar_w = box_w - 40
+        local bar_h = 16
+        local fill_w = math.floor((bar_w * pct) / 100)
+
+        Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, 130))
+        Graphics.drawRect(box_x, box_y, box_w, box_h, Color.new(0, 0, 0, 220))
+        Graphics.drawRect(box_x, box_y, box_w, 2, UI.CCOL.GREY)
+        Graphics.drawRect(box_x, box_y + box_h - 2, box_w, 2, UI.CCOL.GREY)
+
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 12, 8, UI.SCR.X, 16, "Applying BDMA...", UI.CCOL.YELLOW)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 36, 8, UI.SCR.X, 16, tostring(info.stage or "Working"), UI.CCOL.GREY)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 54, 8, UI.SCR.X, 16, string.format("%d%%", pct), UI.CCOL.GREY)
+
+        local copy_cur = tonumber(info.copied) or 0
+        local copy_total = tonumber(info.copy_total) or 0
+        Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 72, 8, UI.SCR.X, 16, string.format("Copy progress: (%d/%d)", copy_cur, copy_total), UI.CCOL.GREY)
+
+        Graphics.drawRect(box_x + 20, box_y + 94, bar_w, bar_h, Color.new(25, 25, 25, 128))
+        if fill_w > 0 then
+          Graphics.drawRect(box_x + 20, box_y + 94, fill_w, bar_h, Color.new(80, 170, 255, 128))
+        end
+        Screen.flip()
+      end;
+      SaveAndExit = function (target_scene)
+        local modes = PLDR.GetBdmaModes()
+        local selected_mode = modes[UI.ProfileQuery.bdma_mode_index] or modes[1]
+        local profcnt = #PLDR.PROFILES
+        local profile_index = CLAMP(UI.ProfileQuery.curopt, 1, math.max(profcnt, 1))
+        local payload = {
+          BDMA_MODE = selected_mode.key,
+          PROFILE_INDEX = profile_index,
+          DKWDRV_PATH = UI.ProfileQuery.dkwdrv_path
+        }
+        UI.ProfileQuery.progress = {
+          stage = "Deleting/Preparing",
+          current = 0,
+          total = 1,
+          copied = 0,
+          copy_total = 0
+        }
+        local ok, err = PLDR.SaveSettings(payload, {
+          apply_bdma = true,
+          progress_cb = function (info)
+            UI.ProfileQuery.progress = info
+            UI.ProfileQuery.DrawProgress(info)
+          end
+        })
+        if not ok then
+          UI.Notif_queue.add("Settings save failed")
+          LOG("Settings save failed:", err)
+          return
+        end
+        UI.ProfileQuery.progress = nil
+        UI.SceneChange(target_scene)
+      end;
       Play = function ()
+        if not UI.ProfileQuery.init_done then
+          UI.ProfileQuery.Init()
+        end
         local layout = UI.LAYOUT
         local profcnt = #PLDR.PROFILES
-        Font.ftPrint(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 8, UI.SCR.X, 16, "Choose POPStarter Profile", UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 30, 8, UI.SCR.X, 16, "Profile "..UI.ProfileQuery.curopt, UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 140, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].DESC, UI.CCOL.GREY)
-        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 220, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].ELF, Color.new(128,128,128, 110))
+        local modes = PLDR.GetBdmaModes()
+        local mode = modes[UI.ProfileQuery.bdma_mode_index] or modes[1]
+        local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
+
+        Font.ftPrint(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 8, UI.SCR.X, 16, "Settings", UI.CCOL.GREY)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 30, 8, UI.SCR.X, 16, "LEFT/RIGHT BDMA MODE: "..mode.label, UI.CCOL.GREY)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 8, UI.SCR.X, 16, "UP/DOWN PROFILE: "..UI.ProfileQuery.curopt.."/"..math.max(profcnt, 1), UI.CCOL.GREY)
+
+        if profile ~= nil then
+          Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 92, 8, UI.SCR.X, 16, profile.DESC, UI.CCOL.GREY)
+          Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 116, 8, UI.SCR.X, 16, profile.ELF, Color.new(128,128,128, 110))
+        end
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 156, 8, UI.SCR.X, 16, "X: Edit DKWDRV Path", UI.CCOL.GREY)
+        Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 180, 8, UI.SCR.X, 16, UI.ProfileQuery.dkwdrv_path, Color.new(128,128,128, 110))
+
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-        if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
-        if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
-        if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) end
-        if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
+        if UI.Pad.Events.EXIT then UI.ProfileQuery.SaveAndExit(UI.SCENES.CREDITS) end
+        if UI.Pad.Events.NAV_RIGHT then
+          UI.ProfileQuery.bdma_mode_index = UI.ProfileQuery.bdma_mode_index + 1
+          if UI.ProfileQuery.bdma_mode_index > #modes then UI.ProfileQuery.bdma_mode_index = 1 end
+        end
+        if UI.Pad.Events.NAV_LEFT then
+          UI.ProfileQuery.bdma_mode_index = UI.ProfileQuery.bdma_mode_index - 1
+          if UI.ProfileQuery.bdma_mode_index < 1 then UI.ProfileQuery.bdma_mode_index = #modes end
+        end
+        if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, math.max(profcnt, 1)) end
+        if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, math.max(profcnt, 1)) end
         if UI.Pad.Events.START then
-          local default_profile = tonumber(PLDR.DEFAULT_PROFILE) or 1
-          UI.ProfileQuery.curopt = CLAMP(default_profile, 1, profcnt)
-          local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
-          if profile ~= nil then
-            PLDR.POPSTARTER_PATH = profile.ELF
-          end
-          UI.Notif_queue.add("Profile defaults restored")
+          UI.ProfileQuery._reset_from_defaults()
+          UI.Notif_queue.add("Settings defaults restored")
         end
         if UI.Pad.Events.CONFIRM then
-          if not doesFileExist(PLDR.PROFILES[UI.ProfileQuery.curopt].ELF) then
-            UI.Notif_queue.add("POPStarter ELF missing")
-          else
-            PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
-            UI.SceneChange(UI.SCENES.MMAIN)
-          end
+          UI.ProfileQuery.EditDkwdrvPath()
         end
+        if UI.Pad.Events.BACK then
+          UI.ProfileQuery.SaveAndExit(UI.SCENES.MMAIN)
+        end
+
         local labels, order = UI.Footer.ResolveLegend({
-          order = UI.Footer.order_with_start_r2,
-          order_id = "start_r2",
+          order = UI.Footer.order_with_start,
+          order_id = "start",
           circle = UI.Footer.labels.circle_other,
-          cross = UI.Footer.labels.cross_select,
-          square = "Cover Art",
+          cross = "Edit DKWDRV",
           start = UI.Footer.labels.start_reset
         })
         UI.Footer.Draw(labels, order)
@@ -1237,19 +1355,13 @@ if found == nil then return end
             UI.Notif_queue.add("SMB not implemented yet.")
             UI.SceneChange(UI.SCENES.GSMB)
           elseif UI.MainMenu.OPT == 7 then
-            local dkwdrv_paths = {
-              "mc0:/PS1_DKWDRV/DKWDRV.ELF",
-              "mc1:/PS1_DKWDRV/DKWDRV.ELF"
-            }
-            local dkwdrv_path = nil
-            for i = 1, #dkwdrv_paths do
-              if doesFileExist(dkwdrv_paths[i]) then
-                dkwdrv_path = dkwdrv_paths[i]
-                break
-              end
+            local configured = PLDR and PLDR.SETTINGS and PLDR.SETTINGS.DKWDRV_PATH or nil
+            local dkwdrv_path = configured
+            if dkwdrv_path == nil or dkwdrv_path == "" then
+              dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
             end
-            if dkwdrv_path == nil then
-              UI.Notif_queue.add("mc?:/PS1_DKWDRV/DKWDRV.ELF not found")
+            if not doesFileExist(dkwdrv_path) then
+              UI.Notif_queue.add("DKWDRV not found\n"..dkwdrv_path)
             else
               System.loadELF(dkwdrv_path)
             end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -496,17 +496,22 @@ if found == nil then return end
 
         -- Exact boot splash duration target: 3.0 seconds.
         local splash_duration_ms = 3000
+        local splash_elapsed_ms = 0
+        local splash_step_ms = 16
         TryBootSound()
-        local splash_timer = Timer.new()
-        local splash_start = Timer.getTime(splash_timer)
-        while true do
-          local now = Timer.getTime(splash_timer)
-          if (now - splash_start) >= splash_duration_ms then
-            break
-          end
+        while splash_elapsed_ms < splash_duration_ms do
           DrawBackground()
           DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
           Screen.flip() -- keep rendering during timed wait
+          local remaining = splash_duration_ms - splash_elapsed_ms
+          local sleep_ms = splash_step_ms
+          if remaining < sleep_ms then sleep_ms = remaining end
+          if sleep_ms > 0 then
+            System.sleep(sleep_ms)
+            splash_elapsed_ms = splash_elapsed_ms + sleep_ms
+          else
+            break
+          end
         end
         DrawTargetScene(next_scene)
         Screen.flip()
@@ -625,7 +630,7 @@ if found == nil then return end
         end
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          System.loadELF(boot_path)
+          System.loadELF(boot_path, 0)
         end
       end;
       HandleInput = function ()
@@ -957,7 +962,12 @@ if found == nil then return end
           if type(System.editPath) == "function" and try_editor(System.editPath) then return end
           if type(System.openOSK) == "function" and try_editor(System.openOSK) then return end
         end
-        UI.Notif_queue.add("Path editor unavailable")
+        if string.sub(current, 1, 26) == "mc0:/PS1_DKWDRV/DKWDRV.ELF" then
+          UI.ProfileQuery.dkwdrv_path = "mc1:/PS1_DKWDRV/DKWDRV.ELF"
+        else
+          UI.ProfileQuery.dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+        end
+        UI.Notif_queue.add("Path editor unavailable\nSwitched MC slot fallback")
       end;
       DrawHintWithIcons = function (left_key, right_key, text, y)
         local cx = UI.SCR.X_MID
@@ -1400,7 +1410,7 @@ if found == nil then return end
             if not doesFileExist(dkwdrv_path) then
               UI.Notif_queue.add("DKWDRV not found\n"..dkwdrv_path)
             else
-              System.loadELF(dkwdrv_path)
+              System.loadELF(dkwdrv_path, 0)
             end
           end --because we still dont support SMB
         end
@@ -1553,6 +1563,30 @@ if found == nil then return end
         UI.Credits._draw_only = true
         UI.Credits.Play()
         UI.Credits._draw_only = false
+      end;
+      PlayBootSequence = function (duration_ms)
+        local total_ms = tonumber(duration_ms) or UI.Credits.BOOT_AUTO_EXIT_MS
+        if total_ms < 0 then total_ms = 0 end
+        local elapsed_ms = 0
+        local step_ms = 16
+        UI.Credits.is_boot_sequence = true
+        UI.Credits.ResetTimer()
+        while elapsed_ms < total_ms do
+          UI.BottomDraw.Play()
+          UI.Credits.DrawOnly()
+          UI.flip()
+          local remaining = total_ms - elapsed_ms
+          local sleep_ms = step_ms
+          if remaining < sleep_ms then sleep_ms = remaining end
+          if sleep_ms > 0 then
+            System.sleep(sleep_ms)
+            elapsed_ms = elapsed_ms + sleep_ms
+          else
+            break
+          end
+        end
+        UI.Credits.is_boot_sequence = false
+        UI.Credits.ResetTimer()
       end;
       Play = function ()
         local layout = UI.LAYOUT

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -364,30 +364,6 @@ UI = {
 	        local function DrawBackground()
 	          Screen.clear(Color.new(0, 0, 0))
 	        end
-        local function DrawTargetBackground(scene)
-          Screen.clear(UI.SCR.BGCOL)
-          if scene == UI.SCENES.MMAIN then
-            if IMG.BGM ~= nil then
-              Graphics.drawScaleImage(IMG.BGM, 0, 0, UI.SCR.X, UI.SCR.Y)
-            elseif IMG.BKG ~= nil then
-              Graphics.drawScaleImage(IMG.BKG, 0, 0, UI.SCR.X, UI.SCR.Y)
-            end
-          else
-            if IMG.BKG ~= nil then
-              Graphics.drawScaleImage(IMG.BKG, 0, 0, UI.SCR.X, UI.SCR.Y)
-            end
-          end
-        end
-        local function DrawTargetScene(scene)
-          if scene == nil then return end
-          DrawTargetBackground(scene)
-          if scene == UI.SCENES.MMAIN and UI.MainMenu ~= nil and UI.MainMenu.DrawOnly ~= nil then
-            UI.MainMenu.DrawOnly()
-          elseif scene == UI.SCENES.CREDITS and UI.Credits ~= nil and UI.Credits.DrawOnly ~= nil then
-            UI.Credits.DrawOnly()
-          end
-        end
-
 -- Boot audio (relative to current directory). Never fatal.
         local boot_sound_tried = false
         local boot_sound_loaded = nil
@@ -527,7 +503,8 @@ if found == nil then return end
           end
           Screen.flip()
         end
-        DrawTargetScene(next_scene)
+        DrawBackground()
+        Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, 128))
         Screen.flip()
 
         -- Cleanup boot sound resource (safe if audio backend ignores it).
@@ -537,6 +514,24 @@ if found == nil then return end
       end
 
     };
+    BootFadeInScene = function (scene, frames)
+      local total = tonumber(frames) or 24
+      if total < 1 then total = 1 end
+      for i = 1, total do
+        UI.BottomDraw.Play()
+        if scene == UI.SCENES.MMAIN and UI.MainMenu ~= nil and UI.MainMenu.DrawOnly ~= nil then
+          UI.MainMenu.DrawOnly()
+        elseif scene == UI.SCENES.CREDITS and UI.Credits ~= nil and UI.Credits.DrawOnly ~= nil then
+          UI.Credits.DrawOnly()
+        end
+        local t = i / total
+        local overlay_alpha = Round(128 * (1 - t))
+        if overlay_alpha > 0 then
+          Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+        end
+        Screen.flip()
+      end
+    end;
     --- UI draw routine applied before drawing UI, add background and stuff you want rendered UNDER UI and text
     BottomDraw = {
       Play = function ()
@@ -1591,13 +1586,13 @@ if found == nil then return end
           if overlay_alpha > 0 then
             Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
           end
-          UI.flip()
+          Screen.flip()
         end
 
         for _ = 1, hold_frames do
           UI.BottomDraw.Play()
           UI.Credits.DrawOnly()
-          UI.flip()
+          Screen.flip()
         end
 
         for i = 1, fade_out_frames do
@@ -1608,7 +1603,7 @@ if found == nil then return end
           if overlay_alpha > 0 then
             Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
           end
-          UI.flip()
+          Screen.flip()
         end
 
         UI.Credits.is_boot_sequence = false

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -494,24 +494,13 @@ if found == nil then return end
           -- no-op placeholder for future custom splash text
         end
 
-        -- Exact boot splash duration target: 3.0 seconds.
-        local splash_duration_ms = 3000
-        local splash_elapsed_ms = 0
-        local splash_step_ms = 16
+        -- Exact target: 3.0s splash at 60Hz = 180 frames.
+        local splash_frames = 180
         TryBootSound()
-        while splash_elapsed_ms < splash_duration_ms do
+        for _ = 1, splash_frames do
           DrawBackground()
           DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
           Screen.flip() -- keep rendering during timed wait
-          local remaining = splash_duration_ms - splash_elapsed_ms
-          local sleep_ms = splash_step_ms
-          if remaining < sleep_ms then sleep_ms = remaining end
-          if sleep_ms > 0 then
-            System.sleep(sleep_ms)
-            splash_elapsed_ms = splash_elapsed_ms + sleep_ms
-          else
-            break
-          end
         end
         DrawTargetScene(next_scene)
         Screen.flip()
@@ -1567,23 +1556,14 @@ if found == nil then return end
       PlayBootSequence = function (duration_ms)
         local total_ms = tonumber(duration_ms) or UI.Credits.BOOT_AUTO_EXIT_MS
         if total_ms < 0 then total_ms = 0 end
-        local elapsed_ms = 0
-        local step_ms = 16
+        local total_frames = math.floor((total_ms / 1000) * 60 + 0.5)
+        if total_frames < 1 then total_frames = 1 end
         UI.Credits.is_boot_sequence = true
         UI.Credits.ResetTimer()
-        while elapsed_ms < total_ms do
+        for _ = 1, total_frames do
           UI.BottomDraw.Play()
           UI.Credits.DrawOnly()
           UI.flip()
-          local remaining = total_ms - elapsed_ms
-          local sleep_ms = step_ms
-          if remaining < sleep_ms then sleep_ms = remaining end
-          if sleep_ms > 0 then
-            System.sleep(sleep_ms)
-            elapsed_ms = elapsed_ms + sleep_ms
-          else
-            break
-          end
         end
         UI.Credits.is_boot_sequence = false
         UI.Credits.ResetTimer()

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -494,31 +494,22 @@ if found == nil then return end
           -- no-op placeholder for future custom splash text
         end
 
-        local fade_in_frames = 24        local hold_frames = 48
-        local fade_out_frames = 24
-
-        -- Start boot sound once, and extend splash hold to cover it (configurable).
+        -- Exact boot splash duration target: 3.0 seconds.
+        local splash_duration_ms = 3000
         TryBootSound()
-        if boot_sound_hold_frames ~= nil and boot_sound_hold_frames > hold_frames then
-          hold_frames = boot_sound_hold_frames
-        end
-        for i = 1, fade_in_frames do
-          local alpha = Round(128 * (i / fade_in_frames))
-          DrawBackground()
-          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, alpha)
-          Screen.flip() -- we dont use UI.flip here because we dont want notifications on the welcome screen
-        end
-        for _ = 1, hold_frames do
+        local splash_timer = Timer.new()
+        local splash_start = Timer.getTime(splash_timer)
+        while true do
+          local now = Timer.getTime(splash_timer)
+          if (now - splash_start) >= splash_duration_ms then
+            break
+          end
           DrawBackground()
           DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
-          Screen.flip()
+          Screen.flip() -- keep rendering during timed wait
         end
-        for i = 1, fade_out_frames do
-          local alpha = Round(128 * (1 - (i / fade_out_frames)))
-          DrawTargetScene(next_scene)
-          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, alpha)
-          Screen.flip()
-        end
+        DrawTargetScene(next_scene)
+        Screen.flip()
 
         -- Cleanup boot sound resource (safe if audio backend ignores it).
         if boot_sound_loaded ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then
@@ -821,7 +812,7 @@ if found == nil then return end
           Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, UI.SCR.Y_MID, 20, UI.SCR.X, 32, "Not implemented yet", UI.CCOL.YELLOW)
           Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-          if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
+          if UI.Pad.Events.EXIT then UI.Credits.Open(false) end
           if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
           if UI.Pad.Events.CONFIRM then
             UI.Notif_queue.add("Not implemented yet")
@@ -868,7 +859,7 @@ if found == nil then return end
         end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-        if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
+        if UI.Pad.Events.EXIT then UI.Credits.Open(false) end
         if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
         if UI.Pad.Events.NAV_DOWN then UI.GameList.CURR = CLAMP(UI.GameList.CURR+1, 1, ammount) end
         if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
@@ -1316,7 +1307,7 @@ if found == nil then return end
             carousel.slide = 0
           end
         end
-        if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
+        if UI.Pad.Events.EXIT then UI.Credits.Open(false) end
         if UI.Pad.Events.BACK then
           UI.Modal.OpenExit()
           return
@@ -1545,9 +1536,19 @@ if found == nil then return end
       end;
     };
     Credits = {
-      AUTO_EXIT_MS = 3000;
+      BOOT_AUTO_EXIT_MS = 4000;
+      is_boot_sequence = false;
       Timer = nil;
       StartTime = 0;
+      ResetTimer = function ()
+        UI.Credits.Timer = nil
+        UI.Credits.StartTime = 0
+      end;
+      Open = function (is_boot_sequence)
+        UI.Credits.is_boot_sequence = (is_boot_sequence == true)
+        UI.Credits.ResetTimer()
+        UI.SceneChange(UI.SCENES.CREDITS)
+      end;
       DrawOnly = function ()
         UI.Credits._draw_only = true
         UI.Credits.Play()
@@ -1565,10 +1566,12 @@ Special Thanks To:
 krHACKen for making POPStarter
 uyjulian, fjtrujy, HWC, and others for always helping
 This Program is FREE and OPEN-SOURCE
-If you bought it, you've been scammed.]]
+If you bought it, you've been scammed.
+Compatibility Problems?
+Visit
+youtube.com/@hugopocked6695]]
 
         Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y, 22, UI.SCR.X, UI.SCR.Y, credits_text, currcol)
-        -- TODO: verify whether POPSLDR_VER should still be shown anywhere else after this copy change.
         if UI.BUILD_INFO ~= nil and UI.BUILD_INFO.stamp ~= nil then
           local stamp_y = Round(layout.FOOTER_LABEL_Y - 18)
           Font.ftPrint(SFONT, layout.SAFE.L, stamp_y, 0, UI.SCR.X, 16, UI.BUILD_INFO.stamp, UI.CCOL.GREY)
@@ -1579,17 +1582,22 @@ If you bought it, you've been scammed.]]
             UI.Credits.Timer = Timer.new()
             UI.Credits.StartTime = Timer.getTime(UI.Credits.Timer)
           end
-          local now = Timer.getTime(UI.Credits.Timer)
-          if (now - UI.Credits.StartTime) >= UI.Credits.AUTO_EXIT_MS then
-            UI.Credits.Timer = nil
-            UI.SceneChange(UI.SCENES.MMAIN)
-            return
+
+          if UI.Credits.is_boot_sequence then
+            local now = Timer.getTime(UI.Credits.Timer)
+            if (now - UI.Credits.StartTime) >= UI.Credits.BOOT_AUTO_EXIT_MS then
+              UI.Credits.is_boot_sequence = false
+              UI.Credits.ResetTimer()
+              UI.SceneChange(UI.SCENES.MMAIN)
+              return
+            end
           end
 
           Input_GetEvent()
           if UI.HandleGlobalInput(false) then return end
-          if UI.Pad.Events.EXIT or UI.Pad.Events.BACK or UI.Pad.Events.ANY then
-            UI.Credits.Timer = nil
+          if UI.Pad.Events.EXIT or UI.Pad.Events.BACK then
+            UI.Credits.is_boot_sequence = false
+            UI.Credits.ResetTimer()
             UI.SceneChange(UI.SCENES.MMAIN)
           end
         end


### PR DESCRIPTION
### Motivation
- Replace the old "POPS Profiles" page with a single flat "Settings" page that exposes BDMA mode selection, profile selection, and DKWDRV path editing while keeping the same START navigation entrypoint and legacy fallback behavior.
- Persist the settings (BDMA mode, selected profile, DKWDRV path) and only apply BDMA filesystem changes when the user leaves/saves to avoid surprising mid-session mutations.
- Provide an explicit, inventory-driven BDMA payload model and a visible progress overlay so users can see and wait for the mc0:/POPSTARTER/ changes to finish.
- TODO: verify the external on-screen keyboard/editor hook (used in `UI.ProfileQuery.EditDkwdrvPath`) and confirm expected runtime I/O behavior on-device; see `bin/POPSLDR/ui.lua` and `bin/POPSLDR/system.lua` for locations to verify.

### Description
- Added persisted settings support (`PLDR.SETTINGS`) and load/save helpers (`PLDR.LoadSettings`, `PLDR.SaveSettings`, and `settings.lua` storage) in `bin/POPSLDR/system.lua` and load these after profiles are registered.
- Introduced a canonical BDMA modes table and helpers (`PLDR.GetBdmaModes`, `PLDR.GetBdmaModeIndex`) and implemented `PLDR.ApplyBdmaMode` which performs the requested mc0:/POPSTARTER/ mutation (recursive delete for `NONE`, or copy a fixed inventory with suffix-based variants for `USBEXFAT`, `MMCE`, `MX4SIO`).
- Replaced dynamic pack discovery with an explicit payload inventory and fixed source directory `POPSLDR/` and deterministic per-mode suffix handling (`.usbexfat`, `.mmce`, `.mx4sio`) in `bin/POPSLDR/system.lua`.
- Added copy/delete progress wiring with incremental ticks during filesystem operations so the UI can redraw; added `PLDR.CountPopstarterEntries` and a progress-aware `RemoveDirectoryRecursive`.
- Reworked the old profile scene into a Settings UI (`UI.ProfileQuery` now renders "Settings") in `bin/POPSLDR/ui.lua` implementing exact requested controls: LEFT/RIGHT cycles BDMA mode (visual only until save), UP/DOWN maintains profile selection, `X` launches the external editor hook (calls `ExternalPathEditor.Edit` if available; shows fallback notification otherwise), and `BACK` saves and (if BDMA changed) applies BDMA with a blocking progress overlay via `UI.ProfileQuery.DrawProgress`.
- Kept navigation/entrypoint unchanged (START opens the same scene), and updated the Disc (DKWDRV) launch to use the configured `PLDR.SETTINGS.DKWDRV_PATH` with the documented default fallback `mc0:/PS1_DKWDRV/DKWDRV.ELF`.
- Small UX details: page title/labels changed to "Settings", and footer legend updated to match the new flow.

### Testing
- Ran `git diff --check` with no issues reported.
- Performed repo-level edits and commits locally; commit message: "Unify POPS Profiles into Settings with deferred BDMA apply".
- Attempted full build (`make clean elfloader all package`) but the environment lacks the PS2 toolchain includes, causing Make to fail with a missing include (`/samples/Makefile.eeglobal`), so CI-style build could not be completed here.
- No on-device runtime tests were executed in this environment; filesystem-copy/delete behavior and external editor integration should be verified on target hardware or a PS2-enabled test environment by exercising `BACK`/save from the Settings page and checking `mc0:/POPSTARTER/` contents and `settings.lua` in the ELF directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937631c54083218585355f672b4e63)