### PR TITLE
Replace Lua timer clock() usage with PS2SDK system timer ticks

### DIFF
--- a/src/luatimer.cpp
+++ b/src/luatimer.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
-#include <time.h>
+#include <stdint.h>
+#include <timer.h>
 #include "include/luaplayer.h"
 
 // if the timer is running:
@@ -13,14 +14,21 @@
 struct Timer{
 	uint32_t magic;
 	bool isPlaying;
-	clock_t tick;
+	uint64_t tick;
 };
+
+static const uint32_t TIMER_TICKS_PER_SEC = kBUSCLK;
+
+static inline uint64_t timer_now_ticks()
+{
+	return GetTimerSystemTime();
+}
 
 static int lua_newT(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 0) return luaL_error(L, "wrong number of arguments");
 	Timer* new_timer = (Timer*)malloc(sizeof(Timer));
-	new_timer->tick = clock();
+	new_timer->tick = timer_now_ticks();
 	new_timer->magic = 0x4C544D52;
 	new_timer->isPlaying = true;
 	lua_pushinteger(L,(uint32_t)new_timer);
@@ -35,9 +43,9 @@ static int lua_time(lua_State *L) {
 	if (src->magic != 0x4C544D52) return luaL_error(L, "attempt to access wrong memory block type");
 	#endif
 	if (src->isPlaying){
-		lua_pushinteger(L, (clock() - src->tick));
+		lua_pushinteger(L, (uint32_t)(timer_now_ticks() - src->tick));
 	}else{
-		lua_pushinteger(L, src->tick);
+		lua_pushinteger(L, (uint32_t)src->tick);
 	}
 	return 1;
 }
@@ -51,7 +59,7 @@ static int lua_pause(lua_State *L){
 	#endif
 	if (src->isPlaying){
 		src->isPlaying = false;
-		src->tick = (clock()-src->tick);
+		src->tick = (timer_now_ticks() - src->tick);
 	}
 	return 0;
 }
@@ -65,7 +73,7 @@ static int lua_resume(lua_State *L){
 	#endif
 	if (!src->isPlaying){
 		src->isPlaying = true;
-		src->tick = (clock()-src->tick);
+		src->tick = (timer_now_ticks() - src->tick);
 	}
 	return 0;
 }
@@ -77,7 +85,7 @@ static int lua_reset(lua_State *L){
 	#ifndef SKIP_ERROR_HANDLING
 	if (src->magic != 0x4C544D52) return luaL_error(L, "attempt to access wrong memory block type");
 	#endif
-	if (src->isPlaying) src->tick = clock();
+	if (src->isPlaying) src->tick = timer_now_ticks();
 	else src->tick = 0;
 	return 0;
 }
@@ -90,7 +98,7 @@ static int lua_set(lua_State *L){
 	#ifndef SKIP_ERROR_HANDLING
 	if (src->magic != 0x4C544D52) return luaL_error(L, "attempt to access wrong memory block type");
 	#endif
-	if (src->isPlaying) src->tick = clock() + val;
+	if (src->isPlaying) src->tick = timer_now_ticks() + val;
 	else src->tick = val;
 	return 0;
 }
@@ -109,7 +117,7 @@ static int lua_wisPlaying(lua_State *L){
 static int lua_clockPerSec(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 0) return luaL_error(L, "wrong number of arguments");
-	lua_pushinteger(L, (uint32_t)CLOCKS_PER_SEC);
+	lua_pushinteger(L, TIMER_TICKS_PER_SEC);
 	return 1;
 }
 


### PR DESCRIPTION
### Motivation
- Replace fragile C `clock()`/`CLOCKS_PER_SEC` timing with a stable PS2SDK monotonic source so Lua timers aren't frame-dependent and have a fixed tick unit.
- Preserve the Lua API surface (`Timer.new/getTime/getClockPerSec/setTime/pause/resume/reset/isPlaying/destroy`) so scripts and conversion helpers remain compatible.
- Expose a matching frequency constant from C so Lua ms→tick conversions remain correct without changing Lua code.

### Description
- Switched `src/luatimer.cpp` to use PS2SDK system timer via `GetTimerSystemTime()` through a small helper `timer_now_ticks()` and removed `clock()` usage.
- Changed internal timer storage from `clock_t` to `uint64_t` to hold system-time tick values safely and avoid truncation.
- Introduced `TIMER_TICKS_PER_SEC = kBUSCLK` so `Timer.getClockPerSec()` returns the PS2 system tick frequency and preserves unit semantics for Lua-side conversion helpers.
- Updated all timer operations (`new`, `getTime`, `setTime`, `pause`, `resume`, `reset`, `isPlaying`, `destroy`) to operate on the new tick source and types while keeping the Lua-visible API unchanged.

### Testing
- Confirmed removal of `clock()`/`CLOCKS_PER_SEC` by running `rg "clock\(|CLOCKS_PER_SEC" -n src/luatimer.cpp bin/POPSLDR/ui.lua` and observing no remaining matches in `src/luatimer.cpp`.
- Audited `bin/POPSLDR/ui.lua` `TimerMsToTicks` and verified it uses the formula `(ms * Timer.getClockPerSec()) / 1000`, which remains correct with `getClockPerSec()` now returning `kBUSCLK` (no Lua changes required).
- Attempted `make -n` in this environment but the container lacks PS2SDK includes (`/samples/Makefile.eeglobal`), so a full CI build was not executed here; see CI requirement `make clean elfloader all package` for final verification.
- TODO: verify runtime behavior on PS2 hardware or an emulator (e.g., PCSX2) to confirm absolute tick scaling and pause/resume semantics under the real `GetTimerSystemTime()` source.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950e46d2b08321a141a3ff9acb6475)