### PR TITLE
Add STANDARD/MMCE/MX4SIO boot variants with isolated boot-root selection

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,6 +15,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: STANDARD
+            zip_name: PS1_POPSLOADER.ZIP
+          - variant: MMCE
+            zip_name: PS1_POPSLOADER-MMCE.ZIP
+          - variant: MX4SIO
+            zip_name: PS1_POPSLOADER-MX4SIO.ZIP
     steps:
       - name: Install dependencies
         run: |
@@ -38,52 +48,22 @@ jobs:
           printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
           cat bin/POPSLDR/BUILD_INFO.txt
 
-      - name: Compile project
+      - name: Compile project (${{ matrix.variant }})
         run: |
-          make clean elfloader all package
+          make clean elfloader all package BOOT_VARIANT=${{ matrix.variant }}
 
-      # This step is the key: it discovers wherever your Makefile put the .7z,
-      # then copies it to repo root as POPSLoader.7z so upload-artifact is stable.
-      - name: Locate and normalize POPSLoader.7z
+      - name: Verify package name
         shell: sh
         run: |
           set -eu
+          test -f "bin/${{ matrix.zip_name }}"
+          ls -lah "bin/${{ matrix.zip_name }}"
 
-          echo "== Workspace contents (top-level) =="
-          ls -lah
-
-          echo "== Searching for .7z artifacts (up to 6 levels deep) =="
-          # Show all matches for debugging
-          find . -maxdepth 6 -type f -name '*.7z' -print || true
-
-          # Prefer an exact name match first (any location)
-          EXACT="$(find . -maxdepth 6 -type f -name 'POPSLoader.7z' -print | head -n 1 || true)"
-
-          if [ -n "$EXACT" ]; then
-            echo "Found exact artifact: $EXACT"
-            cp -f "$EXACT" "./POPSLoader.7z"
-          else
-            # Otherwise pick the newest .7z produced (common when Makefile names differ)
-            NEWEST="$(find . -maxdepth 6 -type f -name '*.7z' -print -exec ls -t {} + 2>/dev/null | head -n 1 || true)"
-
-            if [ -z "$NEWEST" ]; then
-              echo "ERROR: No .7z artifact found after build."
-              echo "Hint: your Makefile 'package' target may be outputting a different extension or skipping packaging."
-              exit 1
-            fi
-
-            echo "No exact POPSLoader.7z found. Using newest .7z: $NEWEST"
-            cp -f "$NEWEST" "./POPSLoader.7z"
-          fi
-
-          echo "== Final normalized artifact =="
-          ls -lah "./POPSLoader.7z"
-
-      - name: Upload artifact (no release)
+      - name: Upload artifact (${{ matrix.variant }})
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: POPSLoader
-          path: POPSLoader.7z
+          name: POPSLoader-${{ matrix.variant }}
+          path: bin/${{ matrix.zip_name }}
           if-no-files-found: error
           compression-level: 0

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ RESET_IOP = 1
 DEBUG = 0
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
+#------------------------ Boot root variant ------------------------#
+BOOT_VARIANT ?= STANDARD
 #------------------------------------------------------------------#
 
 BINDIR = bin/
@@ -56,6 +58,19 @@ endif
 
 ifeq ($(DEBUG),1)
 EE_CXXFLAGS += -DDEBUG
+endif
+
+ifeq ($(BOOT_VARIANT),STANDARD)
+EE_CXXFLAGS += -DBOOT_VARIANT_STANDARD
+PACKAGE_NAME = PS1_POPSLOADER.ZIP
+else ifeq ($(BOOT_VARIANT),MMCE)
+EE_CXXFLAGS += -DBOOT_VARIANT_MMCE
+PACKAGE_NAME = PS1_POPSLOADER-MMCE.ZIP
+else ifeq ($(BOOT_VARIANT),MX4SIO)
+EE_CXXFLAGS += -DBOOT_VARIANT_MX4SIO
+PACKAGE_NAME = PS1_POPSLOADER-MX4SIO.ZIP
+else
+$(error Unsupported BOOT_VARIANT '$(BOOT_VARIANT)'. Use STANDARD, MMCE, or MX4SIO.)
 endif
 
 BIN2S = $(PS2SDK)/bin/bin2c
