### PR TITLE
Unify USB scenes into GUSB and preserve per-entry mass slot metadata

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -877,22 +877,35 @@ function PLDR.CheckPOPStarterDEPS(device)
   end
 end
 
+local function ParseMassGameEntry(entry)
+  if entry == nil or entry == "" then
+    return nil, nil
+  end
+  local prefix, relpath = string.match(entry, "^(mass%d*:/)|(.+)$")
+  return prefix, relpath
+end
+
 function PLDR.GetPS1GameLists(path, updating)
   LOG("Listing games on ", path)
   local RET = {}
   local found_smth = false
   if path ~= nil then PLDR.GAMEPATH = path end
+  local source_prefix = string.match(PLDR.GAMEPATH or "", "^(mass%d*:/)")
   local DIR = System.listDirectory(PLDR.GAMEPATH)
   if DIR ~= nil then
     for i = 1, #DIR do
       if not DIR[i].directory then -- not a folder
         if string.lower(string.sub(DIR[i].name,-4)) == ".vcd" then
-          LOG(" Found", DIR[i].name)
+          local entry_name = DIR[i].name
+          if source_prefix ~= nil then
+            entry_name = source_prefix..DIR[i].name
+          end
+          LOG(" Found", entry_name)
           found_smth = true
           if updating then
-            table.insert(PLDR.GAMES, DIR[i].name)
+            table.insert(PLDR.GAMES, entry_name)
           else
-            table.insert(RET, DIR[i].name)
+            table.insert(RET, entry_name)
           end
         end
       end
@@ -904,7 +917,16 @@ function PLDR.GetPS1GameLists(path, updating)
     if not updating then
       PLDR.GAMES = RET
     end
-    table.sort(PLDR.GAMES)
+    table.sort(PLDR.GAMES, function(a, b)
+      local _, mass_rel_a = ParseMassGameEntry(a)
+      local _, mass_rel_b = ParseMassGameEntry(b)
+      local sort_a = string.lower(mass_rel_a or a or "")
+      local sort_b = string.lower(mass_rel_b or b or "")
+      if sort_a == sort_b then
+        return tostring(a) < tostring(b)
+      end
+      return sort_a < sort_b
+    end)
     return PLDR.GAMES
   else
     return nil
@@ -1673,6 +1695,13 @@ end
 
 function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   local policy, device_page = ResolveLaunchPolicy(gamelocation, ui_scene)
+  local selected_game = game
+  local selected_gamelocation = gamelocation
+  local mass_source_prefix, mass_relpath = ParseMassGameEntry(game)
+  if mass_source_prefix ~= nil and mass_relpath ~= nil then
+    selected_gamelocation = mass_source_prefix
+    selected_game = mass_relpath
+  end
   local hdd_init = nil
   local hdd_partition_label = nil
   local hdd_relpath = nil
@@ -1680,15 +1709,16 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   if policy.name == "HDD" then
     hdd_partition_label, hdd_relpath = ParseHddGameEntry(game)
     hdd_relpath = NormalizeHddRelpath(hdd_relpath or game)
+    selected_game = hdd_relpath
     if hdd_partition_label ~= nil then
       hdd_partition = "hdd0:"..hdd_partition_label
     end
   end
-  local normalized_gamelocation = policy.normalize(gamelocation)
+  local normalized_gamelocation = policy.normalize(selected_gamelocation)
   local handoff_gamelocation = policy.handoff(normalized_gamelocation)
   local source_mode = policy.mode
   local raw_source_mode = source_mode
-  local vcd_path = normalized_gamelocation..game
+  local vcd_path = normalized_gamelocation..selected_game
   local popstarter = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
   local pops_root = normalized_gamelocation
   local boot_source_mode = source_mode
@@ -1747,18 +1777,18 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     bootparam, prefix, normalized_basename, prefix_added = BuildPopstarterBootString(
       boot_source_mode,
       pops_root,
-      game
+      selected_game
     )
     bootparam_exists = doesFileExist(bootparam)
     bootparam_basename_used = normalized_basename
     prefix_used = HasBootPrefix(normalized_basename, prefix) and prefix or ""
   end
-  local selection_for_name = game
+  local selection_for_name = selected_game
   if policy.name == "HDD" then
     selection_for_name = NormalizeHddRelpath(hdd_relpath or game)
   end
   local game_name = DeriveGameNameFromSelection(selection_for_name)
-  local vcd_basename_raw = game
+  local vcd_basename_raw = selected_game
   if policy.name == "HDD" then
     vcd_basename_raw = NormalizeHddRelpath(hdd_relpath or game)
   end
@@ -1801,11 +1831,11 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     return
   end
   if boot_source_mode == "mass" and prefix_added and not bootparam_exists then
-    fallback_bootparam = EnsureTrailingSlash(pops_root)..game
+    fallback_bootparam = EnsureTrailingSlash(pops_root)..selected_game
     fallback_exists = doesFileExist(fallback_bootparam)
     if fallback_exists then
       bootparam = fallback_bootparam
