### PR TITLE
Add mx4sio IRX externs and unconditional load in main init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,9 @@ extern unsigned int size_bdmfs_fatfs_irx;
 extern unsigned char usbmass_bd_irx;
 extern unsigned int size_usbmass_bd_irx;
 
+extern unsigned char mx4sio_bd_irx;
+extern unsigned int size_mx4sio_bd_irx;
+
 extern unsigned char audsrv_irx;
 extern unsigned int size_audsrv_irx;
 
@@ -388,6 +391,7 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(bdm_irx);
     LOAD_IRX_NARG(bdmfs_fatfs_irx);
     LOAD_IRX_NARG(usbmass_bd_irx);
+    LOAD_IRX_NARG(mx4sio_bd_irx);
 
     LOAD_IRX_NARG(cdfs_irx);
 


### PR DESCRIPTION
### Motivation
- Ensure the `mx4sio` IOP backend is declared and loaded during startup so the mx4sio driver is available alongside other block-device modules; TODO: verify the embedded IRX blob is present in the packaging (`EMBED/` or `Makefile`).

### Description
- Added `extern` declarations for `mx4sio_bd_irx` and `size_mx4sio_bd_irx` in `src/main.cpp` to match existing IRX blob declarations.
- Inserted a single unconditional `LOAD_IRX_NARG(mx4sio_bd_irx);` call in `main()` immediately after `LOAD_IRX_NARG(usbmass_bd_irx);` without reordering any existing loads.

### Testing
- Verified symbol and call placement using repository inspection commands (`rg` to locate symbols and `nl`/source checks to confirm insertion), both checks succeeded.
- Recommend running CI build (`make clean elfloader all package`) to validate linking, packaging, and that the embedded blob is present and loads correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a60330a083218d9e11d9ce8edc87)