### PR TITLE
Refactor UI transition into dedicated bin/POPSLDR/transition.lua module

### DIFF
--- a/bin/POPSLDR/transition.lua
+++ b/bin/POPSLDR/transition.lua
@@ -1,0 +1,127 @@
+local function Clamp(v, lo, hi)
+  if v < lo then return lo end
+  if v > hi then return hi end
+  return v
+end
+
+local function Round(value)
+  return math.floor(value + 0.5)
+end
+
+local function ResolveDelta(state, dt_or_timer_time)
+  if type(dt_or_timer_time) == "number" then
+    return dt_or_timer_time
+  end
+  if state.timer == nil then
+    state.timer = Timer.new()
+  end
+  local now = Timer.getTime(state.timer)
+  local last = state.last_time or now
+  state.last_time = now
+  return now - last
+end
+
+local Transition = {}
+
+function Transition.new(hooks, options)
+  hooks = hooks or {}
+  options = options or {}
+
+  local state = {
+    active = false,
+    phase = "out",
+    target = nil,
+    args = nil,
+    allow_scene_write = false,
+    timer = nil,
+    elapsed = 0,
+    last_time = nil,
+    max_step = options.max_step or 33,
+    duration_out = options.duration_out or 350,
+    duration_in = options.duration_in or 350
+  }
+
+  local instance = {}
+
+  function instance.request(next_scene_id, optional_args)
+    if next_scene_id == nil then return end
+    if hooks.get_scene ~= nil and next_scene_id == hooks.get_scene() then return end
+    if state.active == true then return end
+
+    state.active = true
+    state.phase = "out"
+    state.target = next_scene_id
+    state.args = optional_args
+    state.elapsed = 0
+    state.last_time = nil
+  end
+
+  function instance.update(dt_or_timer_time)
+    if not state.active then
+      return 0
+    end
+
+    local delta = ResolveDelta(state, dt_or_timer_time)
+    if delta < 0 then delta = 0 end
+    delta = Clamp(delta, 0, state.max_step)
+    state.elapsed = state.elapsed + delta
+
+    local duration = state.phase == "out" and state.duration_out or state.duration_in
+    if duration <= 0 then duration = 1 end
+    local t = Clamp(state.elapsed / duration, 0, 1)
+    local alpha = state.phase == "out" and Round(128 * t) or Round(128 * (1 - t))
+
+    if t >= 1 then
+      if state.phase == "out" then
+        local previous_scene = hooks.get_scene ~= nil and hooks.get_scene() or nil
+        if hooks.on_scene_exit ~= nil then
+          hooks.on_scene_exit(previous_scene, state.target)
+        end
+
+        if hooks.set_last_scene ~= nil then
+          hooks.set_last_scene(previous_scene)
+        end
+
+        state.allow_scene_write = true
+        if hooks.set_scene ~= nil then
+          hooks.set_scene(state.target)
+        end
+        state.allow_scene_write = false
+
+        local next_scene = hooks.get_scene ~= nil and hooks.get_scene() or state.target
+        if hooks.on_scene_enter ~= nil then
+          hooks.on_scene_enter(previous_scene, next_scene)
+        end
+
+        state.phase = "in"
+        state.elapsed = 0
+        state.last_time = nil
+        alpha = 128
+      else
+        state.active = false
+        state.target = nil
+        state.args = nil
+        alpha = 0
+      end
+    end
+
+    return alpha
+  end
+
+  function instance.isSceneWriteAllowed()
+    return state.allow_scene_write
+  end
+
+  setmetatable(instance, {
+    __index = function(_, key)
+      if key == "active" then
+        return state.active
+      end
+      return nil
+    end
+  })
+
+  return instance
+end
+
+return Transition

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -9,6 +9,7 @@
 LOG("Registering POPSLoader UI")
 local DEVLOCK = { NONE = 0, USB = 1, MMCE = 2, MX4SIO = 3 }
 local UI
+local Transition = require("transition")
 local function Round(value)
   return math.floor(value + 0.5)
 end
@@ -31,8 +32,6 @@ local function EaseInOutCubic(t)
   return 1 - (f * f * f) / 2
 end
 
-local TRANSITION_OUT_MS = 350
-local TRANSITION_IN_MS = 350
 
 local function GuardTrace()
   if debug ~= nil and debug.traceback ~= nil then
@@ -716,7 +715,7 @@ UI = {
       UI.TextEntry.Draw()
       UI.Modal.Draw()
       if UI.Transition ~= nil then
-        local alpha = UI.Transition.Update()
+        local alpha = UI.Transition.update()
         if alpha > 0 then
           Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
         end
@@ -1355,85 +1354,7 @@ end
         Font.ftPrint(BFONT, UI.SCR.X_MID, box_y + 95, 8, UI.SCR.X, 16, hint, UI.CCOL.GREY)
       end;
     };
