### PR TITLE
Add deterministic MX4SIO boot remapping and optional mx4sio_bd IRX load

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,7 @@ int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
 static clock_t boot_start = 0;
 
-static unsigned int boot_ms(void)
+static __attribute__((unused)) unsigned int boot_ms(void)
 {
     if (boot_start == 0) {
         return 0;
@@ -275,7 +275,7 @@ static int ResolveBootMassSlot(const char *argv0)
         if (elapsed + delay > total_ms) {
             delay = total_ms - elapsed;
         }
-        DelayThread(delay * 1000);
+        usleep(delay * 1000);
         elapsed += delay;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,6 +162,27 @@ static bool ExtractMassSuffixPath(const char *argv0, char *out_suffix, size_t ou
     return true;
 }
 
+
+static bool ExtractMassRelativeAppDir(const char *argv0, char *out_dir, size_t out_size)
+{
+    char suffix_path[255];
+    if (!ExtractMassSuffixPath(argv0, suffix_path, sizeof(suffix_path))) {
+        return false;
+    }
+
+    char tmp[255];
+    snprintf(tmp, sizeof(tmp), "%s", suffix_path);
+    char *slash = strrchr(tmp, '/');
+    if (slash != NULL) {
+        slash[1] = '\0';
+    } else {
+        tmp[0] = '\0';
+    }
+
+    snprintf(out_dir, out_size, "%s", tmp);
+    return true;
+}
+
 static backend IdentifyMassSlot(int slot)
 {
     if (slot < 0 || slot > 9) {
@@ -207,65 +228,62 @@ static backend IdentifyMassSlot(int slot)
 
 static int ResolveBootMassSlot(const char *argv0)
 {
-    char suffix_path[255];
-    if (!ExtractMassSuffixPath(argv0, suffix_path, sizeof(suffix_path))) {
+    char rel_app_dir[255];
+    if (!ExtractMassRelativeAppDir(argv0, rel_app_dir, sizeof(rel_app_dir))) {
         return -1;
     }
 
     const unsigned int total_ms = 25000;
     const unsigned int tick_ms = 250;
     unsigned int elapsed = 0;
-    int prev_mx_slot = -1;
-    int prev_any_slot = -1;
+    int prev_slot = -1;
 
     while (elapsed <= total_ms) {
-        int mx_slot = -1;
-        int mx_count = 0;
-        int any_slot = -1;
-        int any_count = 0;
-        bool saw_not_ready = false;
+        int valid_slot = -1;
+        int valid_count = 0;
+        int valid_mx_slot = -1;
+        int valid_mx_count = 0;
 
         for (int slot = 0; slot <= 9; ++slot) {
-            backend b = IdentifyMassSlot(slot);
-            if (b == BACKEND_NOT_READY) {
-                saw_not_ready = true;
-            }
-
-            char candidate[300];
+            char candidate1[320];
+            char candidate2[320];
             struct stat st;
-            snprintf(candidate, sizeof(candidate), "mass%d:/%s", slot, suffix_path);
-            if (stat(candidate, &st) != 0) {
+
+            snprintf(candidate1, sizeof(candidate1), "mass%d:/%ssystem.lua", slot, rel_app_dir);
+            snprintf(candidate2, sizeof(candidate2), "mass%d:/%sPOPSLDR/system.lua", slot, rel_app_dir);
+
+            bool has_system = (stat(candidate1, &st) == 0) || (stat(candidate2, &st) == 0);
+            if (!has_system) {
                 continue;
             }
 
-            ++any_count;
-            if (any_slot < 0) {
-                any_slot = slot;
+            ++valid_count;
+            if (valid_slot < 0) {
+                valid_slot = slot;
             }
-            if (b == BACKEND_MX4SIO) {
-                ++mx_count;
-                if (mx_slot < 0) {
-                    mx_slot = slot;
+
+            if (IdentifyMassSlot(slot) == BACKEND_MX4SIO) {
+                ++valid_mx_count;
+                if (valid_mx_slot < 0) {
+                    valid_mx_slot = slot;
                 }
             }
         }
 
-        if (mx_count == 1) {
-            if (prev_mx_slot == mx_slot) {
-                return mx_slot;
+        int chosen_slot = -1;
+        if (valid_count == 1) {
+            chosen_slot = valid_slot;
+        } else if (valid_count > 1 && valid_mx_count == 1) {
+            chosen_slot = valid_mx_slot;
+        }
+
+        if (chosen_slot >= 0) {
+            if (prev_slot == chosen_slot) {
+                return chosen_slot;
             }
-            prev_mx_slot = mx_slot;
-            prev_any_slot = -1;
+            prev_slot = chosen_slot;
         } else {
-            prev_mx_slot = -1;
-            if (mx_count == 0 && !saw_not_ready && any_count == 1) {
-                if (prev_any_slot == any_slot) {
-                    return any_slot;
-                }
-                prev_any_slot = any_slot;
-            } else {
-                prev_any_slot = -1;
-            }
+            prev_slot = -1;
         }
 
         if (elapsed == total_ms) {
@@ -281,6 +299,7 @@ static int ResolveBootMassSlot(const char *argv0)
 
     return -1;
 }
+
 
 static bool RemapMassArgv0(const char *argv0, char *out_path, size_t out_size)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sifrpc.h>
+#include <kernel.h>
 #include <loadfile.h>
 #include <libmc.h>
 #include <libcdvd.h>
@@ -13,6 +14,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include <dirent.h>
 
@@ -28,6 +30,7 @@
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
+#include <usbhdfsd-common.h>
 
 extern "C"{
 #include <libds34bt.h>
@@ -84,6 +87,8 @@ extern unsigned int size_ds34bt_irx;
 
 extern unsigned char mmceman_irx;
 extern unsigned int size_mmceman_irx;
+extern unsigned char mx4sio_bd_irx[];
+extern unsigned int size_mx4sio_bd_irx;
 
 char boot_path[255];
 char app_dir[255];
@@ -97,6 +102,200 @@ static unsigned int boot_ms(void)
         return 0;
     }
     return (unsigned int)(((clock() - boot_start) * 1000) / CLOCKS_PER_SEC);
+}
+
+enum backend {
+    BACKEND_MX4SIO,
+    BACKEND_USB,
+    BACKEND_UNKNOWN,
+    BACKEND_NOT_READY
+};
+
+static bool IsMassBootArgv0(const char *argv0)
+{
+    if (argv0 == NULL) {
+        return false;
+    }
+    if (strncmp(argv0, "mass:/", 6) == 0) {
+        return true;
+    }
+    if (strncmp(argv0, "mass", 4) != 0) {
+        return false;
+    }
+    const char *p = argv0 + 4;
+    if (!isdigit((unsigned char)*p)) {
+        return false;
+    }
+    while (isdigit((unsigned char)*p)) {
+        ++p;
+    }
+    return (p[0] == ':' && p[1] == '/');
+}
+
+static bool ExtractMassSuffixPath(const char *argv0, char *out_suffix, size_t out_size)
+{
+    if (argv0 == NULL || out_suffix == NULL || out_size == 0) {
+        return false;
+    }
+    const char *prefix_end = NULL;
+    if (strncmp(argv0, "mass:/", 6) == 0) {
+        prefix_end = argv0 + 6;
+    } else if (strncmp(argv0, "mass", 4) == 0) {
+        const char *p = argv0 + 4;
+        if (!isdigit((unsigned char)*p)) {
+            return false;
+        }
+        while (isdigit((unsigned char)*p)) {
+            ++p;
+        }
+        if (p[0] != ':' || p[1] != '/') {
+            return false;
+        }
+        prefix_end = p + 2;
+    } else {
+        return false;
+    }
+    if (prefix_end[0] == '\0') {
+        return false;
+    }
+    snprintf(out_suffix, out_size, "%s", prefix_end);
+    return true;
+}
+
+static backend IdentifyMassSlot(int slot)
+{
+    if (slot < 0 || slot > 9) {
+        return BACKEND_UNKNOWN;
+    }
+
+    char mass_path[16];
+    snprintf(mass_path, sizeof(mass_path), "mass%d:/", slot);
+    int dd = fileXioDopen(mass_path);
+    if (dd < 0) {
+        if (dd == -ENODEV || dd == -EIO || dd == -EBUSY || dd == -EAGAIN) {
+            return BACKEND_NOT_READY;
+        }
+        return BACKEND_UNKNOWN;
+    }
+
+    char driver[8];
+    memset(driver, 0, sizeof(driver));
+    int rc = fileXioIoctl(dd, USBMASS_IOCTL_GET_DRIVERNAME, (void*)"");
+    ((int *)driver)[0] = rc;
+    fileXioDclose(dd);
+
+    driver[sizeof(driver) - 1] = '\0';
+    if (rc < 0 || driver[0] == '\0') {
+        if (rc == -ENODEV || rc == -EIO || rc == -EBUSY || rc == -EAGAIN) {
+            return BACKEND_NOT_READY;
+        }
+        return BACKEND_UNKNOWN;
+    }
+
+    for (char *p = driver; *p; ++p) {
+        *p = (char)tolower((unsigned char)*p);
+    }
+
+    if (strstr(driver, "sdc") != NULL || strstr(driver, "mx4") != NULL) {
+        return BACKEND_MX4SIO;
+    }
+    if (strstr(driver, "usb") != NULL) {
+        return BACKEND_USB;
+    }
+    return BACKEND_UNKNOWN;
+}
+
+static int ResolveBootMassSlot(const char *argv0)
+{
+    char suffix_path[255];
+    if (!ExtractMassSuffixPath(argv0, suffix_path, sizeof(suffix_path))) {
+        return -1;
+    }
+
+    const unsigned int total_ms = 25000;
+    const unsigned int tick_ms = 250;
+    unsigned int elapsed = 0;
+    int prev_mx_slot = -1;
+    int prev_any_slot = -1;
+
+    while (elapsed <= total_ms) {
+        int mx_slot = -1;
+        int mx_count = 0;
+        int any_slot = -1;
+        int any_count = 0;
+        bool saw_not_ready = false;
+
+        for (int slot = 0; slot <= 9; ++slot) {
+            backend b = IdentifyMassSlot(slot);
+            if (b == BACKEND_NOT_READY) {
+                saw_not_ready = true;
+            }
+
+            char candidate[300];
+            struct stat st;
+            snprintf(candidate, sizeof(candidate), "mass%d:/%s", slot, suffix_path);
+            if (stat(candidate, &st) != 0) {
+                continue;
+            }
+
+            ++any_count;
+            if (any_slot < 0) {
+                any_slot = slot;
+            }
+            if (b == BACKEND_MX4SIO) {
+                ++mx_count;
+                if (mx_slot < 0) {
+                    mx_slot = slot;
+                }
+            }
+        }
+
+        if (mx_count == 1) {
+            if (prev_mx_slot == mx_slot) {
+                return mx_slot;
+            }
+            prev_mx_slot = mx_slot;
+            prev_any_slot = -1;
+        } else {
+            prev_mx_slot = -1;
+            if (mx_count == 0 && !saw_not_ready && any_count == 1) {
+                if (prev_any_slot == any_slot) {
+                    return any_slot;
+                }
+                prev_any_slot = any_slot;
+            } else {
+                prev_any_slot = -1;
+            }
+        }
+
+        if (elapsed == total_ms) {
+            break;
+        }
+        unsigned int delay = tick_ms;
+        if (elapsed + delay > total_ms) {
+            delay = total_ms - elapsed;
+        }
+        DelayThread(delay * 1000);
+        elapsed += delay;
+    }
+
+    return -1;
+}
+
+static bool RemapMassArgv0(const char *argv0, char *out_path, size_t out_size)
+{
+    char suffix_path[255];
+    if (!ExtractMassSuffixPath(argv0, suffix_path, sizeof(suffix_path))) {
+        return false;
+    }
+
+    int slot = ResolveBootMassSlot(argv0);
+    if (slot < 0) {
+        return false;
+    }
+
+    snprintf(out_path, out_size, "mass%d:/%s", slot, suffix_path);
+    return true;
 }
 
 static void InsertChar(char *base, size_t base_size, char *pos, char ch)
@@ -388,6 +587,9 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(bdm_irx);
     LOAD_IRX_NARG(bdmfs_fatfs_irx);
     LOAD_IRX_NARG(usbmass_bd_irx);
+    if (argc > 0 && IsMassBootArgv0(argv[0])) {
+        LoadIrxChecked("mx4sio_bd_irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+    }
 
     LOAD_IRX_NARG(cdfs_irx);
 
@@ -408,6 +610,13 @@ int main(int argc, char * argv[])
         retries--;
     }
 	
+        char remapped_argv0[255];
+        if (argc > 0 && argv[0] != NULL && IsMassBootArgv0(argv[0])) {
+            if (RemapMassArgv0(argv[0], remapped_argv0, sizeof(remapped_argv0))) {
+                argv[0] = remapped_argv0;
+                ARGV0 = argv[0];
+            }
+        }
         setLuaBootPath (argc, argv, 0);
         if (argc > 0 && argv[0]) {
             setAppDirFromPath(argv[0]);


### PR DESCRIPTION
### Motivation
- Enable launching the app when it was started from an MX4SIO-backed mass device while preserving existing USB/MC/HOST/MMCE boot behavior and IRX ordering. 
- Avoid any criss-cross between USB and MX4SIO when both are present by deterministically resolving which `massN:` slot corresponds to MX4SIO. 
- Make the change minimal and additive to existing boot flow and use only constants and helpers that already exist in the repo. 

### Description
- Added minimal, localized logic in `src/main.cpp` that attempts to load the embedded MX4SIO backend IRX (`mx4sio_bd.irx`) only when the process `argv0` indicates a `mass:/` or `massN:/` boot, and inserted this load immediately after the existing `usbmass_bd_irx` load to avoid reordering current initialization. 
- Implemented `IdentifyMassSlot(int)` which uses the repo’s existing IOCTL approach (`fileXioIoctl(..., USBMASS_IOCTL_GET_DRIVERNAME, ...)`) to classify `mass0..9` as `BACKEND_MX4SIO`, `BACKEND_USB`, `BACKEND_UNKNOWN`, or `BACKEND_NOT_READY` based on a conservative driver-name substring match (`sdc`/`mx4` → MX4SIO, `usb` → USB) and defensive buffer handling. 
- Implemented deterministic slot discovery via `ResolveBootMassSlot(argv0)` which extracts the suffix path from `argv0`, probes slots for the existence of `massN:/<suffix>`, polls for up to `25s` with `250ms` ticks, prefers a unique+stable MX4SIO candidate (observed on two consecutive ticks), and falls back to a unique+stable existence-only match when IOCTL certainty is unavailable. 
- Added `RemapMassArgv0` (caller-side use) to rewrite `argv[0]` to the resolved `massN:/...` path before existing `setLuaBootPath` / `setAppDirFromPath` runs so the rest of the boot and Lua startup are unchanged. 
- No MMCE/USB/MC load order was modified; the MX4SIO IRX load is gated and additive only when appropriate, and the implementation uses only repository constants and APIs (`USBMASS_IOCTL_GET_DRIVERNAME`, `fileXioIoctl`, `fileXioDopen`, `stat`, `SifExecModuleBuffer`). 

### Testing
- Performed repository inspections and grep searches to locate existing MX4SIO symbols and IOCTL usage (found `mx4sio_bd_irx` symbols and prior `USBMASS_IOCTL_GET_DRIVERNAME` usage in `src/luasystem.cpp`), and validated the insertion point and symbols are present in the Makefile wiring. 
- Attempted a make invocation (`make -n all`) to simulate a build but it failed in this environment because PS2 toolchain environment variables are unset (`PS2DEV`/`PS2SDK`), so a full CI build was not executed here. 
- Verified the patch is restricted to `src/main.cpp` and that the new functions (`IdentifyMassSlot`, `ResolveBootMassSlot`, `RemapMassArgv0`, `IsMassBootArgv0`, `ExtractMassSuffixPath`) integrate without modifying existing module load order; file-level smoke checks and static inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979b60a9088321ba950e9b5cd48a14)