### PR TITLE
Centralize UI transition durations with 350ms defaults

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -30,6 +30,10 @@ local function EaseInOutCubic(t)
   local f = -2 * t + 2
   return 1 - (f * f * f) / 2
 end
+
+local TRANSITION_OUT_MS = 350
+local TRANSITION_IN_MS = 350
+
 local function GuardTrace()
   if debug ~= nil and debug.traceback ~= nil then
     return debug.traceback("TRACE", 2)
@@ -1362,8 +1366,8 @@ end
       elapsed = 0,
       last_time = nil,
       max_step = 33,
-      duration_out = 140,
-      duration_in = 120,
+      duration_out = TRANSITION_OUT_MS,
+      duration_in = TRANSITION_IN_MS,
       request = function (next_scene_id, optional_args)
         if next_scene_id == nil then return end
         if next_scene_id == UI.CURSCENE then return end


### PR DESCRIPTION
### Motivation
- Reduce scattered magic numbers for UI transitions by centralizing out/in durations into named constants in `bin/POPSLDR/ui.lua`.
- Make the default transition timing consistent and easier to tune by setting both phases to ~350ms.
- Preserve existing frame-rate independent stepping and immediate out→in handoff so visual behavior is unchanged except for the duration values.

### Description
- Added `TRANSITION_OUT_MS = 350` and `TRANSITION_IN_MS = 350` near the transition helper setup in `bin/POPSLDR/ui.lua`.
- Bound `UI.Transition.duration_out` and `UI.Transition.duration_in` to those constants so the runtime transition table uses the centralized defaults.
- Left the `Update` logic unchanged, preserving `delta = now - last`, clamping via `max_step`, `UI.Transition.elapsed = UI.Transition.elapsed + delta`, and the immediate phase switch from `"out"` to `"in"` to avoid introducing any extra hold delay.

### Testing
- Verified the changes are present with `rg -n "duration_out|duration_in|TRANSITION_OUT_MS|TRANSITION_IN_MS|delta = now - last|elapsed = \(UI\.Transition\.elapsed" bin/POPSLDR/ui.lua` which returned the updated references.
- Inspected the modified file region with `nl`/`sed` to confirm constants are declared and the transition table now references them; this inspection succeeded.
- Attempted a Lua `loadfile` smoke-check with `lua -e "assert(loadfile('bin/POPSLDR/ui.lua'))"` but it could not run in this environment because the `lua` executable is not installed (test not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f4509f70832180fb546a0ca2d6ab)