### PR TITLE
Preload MX4SIO backend IRX, add MX4SIO script fallback, and guard font calls

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -105,6 +105,33 @@ local function wait_for_readable_script(path)
   return path
 end
 
+local function read_wait_open(path, attempts)
+  for i = 1, attempts do
+    local fd = System.openFile(path, FREAD)
+    if fd ~= nil then
+      System.closeFile(fd)
+      return true
+    end
+    if i < attempts then
+      System.delayThreadMs(250)
+    end
+  end
+  return false
+end
+
+local function mx4sio_path_from(base_dir, leaf)
+  local normalized = ensure_dir(normalize_path(base_dir))
+  if normalized == nil then
+    return nil
+  end
+  local suffix = string.gsub(normalized, "^[%a%d_]+:/?", "")
+  suffix = string.gsub(suffix, "^/+", "")
+  if suffix ~= "" and string.sub(suffix, -1) ~= "/" then
+    suffix = suffix.."/"
+  end
+  return normalize_path("mx4sio:/"..suffix..leaf)
+end
+
 local function dir_exists(path)
   if path == nil or path == "" then
     return false
@@ -192,8 +219,12 @@ Font.ftInit()
 BFONT = Font.LoadBuiltinFont()
 SFONT = Font.LoadBuiltinFont()
 LFONT = Font.LoadBuiltinFont()
-Font.ftSetCharSize(BFONT, 800, 800)
-Font.ftSetCharSize(SFONT, 600, 600)
+if BFONT ~= nil then
+  Font.ftSetCharSize(BFONT, 800, 800)
+end
+if SFONT ~= nil then
+  Font.ftSetCharSize(SFONT, 600, 600)
+end
 BOOT_PROF.stamp("UI assets init (fonts)")
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end
 
@@ -309,5 +340,23 @@ if SYS ~= nil then
   SYS = wait_for_readable_script(SYS)
   RunScript(SYS)
 else
+  local first_candidate = normalize_path(SYS_CANDIDATES[1])
+  if first_candidate ~= nil and is_usb_mass_root(first_candidate) then
+    local mx4_flat = mx4sio_path_from(BASE_DIR, "system.lua")
+    local mx4_pop = mx4sio_path_from(BASE_DIR, "POPSLDR/system.lua")
+    local mx4_candidates = {mx4_flat, mx4_pop}
+    for i = 1, #mx4_candidates do
+      local p = mx4_candidates[i]
+      if p ~= nil and read_wait_open(p, 100) then
+        local script_dir = dirname(p)
+        if script_dir ~= nil then
+          BASE_DIR = ensure_dir(script_dir)
+          System.currentDirectory(BASE_DIR)
+        end
+        RunScript(p)
+        return
+      end
+    end
+  end
   error("Cant access system.lua (flat) or POPSLDR/system.lua (fallback)\n\n\targv0: "..tostring(ARGV0).."\n\tcwd: "..tostring(System.currentDirectory()))
 end

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sifrpc.h>
 #include <string.h>
+#include <smod.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
@@ -50,6 +51,12 @@ static bool bdm_rpc_bound = false;
 static bool bdm_rpc_loaded = false;
 static bdm_dev_list_t bdm_rpc_buffer __attribute__((aligned(64)));
 static bool mx4sio_bd_loaded = false;
+
+static bool IsModuleLoadedByName(const char *name)
+{
+	smod_mod_info_t info;
+	return (name != NULL && smod_get_mod_by_name(name, &info) >= 0);
+}
 
 static bool EnsureBdmQueryRpc()
 {
@@ -172,7 +179,8 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 	}
 	DPRINTF("MX4SIO SDK init start\n");
 	if (!mx4sio_bd_loaded) {
-		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL) &&
+		    !IsModuleLoadedByName("mx4sio_bd")) {
 			return -1;
 		}
 		mx4sio_bd_loaded = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,9 @@ extern unsigned int size_ds34bt_irx;
 extern unsigned char mmceman_irx;
 extern unsigned int size_mmceman_irx;
 