-    Transition = {
-      active = false,
-      phase = "out",
-      target = nil,
-      args = nil,
-      allowSceneWrite = false,
-      timer = nil,
-      start = 0,
-      elapsed = 0,
-      last_time = nil,
-      max_step = 33,
-      duration_out = TRANSITION_OUT_MS,
-      duration_in = TRANSITION_IN_MS,
-      request = function (next_scene_id, optional_args)
-        if next_scene_id == nil then return end
-        if next_scene_id == UI.CURSCENE then return end
-        if UI.Transition.active == true then return end
-        if UI.Transition.timer == nil then
-          UI.Transition.timer = Timer.new()
-        end
-        UI.Transition.active = true
-        UI.Transition.phase = "out"
-        UI.Transition.target = next_scene_id
-        UI.Transition.args = optional_args
-        UI.Transition.start = Timer.getTime(UI.Transition.timer)
-        UI.Transition.elapsed = 0
-        UI.Transition.last_time = UI.Transition.start
-      end,
-      Update = function ()
-        if not UI.Transition.active then
-          return 0
-        end
-        local now = Timer.getTime(UI.Transition.timer)
-        local last = UI.Transition.last_time or now
-        local delta = now - last
-        if delta < 0 then delta = 0 end
-        local max_step = UI.Transition.max_step or 33
-        if delta > max_step then delta = max_step end
-        UI.Transition.elapsed = (UI.Transition.elapsed or 0) + delta
-        UI.Transition.last_time = now
-        local elapsed = UI.Transition.elapsed or 0
-        local duration = UI.Transition.phase == "out" and UI.Transition.duration_out or UI.Transition.duration_in
-        if duration <= 0 then duration = 1 end
-        local t = elapsed / duration
-        if t > 1 then t = 1 end
-        local alpha
-        if UI.Transition.phase == "out" then
-          alpha = Round(128 * t)
-        else
-          alpha = Round(128 * (1 - t))
-        end
-        if t >= 1 then
-          if UI.Transition.phase == "out" then
-            local previous_scene = UI.CURSCENE
-            if UI.OnSceneExit ~= nil then
-              UI.OnSceneExit(previous_scene, UI.Transition.target)
-            end
-            UI.LASTSCENE = UI.CURSCENE
-            UI.Transition.allowSceneWrite = true
-            UI.CURSCENE = UI.Transition.target
-            UI.Transition.allowSceneWrite = false
-            if UI.OnSceneEnter ~= nil then
-              UI.OnSceneEnter(previous_scene, UI.CURSCENE)
-            end
-            UI.Transition.phase = "in"
-            UI.Transition.start = now
-            UI.Transition.elapsed = 0
-            UI.Transition.last_time = now
-            alpha = 128
-          else
-            UI.Transition.active = false
-            UI.Transition.target = nil
-            UI.Transition.args = nil
-            alpha = 0
-          end
-        end
-        return alpha
-      end
-    };
+    Transition = nil;
     HandleGlobalInput = function (allow_exit)
       if UI.TextEntry ~= nil and UI.TextEntry.active then
         UI.TextEntry.HandleInput()
@@ -2427,6 +2348,21 @@ function UI.OnSceneExit(previous_scene, next_scene)
     end
   end
 end
+UI.Transition = Transition.new({
+  get_scene = function () return UI.CURSCENE end,
+  set_scene = function (scene_id) UI.CURSCENE = scene_id end,
+  set_last_scene = function (scene_id) UI.LASTSCENE = scene_id end,
+  on_scene_exit = function (previous_scene, next_scene)
+    if UI.OnSceneExit ~= nil then
+      UI.OnSceneExit(previous_scene, next_scene)
+    end
+  end,
+  on_scene_enter = function (previous_scene, next_scene)
+    if UI.OnSceneEnter ~= nil then
+      UI.OnSceneEnter(previous_scene, next_scene)
+    end
+  end
+})
 UI.RecalcLayout()
 function Input_GetEvent()
   UI.Pad.Listen()
@@ -2475,7 +2411,7 @@ do
     end,
     __newindex = function (t, key, value)
       if key == "CURSCENE" then
-        if UI.Transition == nil or not UI.Transition.allowSceneWrite then
+        if UI.Transition == nil or not UI.Transition.isSceneWriteAllowed or not UI.Transition.isSceneWriteAllowed() then
           LOG("ERROR: scene change blocked outside transition midpoint")
           LOG(GuardTrace())
           return


### PR DESCRIPTION
### Motivation
- Centralize scene transition state and behavior to a single testable module instead of an inline table inside `ui.lua` to reduce call-site churn and make the transition mechanics reusable and easier to maintain.
- Preserve existing UI semantics (midpoint scene swap, enter/exit hooks, protected scene-write window) while keeping the welcome/splash boot-only flow untouched.
- TODO: verify runtime behavior on hardware/emulator to ensure timing and scene-write protection behave identically; check `bin/POPSLDR/ui.lua` and runtime `WelcomeDraw` flow if regressions appear.

### Description
- Added `bin/POPSLDR/transition.lua` that exposes `Transition.new(hooks, options)` and returns an instance implementing `request(next_scene_id, optional_args)`, `update(dt_or_timer_time)` (returns overlay alpha), and `isSceneWriteAllowed()`; a read-only `active` property is exposed via metatable. (See `bin/POPSLDR/transition.lua`.)
- Rewrote `bin/POPSLDR/ui.lua` to require the new module, remove the inline `Transition` table, and wire `UI.Transition = Transition.new({...})` with injected hooks: `get_scene`, `set_scene`, `set_last_scene`, `on_scene_exit`, and `on_scene_enter`.
- Minimal call-site changes: replaced `UI.Transition.Update()` with `UI.Transition.update()` and updated the `CURSCENE` setter guard to use `isSceneWriteAllowed()` for the protected write window.
- Kept boot-only welcome/splash logic unchanged and not routed through the new transition module.

### Testing
- Attempted Lua syntax checks with `luac -p bin/POPSLDR/ui.lua && luac -p bin/POPSLDR/transition.lua` but the `luac` binary is not available in this environment (failed).
- Attempted `lua -v` to confirm runtime Lua availability but `lua` is not installed in this environment (failed).
- Performed repository sanity checks and committed the changes (`git commit` succeeded) and verified the diff (`git show --stat`) showing the new module and `ui.lua` changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f4d0e44c8321b39505a8dfe46a55)