### PR TITLE
Fix boot intro timing regression with PS2 microsecond state machine

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -47,23 +47,25 @@ local function TimerMsToTicks(ms)
   end
   return value
 end
-local function ms_to_us(ms)
-  local value = tonumber(ms) or 0
-  if value <= 0 then return 0 end
-  return value * 1000
-end
-local now_us_fallback_timer = nil
-local function now_us()
-  if type(Timer) == "table" and type(Timer.getTimeUS) == "function" then
-    local ok, t = pcall(Timer.getTimeUS)
+local now_ms_fallback_timer = nil
+local function now_ms()
+  if type(Timer) == "table" and type(Timer.getTimeMS) == "function" then
+    local ok, t = pcall(Timer.getTimeMS)
     if ok and type(t) == "number" then
-      return t
+      return math.floor(t)
     end
   end
-  if now_us_fallback_timer == nil then
-    now_us_fallback_timer = Timer.new()
+  if now_ms_fallback_timer == nil and type(Timer) == "table" and type(Timer.new) == "function" then
+    now_ms_fallback_timer = Timer.new()
   end
-  return Timer.getTime(now_us_fallback_timer)
+  if now_ms_fallback_timer ~= nil and type(Timer.getTime) == "function" and type(Timer.getClockPerSec) == "function" then
+    local ticks = Timer.getTime(now_ms_fallback_timer)
+    local ok, cps = pcall(Timer.getClockPerSec)
+    if ok and type(cps) == "number" and cps > 0 then
+      return math.floor((ticks * 1000) / cps)
+    end
+  end
+  return 0
 end
 UI = {
     LASTSCENE = 5;
@@ -478,75 +480,80 @@ UI = {
         end
       end;
       Play = function ()
-        local state = UI.BootIntro.STATES.SPLASH_HOLD
-        local state_start_us = 0
-        local duration_us = 0
+        local intro = {
+          state = UI.BootIntro.STATES.SPLASH_HOLD,
+          state_start_ms = 0,
+          state_duration_ms = 0
+        }
         local boot_sound = UI.BootIntro.StartBootSound()
 
-        local function state_duration_us(curr)
-          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return ms_to_us(UI.BootIntro.SPLASH_HOLD_MS) end
-          if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return ms_to_us(UI.BootIntro.CREDITS_HOLD_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.MENU_FADE_IN then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
+        local function state_duration_ms(curr)
+          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return 3000 end
+          if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return UI.BootIntro.BOOT_FADE_MS end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return UI.BootIntro.BOOT_FADE_MS end
+          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return 4000 end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return UI.BootIntro.BOOT_FADE_MS end
+          if curr == UI.BootIntro.STATES.MENU_FADE_IN then return UI.BootIntro.BOOT_FADE_MS end
           return 0
         end
 
-        local function set_state(next_state, at_us)
-          state = next_state
-          state_start_us = at_us
-          duration_us = state_duration_us(next_state)
+        local function next_state(curr)
+          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return UI.BootIntro.STATES.SPLASH_FADE_OUT end
+          if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return UI.BootIntro.STATES.CREDITS_FADE_IN end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return UI.BootIntro.STATES.CREDITS_HOLD end
+          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return UI.BootIntro.STATES.CREDITS_FADE_OUT end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return UI.BootIntro.STATES.MENU_FADE_IN end
+          if curr == UI.BootIntro.STATES.MENU_FADE_IN then return UI.BootIntro.STATES.DONE end
+          return UI.BootIntro.STATES.DONE
         end
 
-        set_state(UI.BootIntro.STATES.SPLASH_HOLD, now_us())
+        local function IntroEnter(state)
+          intro.state = state
+          intro.state_start_ms = now_ms()
+          intro.state_duration_ms = state_duration_ms(state)
+        end
 
-        while state ~= UI.BootIntro.STATES.DONE do
-          local frame_now_us = now_us()
-          local elapsed_us = frame_now_us - state_start_us
-          local progress = 1
-          if duration_us > 0 then
-            progress = Clamp01(elapsed_us / duration_us)
+        local function IntroProgress(elapsed_ms)
+          if intro.state_duration_ms <= 0 then
+            return 1
+          end
+          return Clamp01(elapsed_ms / intro.state_duration_ms)
+        end
+
+        IntroEnter(UI.BootIntro.STATES.SPLASH_HOLD)
+
+        while intro.state ~= UI.BootIntro.STATES.DONE do
+          local frame_now_ms = now_ms()
+          local elapsed_ms = frame_now_ms - intro.state_start_ms
+
+          if intro.state_duration_ms > 0 and elapsed_ms >= intro.state_duration_ms then
+            IntroEnter(next_state(intro.state))
+            elapsed_ms = 0
           end
 
-          if state == UI.BootIntro.STATES.SPLASH_HOLD or state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
+          local progress = IntroProgress(elapsed_ms)
+
+          if intro.state == UI.BootIntro.STATES.SPLASH_HOLD or intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
             Screen.clear(Color.new(0, 0, 0))
             UI.BootIntro.DrawSplash()
-          elseif state == UI.BootIntro.STATES.CREDITS_FADE_IN or state == UI.BootIntro.STATES.CREDITS_HOLD or state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
+          elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_IN or intro.state == UI.BootIntro.STATES.CREDITS_HOLD or intro.state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
             UI.BottomDraw.Play()
             UI.Credits.DrawOnly()
-          elseif state == UI.BootIntro.STATES.MENU_FADE_IN then
+          elseif intro.state == UI.BootIntro.STATES.MENU_FADE_IN then
             UI.BottomDraw.Play()
             UI.MainMenu.DrawOnly()
           end
 
           local overlay_alpha = 0
-          if state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
+          if intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
             overlay_alpha = Round(255 * progress)
-          elseif state == UI.BootIntro.STATES.CREDITS_FADE_IN or state == UI.BootIntro.STATES.MENU_FADE_IN then
+          elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_IN or intro.state == UI.BootIntro.STATES.MENU_FADE_IN then
             overlay_alpha = Round(255 * (1 - progress))
-          elseif state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
+          elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
             overlay_alpha = Round(255 * progress)
           end
           UI.BootIntro.DrawBlackOverlay(overlay_alpha)
-
           Screen.flip()
-
-          if progress >= 1 then
-            if state == UI.BootIntro.STATES.SPLASH_HOLD then
-              set_state(UI.BootIntro.STATES.SPLASH_FADE_OUT, frame_now_us)
-            elseif state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
-              set_state(UI.BootIntro.STATES.CREDITS_FADE_IN, frame_now_us)
-            elseif state == UI.BootIntro.STATES.CREDITS_FADE_IN then
-              set_state(UI.BootIntro.STATES.CREDITS_HOLD, frame_now_us)
-            elseif state == UI.BootIntro.STATES.CREDITS_HOLD then
-              set_state(UI.BootIntro.STATES.CREDITS_FADE_OUT, frame_now_us)
-            elseif state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
-              set_state(UI.BootIntro.STATES.MENU_FADE_IN, frame_now_us)
-            elseif state == UI.BootIntro.STATES.MENU_FADE_IN then
-              set_state(UI.BootIntro.STATES.DONE, frame_now_us)
-            end
-          end
         end
 
         if boot_sound ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -391,17 +391,18 @@ UI = {
     end;
     BootIntro = {
       STATES = {
-        SPLASH_HOLD = 1,
-        SPLASH_FADE_OUT = 2,
-        CREDITS_FADE_IN = 3,
-        CREDITS_HOLD = 4,
-        CREDITS_FADE_OUT = 5,
-        MENU_FADE_IN = 6,
-        DONE = 7
+        SPLASH_FADE_IN = 1,
+        SPLASH_HOLD = 2,
+        SPLASH_FADE_OUT = 3,
+        CREDITS_FADE_IN = 4,
+        CREDITS_HOLD = 5,
+        CREDITS_FADE_OUT = 6,
+        MENU_FADE_IN = 7,
+        DONE = 8
       };
-      SPLASH_HOLD_MS = 3000;
-      CREDITS_HOLD_MS = 4000;
-      BOOT_FADE_MS = 450;
+      SPLASH_HOLD_MS = 5000;
+      CREDITS_HOLD_MS = 9000;
+      BOOT_FADE_MS = 1200;
       DrawSplash = function ()
         if IMG.PSL == nil then return end
         local img_w = Graphics.getImageWidth(IMG.PSL)
@@ -481,23 +482,25 @@ UI = {
       end;
       Play = function ()
         local intro = {
-          state = UI.BootIntro.STATES.SPLASH_HOLD,
+          state = UI.BootIntro.STATES.SPLASH_FADE_IN,
           state_start_ms = 0,
           state_duration_ms = 0
         }
         local boot_sound = UI.BootIntro.StartBootSound()
 
         local function state_duration_ms(curr)
-          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return 3000 end
+          if curr == UI.BootIntro.STATES.SPLASH_FADE_IN then return UI.BootIntro.BOOT_FADE_MS end
+          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return UI.BootIntro.SPLASH_HOLD_MS end
           if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return UI.BootIntro.BOOT_FADE_MS end
           if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return UI.BootIntro.BOOT_FADE_MS end
-          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return 4000 end
+          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return UI.BootIntro.CREDITS_HOLD_MS end
           if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return UI.BootIntro.BOOT_FADE_MS end
           if curr == UI.BootIntro.STATES.MENU_FADE_IN then return UI.BootIntro.BOOT_FADE_MS end
           return 0
         end
 
         local function next_state(curr)
+          if curr == UI.BootIntro.STATES.SPLASH_FADE_IN then return UI.BootIntro.STATES.SPLASH_HOLD end
           if curr == UI.BootIntro.STATES.SPLASH_HOLD then return UI.BootIntro.STATES.SPLASH_FADE_OUT end
           if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return UI.BootIntro.STATES.CREDITS_FADE_IN end
           if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return UI.BootIntro.STATES.CREDITS_HOLD end
@@ -520,20 +523,26 @@ UI = {
           return Clamp01(elapsed_ms / intro.state_duration_ms)
         end
 
-        IntroEnter(UI.BootIntro.STATES.SPLASH_HOLD)
-
-        while intro.state ~= UI.BootIntro.STATES.DONE do
-          local frame_now_ms = now_ms()
-          local elapsed_ms = frame_now_ms - intro.state_start_ms
-
+        local function IntroUpdate()
+          local elapsed_ms = now_ms() - intro.state_start_ms
           if intro.state_duration_ms > 0 and elapsed_ms >= intro.state_duration_ms then
             IntroEnter(next_state(intro.state))
-            elapsed_ms = 0
+            return true, 0
+          end
+          return false, elapsed_ms
+        end
+
+        IntroEnter(UI.BootIntro.STATES.SPLASH_FADE_IN)
+
+        while intro.state ~= UI.BootIntro.STATES.DONE do
+          local transitioned, elapsed_ms = IntroUpdate()
+          if transitioned then
+            goto intro_next_frame
           end
 
           local progress = IntroProgress(elapsed_ms)
 
-          if intro.state == UI.BootIntro.STATES.SPLASH_HOLD or intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
+          if intro.state == UI.BootIntro.STATES.SPLASH_FADE_IN or intro.state == UI.BootIntro.STATES.SPLASH_HOLD or intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
             Screen.clear(Color.new(0, 0, 0))
             UI.BootIntro.DrawSplash()
           elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_IN or intro.state == UI.BootIntro.STATES.CREDITS_HOLD or intro.state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
@@ -545,15 +554,15 @@ UI = {
           end
 
           local overlay_alpha = 0
-          if intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
-            overlay_alpha = Round(255 * progress)
-          elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_IN or intro.state == UI.BootIntro.STATES.MENU_FADE_IN then
+          if intro.state == UI.BootIntro.STATES.SPLASH_FADE_IN or intro.state == UI.BootIntro.STATES.CREDITS_FADE_IN or intro.state == UI.BootIntro.STATES.MENU_FADE_IN then
             overlay_alpha = Round(255 * (1 - progress))
-          elseif intro.state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
+          elseif intro.state == UI.BootIntro.STATES.SPLASH_FADE_OUT or intro.state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
             overlay_alpha = Round(255 * progress)
           end
           UI.BootIntro.DrawBlackOverlay(overlay_alpha)
           Screen.flip()
+
+          ::intro_next_frame::
         end
 
         if boot_sound ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -47,6 +47,24 @@ local function TimerMsToTicks(ms)
   end
   return value
 end
+local function ms_to_us(ms)
+  local value = tonumber(ms) or 0
+  if value <= 0 then return 0 end
+  return value * 1000
+end
+local now_us_fallback_timer = nil
+local function now_us()
+  if type(Timer) == "table" and type(Timer.getTimeUS) == "function" then
+    local ok, t = pcall(Timer.getTimeUS)
+    if ok and type(t) == "number" then
+      return t
+    end
+  end
+  if now_us_fallback_timer == nil then
+    now_us_fallback_timer = Timer.new()
+  end
+  return Timer.getTime(now_us_fallback_timer)
+end
 UI = {
     LASTSCENE = 5;
     SCENES = {
@@ -453,31 +471,42 @@ UI = {
         end)
         return audio
       end;
+      DrawBlackOverlay = function (alpha)
+        local a = Clamp(Round(alpha or 0), 0, 255)
+        if a > 0 then
+          Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, a))
+        end
+      end;
       Play = function ()
         local state = UI.BootIntro.STATES.SPLASH_HOLD
-        local state_start_ticks = 0
-        local timer = Timer.new()
+        local state_start_us = 0
+        local duration_us = 0
         local boot_sound = UI.BootIntro.StartBootSound()
-        local function set_state(next_state, now_ticks)
-          state = next_state
-          state_start_ticks = now_ticks
-        end
-        local function get_duration_ticks(curr)
-          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return TimerMsToTicks(UI.BootIntro.SPLASH_HOLD_MS) end
-          if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return TimerMsToTicks(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return TimerMsToTicks(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return TimerMsToTicks(UI.BootIntro.CREDITS_HOLD_MS) end
-          if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return TimerMsToTicks(UI.BootIntro.BOOT_FADE_MS) end
-          if curr == UI.BootIntro.STATES.MENU_FADE_IN then return TimerMsToTicks(UI.BootIntro.BOOT_FADE_MS) end
+
+        local function state_duration_us(curr)
+          if curr == UI.BootIntro.STATES.SPLASH_HOLD then return ms_to_us(UI.BootIntro.SPLASH_HOLD_MS) end
+          if curr == UI.BootIntro.STATES.SPLASH_FADE_OUT then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_IN then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
+          if curr == UI.BootIntro.STATES.CREDITS_HOLD then return ms_to_us(UI.BootIntro.CREDITS_HOLD_MS) end
+          if curr == UI.BootIntro.STATES.CREDITS_FADE_OUT then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
+          if curr == UI.BootIntro.STATES.MENU_FADE_IN then return ms_to_us(UI.BootIntro.BOOT_FADE_MS) end
           return 0
         end
-        set_state(UI.BootIntro.STATES.SPLASH_HOLD, Timer.getTime(timer))
+
+        local function set_state(next_state, at_us)
+          state = next_state
+          state_start_us = at_us
+          duration_us = state_duration_us(next_state)
+        end
+
+        set_state(UI.BootIntro.STATES.SPLASH_HOLD, now_us())
+
         while state ~= UI.BootIntro.STATES.DONE do
-          local now_ticks = Timer.getTime(timer)
-          local duration_ticks = get_duration_ticks(state)
+          local frame_now_us = now_us()
+          local elapsed_us = frame_now_us - state_start_us
           local progress = 1
-          if duration_ticks > 0 then
-            progress = Clamp01((now_ticks - state_start_ticks) / duration_ticks)
+          if duration_us > 0 then
+            progress = Clamp01(elapsed_us / duration_us)
           end
 
           if state == UI.BootIntro.STATES.SPLASH_HOLD or state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
@@ -493,33 +522,33 @@ UI = {
 
           local overlay_alpha = 0
           if state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
-            overlay_alpha = Round(128 * progress)
+            overlay_alpha = Round(255 * progress)
           elseif state == UI.BootIntro.STATES.CREDITS_FADE_IN or state == UI.BootIntro.STATES.MENU_FADE_IN then
-            overlay_alpha = Round(128 * (1 - progress))
+            overlay_alpha = Round(255 * (1 - progress))
           elseif state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
-            overlay_alpha = Round(128 * progress)
+            overlay_alpha = Round(255 * progress)
           end
-          if overlay_alpha > 0 then
-            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
-          end
+          UI.BootIntro.DrawBlackOverlay(overlay_alpha)
+
           Screen.flip()
 
           if progress >= 1 then
             if state == UI.BootIntro.STATES.SPLASH_HOLD then
-              set_state(UI.BootIntro.STATES.SPLASH_FADE_OUT, now_ticks)
+              set_state(UI.BootIntro.STATES.SPLASH_FADE_OUT, frame_now_us)
             elseif state == UI.BootIntro.STATES.SPLASH_FADE_OUT then
-              set_state(UI.BootIntro.STATES.CREDITS_FADE_IN, now_ticks)
+              set_state(UI.BootIntro.STATES.CREDITS_FADE_IN, frame_now_us)
             elseif state == UI.BootIntro.STATES.CREDITS_FADE_IN then
-              set_state(UI.BootIntro.STATES.CREDITS_HOLD, now_ticks)
+              set_state(UI.BootIntro.STATES.CREDITS_HOLD, frame_now_us)
             elseif state == UI.BootIntro.STATES.CREDITS_HOLD then
-              set_state(UI.BootIntro.STATES.CREDITS_FADE_OUT, now_ticks)
+              set_state(UI.BootIntro.STATES.CREDITS_FADE_OUT, frame_now_us)
             elseif state == UI.BootIntro.STATES.CREDITS_FADE_OUT then
-              set_state(UI.BootIntro.STATES.MENU_FADE_IN, now_ticks)
+              set_state(UI.BootIntro.STATES.MENU_FADE_IN, frame_now_us)
             elseif state == UI.BootIntro.STATES.MENU_FADE_IN then
-              set_state(UI.BootIntro.STATES.DONE, now_ticks)
+              set_state(UI.BootIntro.STATES.DONE, frame_now_us)
             end
           end
         end
+
         if boot_sound ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then
           pcall(Sound.freeADPCM, boot_sound)
         end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -537,7 +537,7 @@ UI = {
         while intro.state ~= UI.BootIntro.STATES.DONE do
           local transitioned, elapsed_ms = IntroUpdate()
           if transitioned then
-            goto intro_next_frame
+            elapsed_ms = 0
           end
 
           local progress = IntroProgress(elapsed_ms)
@@ -562,7 +562,6 @@ UI = {
           UI.BootIntro.DrawBlackOverlay(overlay_alpha)
           Screen.flip()
 
-          ::intro_next_frame::
         end
 
         if boot_sound ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -400,9 +400,9 @@ UI = {
         MENU_FADE_IN = 7,
         DONE = 8
       };
-      SPLASH_HOLD_MS = 5000;
-      CREDITS_HOLD_MS = 9000;
-      BOOT_FADE_MS = 1200;
+      SPLASH_HOLD_MS = 3000;
+      CREDITS_HOLD_MS = 5000;
+      BOOT_FADE_MS = 1800;
       DrawSplash = function ()
         if IMG.PSL == nil then return end
         local img_w = Graphics.getImageWidth(IMG.PSL)

--- a/src/luatimer.cpp
+++ b/src/luatimer.cpp
@@ -24,9 +24,15 @@ static inline uint64_t timer_now_ticks()
 	return GetTimerSystemTime();
 }
 
-static inline uint64_t now_us()
+static inline uint64_t timer_now_us()
 {
-	return GetTimerSystemTime();
+	const uint64_t ticks = GetTimerSystemTime();
+	return (ticks * 1000000ULL) / TIMER_TICKS_PER_SEC;
+}
+
+static inline uint64_t timer_now_ms()
+{
+	return timer_now_us() / 1000ULL;
 }
 
 static int lua_newT(lua_State *L) {
@@ -129,7 +135,14 @@ static int lua_clockPerSec(lua_State *L) {
 static int lua_nowUS(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 0) return luaL_error(L, "wrong number of arguments");
-	lua_pushnumber(L, (lua_Number)now_us());
+	lua_pushnumber(L, (lua_Number)timer_now_us());
+	return 1;
+}
+
+static int lua_nowMS(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc != 0) return luaL_error(L, "wrong number of arguments");
+	lua_pushnumber(L, (lua_Number)timer_now_ms());
 	return 1;
 }
 
@@ -149,6 +162,7 @@ static const luaL_Reg Timer_functions[] = {
   {"new",        		  lua_newT},
   {"getTime",    		  lua_time},
   {"getTimeUS", 		  lua_nowUS},
+  {"getTimeMS", 		  lua_nowMS},
   {"getClockPerSec",      lua_clockPerSec},
   {"setTime",    		   lua_set},
   {"destroy",    	   lua_destroy},

--- a/src/luatimer.cpp
+++ b/src/luatimer.cpp
@@ -24,6 +24,11 @@ static inline uint64_t timer_now_ticks()
 	return GetTimerSystemTime();
 }
 
+static inline uint64_t now_us()
+{
+	return GetTimerSystemTime();
+}
+
 static int lua_newT(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 0) return luaL_error(L, "wrong number of arguments");
@@ -121,6 +126,13 @@ static int lua_clockPerSec(lua_State *L) {
 	return 1;
 }
 
+static int lua_nowUS(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc != 0) return luaL_error(L, "wrong number of arguments");
+	lua_pushnumber(L, (lua_Number)now_us());
+	return 1;
+}
+
 static int lua_destroy(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 1) return luaL_error(L, "wrong number of arguments");
@@ -136,6 +148,7 @@ static int lua_destroy(lua_State *L) {
 static const luaL_Reg Timer_functions[] = {
   {"new",        		  lua_newT},
   {"getTime",    		  lua_time},
+  {"getTimeUS", 		  lua_nowUS},
   {"getClockPerSec",      lua_clockPerSec},
   {"setTime",    		   lua_set},
   {"destroy",    	   lua_destroy},


### PR DESCRIPTION
### Motivation
- The splash/credits boot intro became unreadable because the timing math used mismatched time bases, causing durations to evaluate as effectively instant.  
- Implement a PS2-correct, deterministic monotonic timing source and a simple intro state machine so fades and holds are consistent on real hardware.  
- Keep changes minimal and confined to the timer binding and the boot intro logic without altering manual credits behavior.  
- TODO: verify behavior on real PS2 hardware and in CI where PS2SDK toolchain is available (see `Makefile` / CI notes). 

### Description
- Added a PS2-backed microsecond helper and Lua binding in `src/luatimer.cpp`: implemented `now_us()` and `lua_nowUS()` and exposed `Timer.getTimeUS` (uses `GetTimerSystemTime()` as monotonic source).  
- Reworked boot intro in `bin/POPSLDR/ui.lua`: added `ms_to_us`, a `now_us` fallback that uses `Timer.getTimeUS` when available, `UI.BootIntro.DrawBlackOverlay(alpha)`, and replaced `UI.BootIntro.Play()` with a deterministic per-state microsecond state machine that stores `state_start_us` and `duration_us`.  
- States implemented: `SPLASH_HOLD`, `SPLASH_FADE_OUT`, `CREDITS_FADE_IN`, `CREDITS_HOLD`, `CREDITS_FADE_OUT`, `MENU_FADE_IN`, `DONE`, with hold/fade durations matching requirements (`SPLASH_HOLD_MS = 3000`, `CREDITS_HOLD_MS = 4000`, `BOOT_FADE_MS = 450`).  
- Kept manual credits path unchanged so manually-entered credits do not auto-exit; only the boot path uses the state machine and timers.  

Files / functions changed (concise):
- `src/luatimer.cpp`: added `now_us()`, `lua_nowUS()`, and registration `{"getTimeUS", lua_nowUS}`.  
- `bin/POPSLDR/ui.lua`: added `ms_to_us`, `now_us` fallback, `UI.BootIntro.DrawBlackOverlay`, and replaced `UI.BootIntro.Play()` timing with microsecond state-machine logic.  

Bug root cause
- The intro used `TimerMsToTicks()` (which relies on `Timer.getClockPerSec()`/`kBUSCLK`) to compute durations but compared those against values from `Timer.getTime()` with a different effective unit, producing incorrect progress calculations and effectively instant transitions; the fix unifies the time base to monotonic microseconds. 

### Testing
- Attempted full CI-style build with `make clean elfloader all package`, but the build fails in this environment due to missing local PS2SDK/sample include (`Makefile:247: /samples/Makefile.eeglobal: No such file or directory`), so a full compile could not be validated here.  
- Verified diffs and code changes locally: `git commit` succeeded with the patch applied to `src/luatimer.cpp` and `bin/POPSLDR/ui.lua`.  
- Performed static inspection and runtime-path checks in the Lua sources (`rg`/file reads) to ensure the new `now_us`/`ms_to_us` helpers are used consistently and that manual credits behavior remains input-driven; these checks succeeded.  
- Runtime verification on real PS2 (or PS2-targeted CI with PS2SDK) is required to confirm exact millisecond timing and fade smoothness; TODO: run `make clean elfloader all package` in CI and smoke-test on hardware or emulator to confirm `3000ms`/`4000ms` holds and `450ms` fades.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995102458d48321a27deca72800cf85)