-      bootparam_basename_used = game
+      bootparam_basename_used = selected_game
       bootparam_exists = true
       prefix_used = ""
     end
@@ -1839,9 +1869,10 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     ui_scene = ui_scene or (UI and UI.CURSCENE or "unknown"),
     source_mode = source_mode,
     raw_source_mode = raw_source_mode,
-    gamelocation = gamelocation,
+    gamelocation = selected_gamelocation,
     handoff_gamelocation = handoff_gamelocation,
-    game = vcd_basename_raw,
+    game = game,
+    selected_game = vcd_basename_raw,
     vcd_path = vcd_path,
     bootparam = bootparam,
     bootparam_prefix_required = prefix,

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -61,6 +61,11 @@ local function ParseHddGameEntry(entry)
   local partition, relpath = string.match(entry, "^([^|]+)|(.+)$")
   return partition, relpath
 end
+local function ParseMassGameEntry(entry)
+  if entry == nil then return nil, nil end
+  local prefix, relpath = string.match(entry, "^(mass%d*:/)|(.+)$")
+  return prefix, relpath
+end
 local function StripExtension(path)
   if path == nil then return nil end
   local stripped = string.match(path, "(.+)%.[^%.]+$")
@@ -69,19 +74,27 @@ end
 local function BuildCoverCandidates(entry, game_path, device_scene)
   -- TODO: verify cover art naming/layout. For now, assume sidecar image next to the VCD.
   local relpath = ExtractGameRelPath(entry)
+  local mass_prefix, mass_relpath = ParseMassGameEntry(entry)
+  if mass_relpath ~= nil then
+    relpath = mass_relpath
+  end
   if relpath == nil or relpath == "" then return {}, nil end
   local hdd_partition_label, hdd_relpath = ParseHddGameEntry(entry)
   if hdd_partition_label ~= nil and hdd_relpath ~= nil then
     relpath = hdd_relpath
   end
   local fullpath = relpath
+  local cover_root = game_path
+  if mass_prefix ~= nil then
+    cover_root = mass_prefix
+  end
   if type(JoinPath) == "function" then
-    fullpath = JoinPath(game_path or "", relpath)
-  elseif game_path ~= nil and game_path ~= "" then
-    if string.sub(game_path, -1) == "/" then
-      fullpath = game_path..relpath
+    fullpath = JoinPath(cover_root or "", relpath)
+  elseif cover_root ~= nil and cover_root ~= "" then
+    if string.sub(cover_root, -1) == "/" then
+      fullpath = cover_root..relpath
     else
-      fullpath = game_path.."/"..relpath
+      fullpath = cover_root.."/"..relpath
     end
   end
   local base = StripExtension(fullpath)
@@ -221,8 +234,7 @@ end
 UI = {
     LASTSCENE = 5;
     SCENES = {
-      GUSBFAT = 1,
-      GUSBEXFAT = 2,
+      GUSB = 1,
       GMMCE = 3,
       GMX4SIO = 4,
       GHDD = 5,
@@ -1490,8 +1502,7 @@ end
         local hide_ui = UI.ShouldHideUI()
         UI.GameList.MAXDRAW = layout.LIST_MAX
         local titles = {
-          [UI.SCENES.GUSBFAT] = "USB FAT32",
-          [UI.SCENES.GUSBEXFAT] = "USB exFAT",
+          [UI.SCENES.GUSB] = "USB",
           [UI.SCENES.GMX4SIO] = "MX4SIO"
         }
         local scene_title = titles[UI.CURSCENE]
@@ -1544,9 +1555,13 @@ end
           if i >= (UI.GameList.STARTUP+UI.GameList.MAXDRAW) then break end
           local Y = layout.LIST_Y + ((i-UI.GameList.STARTUP) * layout.LIST_ROW_H)
           local display_name = PLDR.GAMES[i]
-          local hdd_relpath = string.match(display_name or "", "^[^|]+|(.+)$")
-          if hdd_relpath ~= nil then
-            display_name = string.match(hdd_relpath, "([^/]+)$") or hdd_relpath
+          local _, mass_relpath = ParseMassGameEntry(display_name)
+          local relpath = ExtractGameRelPath(display_name)
+          if mass_relpath ~= nil then
+            relpath = mass_relpath
+          end
+          if relpath ~= nil then
+            display_name = string.match(relpath, "([^/]+)$") or relpath
           end
 	          local c = (i == UI.GameList.CURR) and UI.COLORS.LIST_SELECTED or UI.COLORS.LIST_UNSELECTED
 	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, string.sub(display_name,1, -5), c)
@@ -1614,8 +1629,15 @@ end
             UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..PLDR.POPSTARTER_PATH)
           else
             if UI.CURSCENE ~= UI.SCENES.GHDD then -- only check if game can be found on USB and SMB
