### PR TITLE
Add boot-time probing to resolve `mass:/` to concrete `massN:/` device paths

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,6 +153,38 @@ static void BootStamp(const char *stage)
     DPRINTF("BOOT: %s %u\n", stage, boot_ms());
 }
 
+static void ResolveMassLaunchPath(int argc, char **argv)
+{
+    if (argc <= 0 || argv == NULL || argv[0] == NULL) {
+        return;
+    }
+
+    const char *prefix = "mass:/";
+    if (strncmp(argv[0], prefix, strlen(prefix)) != 0) {
+        return;
+    }
+
+    const char *suffix = argv[0] + strlen(prefix);
+    struct stat path_stat;
+    char probe[255];
+
+    for (int tick = 0; tick < 100; ++tick) {
+        for (int idx = 0; idx < 10; ++idx) {
+            snprintf(probe, sizeof(probe), "mass%d:/%s", idx, suffix);
+            if (stat(probe, &path_stat) == 0) {
+                size_t len = strlen(probe) + 1;
+                char *resolved = (char *)malloc(len);
+                if (resolved != NULL) {
+                    memcpy(resolved, probe, len);
+                    argv[0] = resolved;
+                }
+                return;
+            }
+        }
+        usleep(250000);
+    }
+}
+
 void setLuaBootPath(int argc, char ** argv, int idx)
 {
     if (argc>=(idx+1))
@@ -412,6 +444,7 @@ int main(int argc, char * argv[])
         retries--;
     }
 	
+        ResolveMassLaunchPath(argc, argv);
         setLuaBootPath (argc, argv, 0);
         if (argc > 0 && argv[0]) {
             setAppDirFromPath(argv[0]);


### PR DESCRIPTION
### Motivation
- Ensure launches that use the generic `mass:/` prefix correctly resolve to the actual mounted `massN:/` device at boot time before Lua path setup. 
- Handle delayed device availability by retrying probing for a short boot window instead of immediately failing or leaving `mass:/` unresolved. 
- Preserve existing behavior for already-resolved schemes like `mass0:/`, `mx4sio:/`, etc., by only acting when `argv[0]` starts with the exact `mass:/` prefix. 

### Description
- Added a new function `ResolveMassLaunchPath(int argc, char **argv)` in `src/main.cpp` that runs only when `argv[0]` begins with `mass:/`. 
- The resolver keeps the suffix after `mass:/` and probes `mass0:/<suffix>` through `mass9:/<suffix>` using `stat()` on each probe. 
- The probe loop runs up to 100 ticks with `usleep(250000)` between ticks (25s total), and on the first `stat() == 0` it allocates and rewrites `argv[0]` to the matching `massN:/...` and returns. 
- Invoked `ResolveMassLaunchPath` immediately before `setLuaBootPath(argc, argv, 0)` so the resolved path is used for subsequent boot path logic, and leaves `argv[0]` unchanged if no match is found. 

### Testing
- Attempted build validation with `make -n all` in this environment, but it failed due to missing repository/toolchain files (`/samples/Makefile.eeglobal`), so the change could not be compiled here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a6a3182c83218118eb740f7e7efb)