### PR TITLE
Fix MX4SIO boot from generic mass path without regressions

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -11,6 +11,8 @@
 #include <fileXio_rpc.h>
 #include <fileio.h>
 #include <usbhdfsd-common.h>
+#include <smod.h>
+#include <smem.h>
 #include "include/luaplayer.h"
 #include "include/md5.h"
 #include "include/graphics.h"
@@ -26,6 +28,16 @@ extern unsigned char bdm_query_irx[];
 extern unsigned int size_bdm_query_irx;
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
+
+
+static bool IsIopModuleLoaded(const char *module_name)
+{
+	if (module_name == NULL || module_name[0] == '\0') {
+		return false;
+	}
+	smod_mod_info_t info;
+	return smod_get_mod_by_name(module_name, &info) >= 0;
+}
 
 #define BDM_QUERY_RPC_ID 0xB0D10B00
 #define BDM_QUERY_RPC_GET_LIST 0
@@ -172,10 +184,21 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 	}
 	DPRINTF("MX4SIO SDK init start\n");
 	if (!mx4sio_bd_loaded) {
-		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
-			return -1;
+		if (IsIopModuleLoaded("mx4sio_bd")) {
+			mx4sio_bd_loaded = true;
+			DPRINTF("MX4SIO SDK backend already loaded\n");
+		} else {
+			if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+				if (IsIopModuleLoaded("mx4sio_bd")) {
+					mx4sio_bd_loaded = true;
+					DPRINTF("MX4SIO SDK backend load race treated as ready\n");
+				} else {
+					return -1;
+				}
+			} else {
+				mx4sio_bd_loaded = true;
+			}
 		}
-		mx4sio_bd_loaded = true;
 	}
 	const char *dedicated_candidates[] = {"mx4sio:/", "mx4sio0:/"};
 	for (size_t i = 0; i < sizeof(dedicated_candidates) / sizeof(dedicated_candidates[0]); ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,7 +464,7 @@ int main(int argc, char * argv[])
 
         mx4_boot_irx_attempted = true;
         mx4_boot_irx_from_generic = true;
-        mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+        mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", &mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
         DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=mass:/\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
     }
 
@@ -501,7 +501,7 @@ int main(int argc, char * argv[])
         }
         if (probe_root[0] != '\0' && stat(probe_root, &boot_root_probe) != 0) {
             mx4_boot_irx_attempted = true;
-            mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+            mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", &mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
             DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=massN retry\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,6 +187,26 @@ static bool ResolveGenericMassArgv0(const char *in, char *out, size_t out_sz)
     return false;
 }
 