-              if not doesFileExist(PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR]) then
-                UI.Notif_queue.add("Cant find Game\n"..PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR])
+              local selected_entry = PLDR.GAMES[UI.GameList.CURR]
+              local mass_prefix, mass_relpath = ParseMassGameEntry(selected_entry)
+              local selected_relpath = mass_relpath or selected_entry
+              local selected_root = PLDR.GAMEPATH
+              if mass_prefix ~= nil then
+                selected_root = mass_prefix
+              end
+              if not doesFileExist(selected_root .. selected_relpath) then
+                UI.Notif_queue.add("Cant find Game\n"..selected_root .. selected_relpath)
               end
             end
             local launch_path = PLDR.GAMEPATH
@@ -1810,7 +1832,7 @@ end
     };
     MainMenu = {
       OPT = 1;
-      opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB (exFAT)", "USB (FAT32)", "SMB (v1)", "Disc (DKWDRV)"};
+      opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
         targetIndex = 1,
@@ -1877,8 +1899,7 @@ end
           ["MX4SIO"] = "MX4SIO",
           ["HDD (exFAT)"] = "BDHDD",
           ["HDD (PFS)"] = "APAHDD",
-          ["USB (exFAT)"] = "USBEXFAT",
-          ["USB (FAT32)"] = "USB",
+          ["USB"] = "USB",
           ["SMB (v1)"] = "SMB",
           ["Disc (DKWDRV)"] = "DISC"
         }
@@ -2106,16 +2127,10 @@ end
               return
             end
             UI.setDeviceLock(DEVLOCK.USB)
-            UI.SceneChange(UI.SCENES.GUSBEXFAT)
+            UI.SceneChange(UI.SCENES.GUSB)
           elseif UI.MainMenu.OPT == 6 then
-            if not UI.RefreshMassDevicePage("USB") then
-              return
-            end
-            UI.setDeviceLock(DEVLOCK.USB)
-            UI.SceneChange(UI.SCENES.GUSBFAT)
-          elseif UI.MainMenu.OPT == 7 then
             UI.Notif_queue.add("Not Implemented Yet")
-          elseif UI.MainMenu.OPT == 8 then
+          elseif UI.MainMenu.OPT == 7 then
             UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
         end
@@ -2313,8 +2328,7 @@ if UI.FONT ~= nil then
 end
 _G.UI = UI
 UI.GAME_SCENES = {
-  [UI.SCENES.GUSBFAT] = true,
-  [UI.SCENES.GUSBEXFAT] = true,
+  [UI.SCENES.GUSB] = true,
   [UI.SCENES.GMMCE] = true,
   [UI.SCENES.GMX4SIO] = true,
   [UI.SCENES.GHDD] = true,
@@ -2324,7 +2338,7 @@ function UI.IsGameScene(scene)
   return UI.GAME_SCENES[scene] == true
 end
 function UI.IsUsbScene(scene)
-  return scene == UI.SCENES.GUSBFAT or scene == UI.SCENES.GUSBEXFAT
+  return scene == UI.SCENES.GUSB
 end
 function UI.IsMx4sioScene(scene)
   return scene == UI.SCENES.GMX4SIO


### PR DESCRIPTION
### Motivation
- Simplify the UI by collapsing FAT/exFAT USB pages into a single USB page so filesystem flavor is a label not a page split.
- Preserve the actual mass slot/source for each listed game so selecting and launching a game is lossless across multiple USB mass slots.
- Avoid using filesystem type to drive paging or routing while keeping display metadata for the user.

### Description
- UI: replaced separate `GUSBFAT`/`GUSBEXFAT` scenes with a single `GUSB` scene, updated `UI.SCENES`, `UI.GAME_SCENES`, `UI.IsUsbScene`, main menu `opts`, title map, icon map, and menu routing to always route USB to `GUSB` (`bin/POPSLDR/ui.lua`).
- UI: added `ParseMassGameEntry` and updated game list display/validation/cover resolution so entries encoded with `massX:/` show the clean filename, validate against the correct source root, and fetch cover art from the entry’s source when present (`bin/POPSLDR/ui.lua`).
- Runtime: added `ParseMassGameEntry` helper and modified `PLDR.GetPS1GameLists` to prefix listed mass-device entries with their `massX:/` source prefix and to sort entries by the relative filename (stable tie-breaker uses full entry), preserving per-entry source metadata (`bin/POPSLDR/system.lua`).
- Runtime: updated `PLDR.RunPOPStarterGame` to decode per-entry `massX:/` metadata into `selected_gamelocation`/`selected_game` and build vcd/boot paths from that stored source slot so launches remain accurate and lossless; kept HDD and SMB handling unchanged except for preserving selection semantics (`bin/POPSLDR/system.lua`).
- Cover/preview paths and existence checks now consider per-entry source prefixes so refresh/launch flows use the entry’s stored slot instead of only the current UI page root (`bin/POPSLDR/ui.lua`, `bin/POPSLDR/system.lua`).

### Testing
- Ran `git diff --check` to verify whitespace/formatting issues and it passed with no errors.
- Performed repository-level checks and committed the changes (commit created and PR metadata prepared) and the commit succeeded.
- Attempted to validate Lua parsing with `lua -e 'assert(loadfile(...))'` but a Lua interpreter was not available in the environment, so runtime syntax execution could not be validated here (manual/runtime testing recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953e3632448321a8a823e83ef99adc)