+extern unsigned char mx4sio_bd_irx[];
+extern unsigned int size_mx4sio_bd_irx;
+
 char boot_path[255];
 char app_dir[255];
 int mmce_slot0_ready = -1;
@@ -265,6 +268,29 @@ static bool LoadIrxChecked(const char *name, unsigned char *irx, unsigned int si
     return true;
 }
 
+static bool IsModuleLoadedByName(const char *name)
+{
+    smod_mod_info_t info;
+    return (name != NULL && smod_get_mod_by_name(name, &info) >= 0);
+}
+
+static bool LoadIrxAdditive(const char *log_name, const char *module_name, unsigned char *irx, unsigned int size)
+{
+    if (IsModuleLoadedByName(module_name)) {
+        DPRINTF("IOP module already loaded: %s\n", module_name);
+        return true;
+    }
+
+    int id = -1;
+    int ret = -1;
+    bool loaded = LoadIrxChecked(log_name, irx, size, &id, &ret);
+    if (!loaded && IsModuleLoadedByName(module_name)) {
+        DPRINTF("IOP module became available despite load error: %s id=%d ret=%d\n", module_name, id, ret);
+        return true;
+    }
+    return loaded;
+}
+
 #ifdef DEBUG
 static void DumpLoadedModules(void)
 {
@@ -388,6 +414,7 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(bdm_irx);
     LOAD_IRX_NARG(bdmfs_fatfs_irx);
     LOAD_IRX_NARG(usbmass_bd_irx);
+    LoadIrxAdditive("mx4sio_bd_irx", "mx4sio_bd", mx4sio_bd_irx, size_mx4sio_bd_irx);
 
     LOAD_IRX_NARG(cdfs_irx);
 


### PR DESCRIPTION
### Motivation
- Ensure the MX4SIO backend IRX is attempted during boot every time without changing existing module init order so MX4SIO boots reliably from `mx4sio:/` while preserving USB/MC/HOST/MMCE behavior.
- Make the MX4SIO page init idempotent so duplicate load-attempts are treated as success when the backend is already present.
- Provide a minimal, bounded fallback to try `mx4sio:/<appdir>/system.lua` (and `POPSLDR/system.lua`) only when normal `system.lua` resolution fails on `mass:` boots.
- Prevent the error-screen crash by guarding `Font.ftSetCharSize` when built-in font handles are `nil`.

### Description
- Added an `extern` for `mx4sio_bd_irx` and `size_mx4sio_bd_irx` and a small helper pair in `src/main.cpp`: `IsModuleLoadedByName(...)` (uses `smod_get_mod_by_name`) and `LoadIrxAdditive(...)` which attempts to load the embedded MX4SIO backend IRX additively and treats already-loaded modules as success, then calls it once during boot after the existing BDM/usbmass loads, without reordering any existing loads.
- Made MX4SIO init idempotent in `src/luasystem.cpp` by checking `smod_get_mod_by_name("mx4sio_bd")` and treating that as success when `LoadIrxCheckedBuffer(...)` fails, so page-side init will not error if the IRX is already present.
- Added a minimal MX4SIO script fallback in `etc/boot.lua` that: provides `read_wait_open(...)` and `mx4sio_path_from(...)`, only runs when the regular `system.lua` candidates fail and the first candidate is `mass:`-style, retries the `mx4sio:/` candidates up to `100`×`250ms` (25s), and if successful sets `BASE_DIR`/`System.currentDirectory` to the discovered MX4SIO script directory before running the script; existing candidates remain unchanged.
- Guarded `Font.ftSetCharSize(BFONT, ...)` and `Font.ftSetCharSize(SFONT, ...)` in `etc/boot.lua` to skip the call when `BFONT`/`SFONT` are `nil`, preventing the `ftSetCharSize nil` crash on error screens.

### Testing
- Attempted local build with `make all`, which failed in this environment due to missing PS2SDK include/make include (`/samples/Makefile.eeglobal`), so a full compile/test could not be completed here (failure: environment dependency missing).
- No other automated runtime tests were available in this environment; recommend CI run `make clean elfloader all package` to validate the change in the PS2 toolchain environment and to exercise the MX4SIO boot acceptance cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a232f3588321a84a71d930758cc7)