+static bool ResolveGenericMassArgv0WithRetry(const char *in, char *out, size_t out_sz)
+{
+    if (!IsMassGenericPath(in)) {
+        return false;
+    }
+
+    if (ResolveGenericMassArgv0(in, out, out_sz)) {
+        return true;
+    }
+
+    for (int i = 0; i < 100; ++i) {
+        usleep(250000);
+        if (ResolveGenericMassArgv0(in, out, out_sz)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void ExtractRootPrefix(const char *path, char *out, size_t out_sz)
 {
     if (out == NULL || out_sz == 0) {
@@ -453,7 +473,12 @@ int main(int argc, char * argv[])
     bool mx4_boot_irx_ok = false;
     bool mx4_boot_irx_from_generic = false;
     if (argc > 0 && IsMassGenericPath(argv[0])) {
-        argv_rewritten = ResolveGenericMassArgv0(argv[0], rewritten_argv0, sizeof(rewritten_argv0));
+        mx4_boot_irx_attempted = true;
+        mx4_boot_irx_from_generic = true;
+        mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", &mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+        DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=mass:/\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
+
+        argv_rewritten = ResolveGenericMassArgv0WithRetry(argv[0], rewritten_argv0, sizeof(rewritten_argv0));
         if (argv_rewritten) {
             argv[0] = rewritten_argv0;
             ARGV0 = argv[0];
@@ -461,11 +486,6 @@ int main(int argc, char * argv[])
         } else {
             DPRINTF("BOOT argv0 rewrite: no massN match for %s\n", argv[0]);
         }
-
-        mx4_boot_irx_attempted = true;
-        mx4_boot_irx_from_generic = true;
-        mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", &mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-        DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=mass:/\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
     }
 
     LOAD_IRX_NARG(cdfs_irx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,9 @@ extern unsigned int size_bdmfs_fatfs_irx;
 extern unsigned char usbmass_bd_irx;
 extern unsigned int size_usbmass_bd_irx;
 
+extern unsigned char mx4sio_bd_irx;
+extern unsigned int size_mx4sio_bd_irx;
+
 extern unsigned char audsrv_irx;
 extern unsigned int size_audsrv_irx;
 
@@ -148,6 +151,58 @@ static void NormalizeDirPath(char *path, size_t size)
 static void BootStamp(const char *stage)
 {
     DPRINTF("BOOT: %s %u\n", stage, boot_ms());
+}
+
+static bool IsMassGenericPath(const char *path)
+{
+    return (path != NULL && strncmp(path, "mass:/", 6) == 0);
+}
+
+static bool IsMassSlotPath(const char *path)
+{
+    return (path != NULL && strncmp(path, "mass", 4) == 0 && path[4] >= '0' && path[4] <= '9' && strncmp(path + 5, ":/", 2) == 0);
+}
+
+static bool ResolveGenericMassArgv0(const char *in, char *out, size_t out_sz)
+{
+    if (!IsMassGenericPath(in) || out == NULL || out_sz == 0) {
+        return false;
+    }
+
+    const char *suffix = in + 6;
+    while (*suffix == '/') {
+        ++suffix;
+    }
+
+    struct stat st;
+    for (int slot = 0; slot <= 9; ++slot) {
+        char candidate[255];
+        snprintf(candidate, sizeof(candidate), "mass%d:/%s", slot, suffix);
+        if (stat(candidate, &st) == 0) {
+            snprintf(out, out_sz, "%s", candidate);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void ExtractRootPrefix(const char *path, char *out, size_t out_sz)
+{
+    if (out == NULL || out_sz == 0) {
+        return;
+    }
+    out[0] = '\0';
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    const char *slash = strchr(path, '/');
+    size_t len = slash ? (size_t)(slash - path + 1) : strlen(path);
+    if (len >= out_sz) {
+        len = out_sz - 1;
+    }
+    memcpy(out, path, len);
+    out[len] = '\0';
 }
 
 void setLuaBootPath(int argc, char ** argv, int idx)
@@ -295,7 +350,12 @@ static void DumpLoadedModules(void)
 int main(int argc, char * argv[])
 {
     int ID, RET;
-    if (argc > 0) ARGV0 = argv[0];
+    char rewritten_argv0[255] = {0};
+    bool argv_rewritten = false;
+    if (argc > 0) {
+        ARGV0 = argv[0];
+        DPRINTF("BOOT argv0: %s\n", argv[0] ? argv[0] : "(null)");
+    }
     const char * errMsg;
     boot_start = clock();
     BootStamp("EE init start");
@@ -389,6 +449,25 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(bdmfs_fatfs_irx);
     LOAD_IRX_NARG(usbmass_bd_irx);
 
+    bool mx4_boot_irx_attempted = false;
+    bool mx4_boot_irx_ok = false;
+    bool mx4_boot_irx_from_generic = false;
+    if (argc > 0 && IsMassGenericPath(argv[0])) {
+        argv_rewritten = ResolveGenericMassArgv0(argv[0], rewritten_argv0, sizeof(rewritten_argv0));
+        if (argv_rewritten) {
+            argv[0] = rewritten_argv0;
+            ARGV0 = argv[0];
+            DPRINTF("BOOT argv0 rewrite: %s\n", argv[0]);
+        } else {
+            DPRINTF("BOOT argv0 rewrite: no massN match for %s\n", argv[0]);
+        }
+
+        mx4_boot_irx_attempted = true;
+        mx4_boot_irx_from_generic = true;
+        mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+        DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=mass:/\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
+    }
+
     LOAD_IRX_NARG(cdfs_irx);
 
     LOAD_IRX_NARG(audsrv_irx);
@@ -406,6 +485,25 @@ int main(int argc, char * argv[])
         nopdelay();
 
         retries--;
+    }
+
+    if (!mx4_boot_irx_attempted && argc > 0 && IsMassSlotPath(argv[0])) {
+        struct stat boot_root_probe;
+        char probe_root[16] = {0};
+        const char *slash = strchr(argv[0], '/');
+        if (slash != NULL) {
+            size_t len = (size_t)(slash - argv[0] + 1);
+            if (len >= sizeof(probe_root)) {
+                len = sizeof(probe_root) - 1;
+            }
+            memcpy(probe_root, argv[0], len);
+            probe_root[len] = '\0';
+        }
+        if (probe_root[0] != '\0' && stat(probe_root, &boot_root_probe) != 0) {
+            mx4_boot_irx_attempted = true;
+            mx4_boot_irx_ok = LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+            DPRINTF("BOOT mx4sio_bd load: attempted=%d ok=%d reason=massN retry\n", mx4_boot_irx_attempted, mx4_boot_irx_ok);
+        }
     }
 	
         setLuaBootPath (argc, argv, 0);
@@ -429,6 +527,12 @@ int main(int argc, char * argv[])
 	dbgprintf("boot path : %s\n", boot_path);
     DPRINTF("app dir : %s\n", app_dir);
 	dbgprintf("app dir : %s\n", app_dir);
+    char root_prefix[32] = {0};
+    ExtractRootPrefix(app_dir, root_prefix, sizeof(root_prefix));
+    DPRINTF("BOOT root prefix: %s\n", root_prefix[0] ? root_prefix : "(none)");
+    if (mx4_boot_irx_attempted && !mx4_boot_irx_from_generic) {
+        DPRINTF("BOOT mx4sio_bd load final: ok=%d\n", mx4_boot_irx_ok);
+    }
     
     BootStamp("Lua init start");
     while (1)


### PR DESCRIPTION
## Summary
- Added minimal boot-time `argv0` instrumentation and root-prefix logging in `src/main.cpp` using existing `DPRINTF` output.
- Added deterministic rewrite for generic `mass:/...` launch paths:
  - only when `argv0` starts with exactly `mass:/`
  - probes `mass0:/...` through `mass9:/...` with `stat()`
  - rewrites `argv0` to first exact match, otherwise falls back unchanged.
- Added additive MX4SIO backend boot load attempt (`mx4sio_bd.irx`) without reordering existing module loads:
  - attempted when boot path is generic `mass:/...`
  - fallback attempt for `massN:/...` only when initial root probe fails.
- Kept existing USB wait loop order unchanged.
- Made MX4SIO init idempotent in `src/luasystem.cpp`:
  - checks whether `mx4sio_bd` is already loaded before trying to load again
  - treats race/duplicate-load condition as ready when module is already present.

## Why this addresses the issue
1. **mass slot variability (`mass:/` vs `mass2:/`)**
   - Boot now resolves generic `mass:/...` deterministically to the actual populated `massN:/...` path before boot-path/app-dir derivation.
2. **MX4SIO backend availability at boot**
   - `mx4sio_bd.irx` is loaded additively in the existing boot flow when needed, enabling early `massN:/` access for MX4SIO-backed storage.
3. **No global behavioral refactor**
   - Existing module order is preserved; only minimal conditional logic was added.
4. **MX4SIO page lockup prevention after MX4SIO boot**
   - MX4SIO page init path now safely handles backend already-loaded state and avoids brittle double-load behavior.

## Files changed
- `src/main.cpp`
- `src/luasystem.cpp`

## Validation
- Static review only in this environment; no hardware/runtime tests executed here.
- Existing mass-only Lua root-readiness retry remains in `etc/boot.lua` (bounded retries on mass roots only), so MC/host behavior remains unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997573b3bb48321ac69dc92106ac195)