@@ -181,7 +196,7 @@ run:
 reset:
 	ps2client -h $(PS2LINK_IP) reset   
 
-POPSLDR_PKG = POPSLoader.7z
+POPSLDR_PKG = $(PACKAGE_NAME)
 PKG_DIR = bin/package
 package: $(EE_BIN_PKD)
 	rm -f $(POPSLDR_PKG)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,11 +85,21 @@ extern unsigned int size_ds34bt_irx;
 extern unsigned char mmceman_irx;
 extern unsigned int size_mmceman_irx;
 
+extern unsigned char mx4sio_bd_irx[];
+extern unsigned int size_mx4sio_bd_irx;
+
 char boot_path[255];
 char app_dir[255];
 int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
 static clock_t boot_start = 0;
+
+static bool LoadIrxChecked(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
+static void setAppDirFromPath(const char *path);
+
+#if !defined(BOOT_VARIANT_STANDARD) && !defined(BOOT_VARIANT_MMCE) && !defined(BOOT_VARIANT_MX4SIO)
+#define BOOT_VARIANT_STANDARD
+#endif
 
 static unsigned int boot_ms(void)
 {
@@ -178,6 +188,129 @@ void setLuaBootPath(int argc, char ** argv, int idx)
     NormalizeDirPath(boot_path, sizeof(boot_path));
     
     
+}
+
+static bool ProbeDirReady(const char *path)
+{
+    struct stat st;
+    int ret = stat(path, &st);
+    DPRINTF("Boot root probe %s ret=%d\n", path, ret);
+    return (ret == 0);
+}
+
+static bool BuildPath(char *out, size_t out_size, const char *root, const char *leaf)
+{
+    if (out == NULL || out_size == 0 || root == NULL || leaf == NULL) {
+        return false;
+    }
+    int n = snprintf(out, out_size, "%s%s", root, leaf);
+    if (n < 0 || (size_t)n >= out_size) {
+        return false;
+    }
+    return true;
+}
+
+static bool boot_root_valid_from(const char *root)
+{
+    if (root == NULL || root[0] == '\0') {
+        return false;
+    }
+    if (!ProbeDirReady(root)) {
+        return false;
+    }
+
+    char flat[255];
+    char legacy[255];
+    if (!BuildPath(flat, sizeof(flat), root, "system.lua")) {
+        return false;
+    }
+    if (!BuildPath(legacy, sizeof(legacy), root, "POPSLDR/system.lua")) {
+        return false;
+    }
+
+    return (access(flat, F_OK) == 0 || access(legacy, F_OK) == 0);
+}
+
+static void boot_root_standard(int argc, char *argv[])
+{
+    setLuaBootPath(argc, argv, 0);
+    if (argc > 0 && argv[0]) {
+        setAppDirFromPath(argv[0]);
+    } else {
+        setAppDirFromPath(boot_path);
+    }
+}
+
+static bool boot_init_mmce_minimal(void)
+{
+    return (mmce_slot0_ready != 0 || mmce_slot1_ready != 0);
+}
+
+static bool boot_root_variant_mmce(void)
+{
+    if (boot_root_valid_from(boot_path)) {
+        return true;
+    }
+    if (!boot_init_mmce_minimal()) {
+        return false;
+    }
+
+    const char *candidates[] = {"mmce0:/", "mmce1:/", "mmce:/"};
+    for (size_t i = 0; i < (sizeof(candidates) / sizeof(candidates[0])); ++i) {
+        if (boot_root_valid_from(candidates[i])) {
+            snprintf(boot_path, sizeof(boot_path), "%s", candidates[i]);
+            setAppDirFromPath(candidates[i]);
+            DPRINTF("MMCE variant boot root selected: %s\n", boot_path);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool boot_init_mx4sio_minimal(void)
+{
+    return LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+}
+
+static bool boot_root_variant_mx4sio(void)
+{
+    if (boot_root_valid_from(boot_path)) {
+        return true;
+    }
+
+    if (!boot_init_mx4sio_minimal()) {
+        return false;
+    }
+
+    const char *candidates[] = {"mx4sio:/", "mx4sio0:/"};
+    for (size_t i = 0; i < (sizeof(candidates) / sizeof(candidates[0])); ++i) {
+        if (boot_root_valid_from(candidates[i])) {
+            snprintf(boot_path, sizeof(boot_path), "%s", candidates[i]);
+            setAppDirFromPath(candidates[i]);
+            DPRINTF("MX4SIO variant boot root selected: %s\n", boot_path);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void configure_boot_root(int argc, char *argv[])
+{
+    boot_root_standard(argc, argv);
+#if defined(BOOT_VARIANT_STANDARD)
+    return;
+#elif defined(BOOT_VARIANT_MMCE)
+    if (boot_root_variant_mmce()) {
+        return;
+    }
+#elif defined(BOOT_VARIANT_MX4SIO)
+    if (boot_root_variant_mx4sio()) {
+        return;
+    }
+#endif
+    boot_root_standard(argc, argv);
 }
 
 static void setAppDirFromPath(const char *path)
@@ -408,12 +541,7 @@ int main(int argc, char * argv[])
         retries--;
     }
 	
-        setLuaBootPath (argc, argv, 0);
-        if (argc > 0 && argv[0]) {
-            setAppDirFromPath(argv[0]);
-        } else {
-            setAppDirFromPath(boot_path);
-        }
+        configure_boot_root(argc, argv);
 	// Lua init
 	// init internals library
     


### PR DESCRIPTION
### Motivation
- Provide three build variants that only change early boot root selection so `STANDARD` preserves existing USB/MC/HOST boot behavior while adding optional boot-capable fallbacks for MMCE and MX4SIO.
- Keep all device-page scanning and runtime asset layout unchanged and add only minimal, variant-only early init where required to probe `mmce:/` or `mx4sio:/` roots.
- TODO: verify runtime parity and variant fallback behavior on PS2/PCSX2 by inspecting `src/main.cpp` `configure_boot_root()` and the Lua detection in `bin/POPSLDR/system.lua` (see `DetectBootDevice` and related routines).

### Description
- Froze the existing argv-based boot-path setup into `boot_root_standard()` and routed boot root selection through `configure_boot_root()` in `src/main.cpp` so `STANDARD` returns immediately after standard setup. (`src/main.cpp`)
- Added variant helpers `boot_root_variant_mmce()` and `boot_root_variant_mx4sio()` that try `boot_root_standard()` first and only attempt their device-specific probes if the standard path is not valid, plus tiny variant-only init hooks `boot_init_mmce_minimal()` and `boot_init_mx4sio_minimal()` which reuse existing MMCE readiness state and load the embedded `mx4sio_bd.irx` respectively. (`src/main.cpp`)
- Added lightweight root validation helpers that check for `system.lua` or `POPSLDR/system.lua` under candidate roots so the same flat/fallback layout is enforced. (`src/main.cpp`)
- Introduced `BOOT_VARIANT` support in `Makefile` with compile-time defines (`-DBOOT_VARIANT_STANDARD|MMCE|MX4SIO`) and exact package naming `PS1_POPSLOADER.ZIP`, `PS1_POPSLOADER-MMCE.ZIP`, and `PS1_POPSLOADER-MX4SIO.ZIP`. (`Makefile`)
- Replaced the single-build CI with a matrix that builds all three variants and uploads the corresponding zip artifacts so CI will produce the 3 required ELFs + packages. (`.github/workflows/compilation.yml`)
- Safety measures: no changes were made to device-page scanning or runtime Lua logic, and all variant behavior is gated behind compile-time flags and executed only after the standard boot probe fails. (`src/main.cpp`, `bin/POPSLDR/system.lua`)

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors. (passed)
- Performed a dry `make -n clean elfloader all package BOOT_VARIANT=STANDARD` which could not complete in this environment due to missing PS2 toolchain files (`/samples/Makefile.eeglobal`), so a full local build was not possible here (blocked).
- Added a CI matrix job that will build each `BOOT_VARIANT` and verify the expected package file name (`bin/PS1_POPSLOADER*.ZIP`), but the CI build was not executed in this session (CI will validate actual builds and packaging).
- TODO: run the CI job or build in a PS2DEV environment and verify the three runtime checks: `STANDARD` boots from USB/MC/HOST unchanged, `MMCE` and `MX4SIO` variants still prefer standard roots and additionally boot from their respective devices when present (validate logs from `configure_boot_root()` and Lua `DetectBootDevice`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69965f380ec8832183bf65b77079c0c7)