### PR TITLE
Refactor UI transitions to a single Transition.request entrypoint

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -281,21 +281,15 @@ UI = {
     setDeviceLock = function (target)
       return
     end;
-    RequestScene = function (SCENE)
-      if UI.Transition ~= nil and UI.Transition.Start ~= nil then
-        if UI.Transition.active then
-          if UI.Transition.Queue ~= nil then
-            UI.Transition.Queue(SCENE)
-          end
-          return
-        end
-        if UI.CURSCENE ~= SCENE then
-          UI.Transition.Start(SCENE)
-        end
+    RequestScene = function (SCENE, args)
+      if UI.Transition ~= nil and UI.Transition.request ~= nil then
+        UI.Transition.request(SCENE, args)
       end
     end;
-    SceneChange = function (SCENE)
-      UI.RequestScene(SCENE)
+    SceneChange = function (SCENE, args)
+      if UI.Transition ~= nil and UI.Transition.request ~= nil then
+        UI.Transition.request(SCENE, args)
+      end
     end;
     UpdateVmode = function ()
       Screen.setMode(UI.SCR.VMODE, UI.SCR.X, UI.SCR.Y, CT24, INTERLACED, FIELD)
@@ -1361,7 +1355,7 @@ end
       active = false,
       phase = "out",
       target = nil,
-      next_target = nil,
+      args = nil,
       allowSceneWrite = false,
       timer = nil,
       start = 0,
@@ -1370,24 +1364,17 @@ end
       max_step = 33,
       duration_out = 140,
       duration_in = 120,
-      Queue = function (target)
-        if target == nil then return end
-        if UI.Transition.active and UI.Transition.phase == "out" then
-          UI.Transition.target = target
-          return
-        end
-        if target ~= UI.CURSCENE then
-          UI.Transition.next_target = target
-        end
-      end,
-      Start = function (target)
+      request = function (next_scene_id, optional_args)
+        if next_scene_id == nil then return end
+        if next_scene_id == UI.CURSCENE then return end
+        if UI.Transition.active == true then return end
         if UI.Transition.timer == nil then
           UI.Transition.timer = Timer.new()
         end
         UI.Transition.active = true
         UI.Transition.phase = "out"
-        UI.Transition.target = target
-        UI.Transition.next_target = nil
+        UI.Transition.target = next_scene_id
+        UI.Transition.args = optional_args
         UI.Transition.start = Timer.getTime(UI.Transition.timer)
         UI.Transition.elapsed = 0
         UI.Transition.last_time = UI.Transition.start
@@ -1434,17 +1421,10 @@ end
             UI.Transition.last_time = now
             alpha = 128
           else
-            local queued = UI.Transition.next_target
-            if queued ~= nil and queued ~= UI.CURSCENE then
-              UI.Transition.next_target = nil
-              UI.Transition.Start(queued)
-              alpha = 0
-            else
-              UI.Transition.active = false
-              UI.Transition.target = nil
-              UI.Transition.next_target = nil
-              alpha = 0
-            end
+            UI.Transition.active = false
+            UI.Transition.target = nil
+            UI.Transition.args = nil
+            alpha = 0
           end
         end
         return alpha


### PR DESCRIPTION
### Motivation
- Consolidate transition entrypoints so all scene-change requests funnel through a single public API (`UI.Transition.request`) and avoid duplicated Start/Queue branching across call sites.
- Simplify transition state by removing queued/retarget semantics to make transition lifecycle easier to reason about and to reduce edge-case behavior.
- Preserve the invariant that scene mutation happens only at the transition midpoint (full-black) and that input remains blocked for the duration of an active transition.
- TODO: verify caller expectations for queued transitions were not relied on elsewhere in the codebase (see places calling `UI.SceneChange`/`UI.RequestScene`).

### Description
- Replaced `UI.RequestScene` and `UI.SceneChange` internals to delegate to `UI.Transition.request(next_scene_id, optional_args)` only, passing through optional args when provided.
- Removed `Transition.Queue`, `Transition.Start`, and the `next_target`/queued restart path, and introduced a single `Transition.request` function that initializes `target`, `args`, and timer state.
- Added early-return guards in `Transition.request` so it returns immediately when the requested `next_scene_id` is `nil`, equals `UI.CURSCENE`, or when `UI.Transition.active == true`.
- Kept scene assignment centralized and guarded by `Transition.allowSceneWrite` inside `Transition.Update` where `UI.CURSCENE = UI.Transition.target` occurs, and preserved input-blocking via `Input_GetEvent` while `Transition.active` is true.

### Testing
- Ran `rg -n "Transition\.Start|Transition\.Queue|next_target|request = function|RequestScene = function|SceneChange = function|Transition\.request" bin/POPSLDR/ui.lua` to verify call sites now reference `Transition.request`, and the grep confirmed the refactor (success).
- Attempted to run `lua -e "assert(loadfile('bin/POPSLDR/ui.lua'))"` to validate the file loads, but the `lua` binary is unavailable in this environment so the check could not be performed (failure).
- All automated repository edits were committed successfully and the diff shows the intended removal of queue/start logic and addition of the single `request` API.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f286930883219cf3044f78a610cf)