### PR TITLE
Derive readiness device root from computed boot path

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -251,6 +251,44 @@ static void setAppDirFromPath(const char *path)
     NormalizeDirPath(app_dir, sizeof(app_dir));
 }
 
+static bool ExtractDeviceRoot(const char *path, char *root, size_t root_size)
+{
+    if (path == NULL || root == NULL || root_size < 4) {
+        return false;
+    }
+
+    const char *colon = strchr(path, ':');
+    if (colon == NULL) {
+        return false;
+    }
+
+    size_t prefix_len = (size_t)(colon - path) + 1;
+    if (prefix_len + 1 >= root_size) {
+        return false;
+    }
+
+    memcpy(root, path, prefix_len);
+    root[prefix_len] = '/';
+    root[prefix_len + 1] = '\0';
+    return true;
+}
+
+static int WaitUntilDeviceRootIsReady(const char *root, int retries)
+{
+    struct stat buffer;
+    int ret = -1;
+
+    while (ret != 0 && retries > 0)
+    {
+        ret = stat(root, &buffer);
+        /* Wait until the device is ready */
+        nopdelay();
+        retries--;
+    }
+
+    return ret;
+}
+
 
 void initMC(void)
 {
@@ -429,28 +467,21 @@ int main(int argc, char * argv[])
 
     LOAD_IRX_NARG(audsrv_irx);
 
-    //waitUntilDeviceIsReady by fjtrujy
-
-    struct stat buffer;
-    int ret = -1;
-    int retries = 50;
-
-    while(ret != 0 && retries > 0)
-    {
-        ret = stat("mass:/", &buffer);
-        /* Wait until the device is ready */
-        nopdelay();
-
-        retries--;
+    ResolveMassLaunchPath(argc, argv);
+    setLuaBootPath (argc, argv, 0);
+    if (argc > 0 && argv[0]) {
+        setAppDirFromPath(argv[0]);
+    } else {
+        setAppDirFromPath(boot_path);
     }
-	
-        ResolveMassLaunchPath(argc, argv);
-        setLuaBootPath (argc, argv, 0);
-        if (argc > 0 && argv[0]) {
-            setAppDirFromPath(argv[0]);
-        } else {
-            setAppDirFromPath(boot_path);
-        }
+
+    // waitUntilDeviceIsReady by fjtrujy (root path derived from boot path when possible)
+    char device_root[16];
+    const char *ready_root = "mass:/";
+    if (ExtractDeviceRoot(boot_path, device_root, sizeof(device_root))) {
+        ready_root = device_root;
+    }
+    WaitUntilDeviceRootIsReady(ready_root, 50);
 	// Lua init
 	// init internals library
     


### PR DESCRIPTION
### Motivation

- Ensure the startup readiness probe targets the actual device where the ELF lives (e.g., `mass2:/`, `mx4sio:/`, `mc0:/`, `host:/`) instead of always probing `mass:/`.
- Allow boot-path derivation to run before the readiness wait so the device root can be extracted from the computed boot path.
- Preserve existing compatibility by keeping `mass:/` as a fallback when extraction fails to avoid regressions.

### Description

- Added `ExtractDeviceRoot(const char *path, char *root, size_t root_size)` to extract a normalized device root (returns strings like `mass:/`, `mx4sio:/`, `host:/`) from the computed `boot_path`.
- Added `WaitUntilDeviceRootIsReady(const char *root, int retries)` to provide a bounded `stat(root)` + `nopdelay()` retry helper and return the final `stat` result.
- Reordered startup so `ResolveMassLaunchPath` and `setLuaBootPath` run before the readiness wait and replaced the previous hardcoded `stat("mass:/")` loop with a root-aware wait using the extracted root and a compatibility fallback to `mass:/`.
- Kept the retry bounds (50 attempts) and behavior otherwise unchanged, and left other initialization sequences intact.

### Testing

- Attempted the CI/local build invocation `make -n clean elfloader all package` but it could not complete in this environment because the PS2SDK / `Makefile.eeglobal` is not available, so a full build could not be validated (expected to succeed in CI with toolchain present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a747e9908321b5370698e21eab17)