### PR TITLE
Add gated HDD boot-path preparation before Lua boot resolution

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -92,22 +92,28 @@ local function ResolveWritablePath(rel)
   return modern
 end
 
-local function ResolveStateFilePath()
-  local base_root = NormalizeDirPath(BASE_DIR or APP_DIR_LOCAL)
-  local state_path = JoinPath(base_root, ".pldrs")
-  if string.match(state_path, "^hdd0:[^:]+:pfs/") then
-    local partition = string.match(state_path, "^(hdd0:[^:]+):pfs/")
-    local suffix = string.match(state_path, "^hdd0:[^:]+:pfs(/.*)$")
-    if partition ~= nil and suffix ~= nil and HDD ~= nil and HDD.Initialize ~= nil and HDD.MountPartition ~= nil then
-      local ok = HDD.Initialize()
-      if ok then
-        if HDD.MountPartition(partition, 1, FIO_MT_RDWR) then
-          return "pfs1:"..suffix
-        end
-      end
+local function ResolveHddPfsAlias(path)
+  if path == nil then
+    return nil
+  end
+  if not string.match(path, "^hdd0:[^:]+:pfs/") then
+    return path
+  end
+  local partition = string.match(path, "^(hdd0:[^:]+):pfs/")
+  local suffix = string.match(path, "^hdd0:[^:]+:pfs(/.*)$")
+  if partition ~= nil and suffix ~= nil and HDD ~= nil and HDD.Initialize ~= nil and HDD.MountPartition ~= nil then
+    local ok = HDD.Initialize()
+    if ok and HDD.MountPartition(partition, 1, FIO_MT_RDWR) then
+      return "pfs1:"..suffix
     end
   end
-  return state_path
+  return path
+end
+
+local function ResolveStateFilePath()
+  local base_root = NormalizeDirPath(BASE_DIR or APP_DIR_LOCAL)
+  local primary = JoinPath(base_root, ".pldrs")
+  return ResolveHddPfsAlias(primary)
 end
 
 local function IsAbsoluteDevicePath(path)
@@ -1936,8 +1942,17 @@ end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.MMAIN
-if Touch(ResolveStateFilePath()) then
-  initial_scene = UI.SCENES.CREDITS
+local state_path = ResolveStateFilePath()
+if not doesFileExist(state_path) then
+  if Touch(state_path) then
+    initial_scene = UI.SCENES.CREDITS
+  else
+    local legacy_state = ResolveWritablePath(".pldrs")
+    legacy_state = ResolveHddPfsAlias(legacy_state)
+    if legacy_state ~= state_path and not doesFileExist(legacy_state) and Touch(legacy_state) then
+      initial_scene = UI.SCENES.CREDITS
+    end
+  end
 end
 UI.WelcomeDraw.Play(initial_scene)
 if UI.Transition ~= nil then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -92,6 +92,24 @@ local function ResolveWritablePath(rel)
   return modern
 end
 
+local function ResolveStateFilePath()
+  local base_root = NormalizeDirPath(BASE_DIR or APP_DIR_LOCAL)
+  local state_path = JoinPath(base_root, ".pldrs")
+  if string.match(state_path, "^hdd0:[^:]+:pfs/") then
+    local partition = string.match(state_path, "^(hdd0:[^:]+):pfs/")
+    local suffix = string.match(state_path, "^hdd0:[^:]+:pfs(/.*)$")
+    if partition ~= nil and suffix ~= nil and HDD ~= nil and HDD.Initialize ~= nil and HDD.MountPartition ~= nil then
+      local ok = HDD.Initialize()
+      if ok then
+        if HDD.MountPartition(partition, 1, FIO_MT_RDWR) then
+          return "pfs1:"..suffix
+        end
+      end
+    end
+  end
+  return state_path
+end
+
 local function IsAbsoluteDevicePath(path)
   return path ~= nil and string.match(path, "^[%a]+%d*:/") ~= nil
 end
@@ -1898,18 +1916,27 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
 end
 
 function Touch(FILE)
-  if not doesFileExist(FILE) then
-    local FD = System.openFile(FILE, FCREATE)
-    System.closeFile(FD)
-    return true
-  else
+  if FILE == nil or FILE == "" then
     return false
   end
+  if doesFileExist(FILE) then
+    return false
+  end
+  local parent = string.match(FILE, "^(.*)/[^/]*$")
+  if parent ~= nil and parent ~= "" then
+    EnsureDirectory(NormalizeDirPath(parent))
+  end
+  local FD = System.openFile(FILE, FCREATE)
+  if FD == nil or FD < 0 then
+    return false
+  end
+  System.closeFile(FD)
+  return true
 end
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.MMAIN
-if Touch(ResolveWritablePath(".pldrs")) then
+if Touch(ResolveStateFilePath()) then
   initial_scene = UI.SCENES.CREDITS
 end
 UI.WelcomeDraw.Play(initial_scene)

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -49,6 +49,8 @@ extern void luaSystem_init(lua_State *L);
 extern void luaSound_init(lua_State *L);
 extern void luaRender_init(lua_State *L);
 extern void luaHDD_init(lua_State *L);
+extern bool HDDInitializeStack(void);
+extern int HDDMountPartition(const char *path, int index, int openmod);
 extern void stackDump (lua_State *L);
 
 #endif

--- a/src/luaHDD.cpp
+++ b/src/luaHDD.cpp
@@ -134,6 +134,30 @@ ERR:
     HDDLOADSTATE = HDDLOADSTATES::FAILED_TO_LOAD;
     return 4;
 }
+
+
+bool HDDInitializeStack(void)
+{
+    lua_State *L = luaL_newstate();
+    if (L == NULL) {
+        return false;
+    }
+
+    int result_count = Load_HDD_IRX(L);
+    bool ok = false;
+    if (result_count >= 1 && lua_isboolean(L, -result_count)) {
+        ok = lua_toboolean(L, -result_count) != 0;
+    }
+
+    lua_close(L);
+    return ok;
+}
+
+int HDDMountPartition(const char *path, int index, int openmod)
+{
+    return mnt(path, index, openmod);
+}
+
 static const luaL_Reg HDD_functions[] = {
   	{"MountPartition",    MountPart},
   	{"UMountPartition",    UmountPart},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -202,6 +202,160 @@ static void NormalizeArgv0Path(char *path)
     }
 }
 
+
+
+static bool StartsWith(const char *text, const char *prefix)
+{
+    if (text == NULL || prefix == NULL) {
+        return false;
+    }
+    size_t prefix_len = strlen(prefix);
+    return strncmp(text, prefix, prefix_len) == 0;
+}
+
+static bool IsHDDBootPath(const char *path)
+{
+    if (path == NULL) {
+        return false;
+    }
+    return StartsWith(path, "hdd0:/") || strstr(path, ":pfs/") != NULL || StartsWith(path, "pfs");
+}
+
+static int ParsePfsIndex(const char *pfs_name)
+{
+    if (!StartsWith(pfs_name, "pfs")) {
+        return -1;
+    }
+    const char *digit = pfs_name + 3;
+    if (*digit < '0' || *digit > '9') {
+        return -1;
+    }
+    return *digit - '0';
+}
+
+static void ExtractDirName(const char *path, char *out, size_t out_size)
+{
+    if (out == NULL || out_size == 0) {
+        return;
+    }
+    out[0] = '\0';
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+
+    snprintf(out, out_size, "%s", path);
+    char *slash = strrchr(out, '/');
+    if (slash != NULL) {
+        slash[1] = '\0';
+    } else {
+        char *colon = strchr(out, ':');
+        if (colon != NULL && (size_t)(colon - out + 2) < out_size) {
+            colon[1] = '/';
+            colon[2] = '\0';
+        }
+    }
+}
+
+static bool HDDProbeReadable(const char *resolved_path)
+{
+    if (resolved_path == NULL || resolved_path[0] == '\0') {
+        return false;
+    }
+
+    char dir[255];
+    char syslua[255];
+    struct stat st;
+    ExtractDirName(resolved_path, dir, sizeof(dir));
+    if (dir[0] == '\0') {
+        return false;
+    }
+    snprintf(syslua, sizeof(syslua), "%ssystem.lua", dir);
+
+    for (int tick = 0; tick < 100; ++tick) {
+        if (stat(syslua, &st) == 0 || stat(dir, &st) == 0) {
+            return true;
+        }
+        usleep(250000);
+    }
+    return false;
+}
+
+static const char *EnsureHDDBootPath(const char *argv0)
+{
+    static char resolved[255];
+
+    if (argv0 == NULL || argv0[0] == '\0') {
+        return argv0;
+    }
+    if (!IsHDDBootPath(argv0)) {
+        return argv0;
+    }
+
+    resolved[0] = '\0';
+    if (!HDDInitializeStack()) {
+        return resolved;
+    }
+
+    int mount_index = -1;
+    char mount_part[128] = {0};
+    const char *mapped_suffix = NULL;
+
+    if (StartsWith(argv0, "pfs")) {
+        const char *colon = strchr(argv0, ':');
+        if (colon != NULL) {
+            char pfs_name[8] = {0};
+            size_t name_len = (size_t)(colon - argv0);
+            if (name_len < sizeof(pfs_name)) {
+                memcpy(pfs_name, argv0, name_len);
+                pfs_name[name_len] = '\0';
+                mount_index = ParsePfsIndex(pfs_name);
+            }
+        }
+    }
+
+    const char *pfs_marker = strstr(argv0, ":pfs/");
+    if (pfs_marker != NULL && StartsWith(argv0, "hdd0:")) {
+        size_t part_len = (size_t)(pfs_marker - argv0);
+        if (part_len < sizeof(mount_part)) {
+            memcpy(mount_part, argv0, part_len);
+            mount_part[part_len] = '\0';
+            mapped_suffix = pfs_marker + strlen(":pfs/") - 1; // keep leading '/'
+        }
+    } else if (pfs_marker != NULL) {
+        const char *hdd = strstr(argv0, "hdd0:");
+        if (hdd != NULL && hdd < pfs_marker) {
+            size_t part_len = (size_t)(pfs_marker - hdd);
+            if (part_len < sizeof(mount_part)) {
+                memcpy(mount_part, hdd, part_len);
+                mount_part[part_len] = '\0';
+                mapped_suffix = pfs_marker + strlen(":pfs/") - 1;
+            }
+        }
+    }
+
+    if (mount_part[0] != '\0') {
+        if (mount_index < 0) {
+            mount_index = 1;
+        }
+        if (mount_index >= 0 && mount_index <= 9) {
+            HDDMountPartition(mount_part, mount_index, FIO_MT_RDONLY);
+            if (mapped_suffix != NULL) {
+                snprintf(resolved, sizeof(resolved), "pfs%d:%s", mount_index, mapped_suffix);
+            }
+        }
+    }
+
+    if (resolved[0] == '\0') {
+        snprintf(resolved, sizeof(resolved), "%s", argv0);
+    }
+
+    if (!HDDProbeReadable(resolved)) {
+        resolved[0] = '\0';
+    }
+
+    return resolved;
+}
+
 static bool BootPathMatchesLaunchPath(const char *launch_path)
 {
     if (boot_path[0] == '\0') {
@@ -503,6 +657,10 @@ int main(int argc, char * argv[])
     LOAD_IRX_NARG(audsrv_irx);
 
     ResolveMassLaunchPath(argc, argv);
+    if (argc > 0 && argv[0] != NULL) {
+        const char *hdd_path = EnsureHDDBootPath(argv[0]);
+        argv[0] = (char *)hdd_path;
+    }
     setLuaBootPath (argc, argv, 0);
     if (argc > 0 && argv[0]) {
         setAppDirFromPath(argv[0]);


### PR DESCRIPTION
## Summary
- added an early `EnsureHDDBootPath(argv0)` hook in `src/main.cpp` that only activates when boot path matches HDD/PFS patterns (`hdd0:/`, `:pfs/`, or `pfs...`)
- integrated this hook before `setLuaBootPath` / app-dir derivation so HDD boots are prepared before Lua base-dir probing
- implemented bounded HDD readiness probing (25 seconds, 250ms ticks) checking `dirname(argv0)/system.lua` or the directory itself

## HDD stack reuse and gating
- reused the existing HDD stack from `src/luaHDD.cpp` by exposing two thin wrappers:
  - `HDDInitializeStack()` -> calls the existing `Load_HDD_IRX` logic
  - `HDDMountPartition(...)` -> calls existing `mnt(...)`
- this avoids introducing any new IRX order or alternate mount stack
- non-HDD boots return immediately from the hook and do not invoke HDD init/mount/wait

## Behavior details
- if HDD/PFS boot path is detected, initialize HDD stack and attempt mount mapping from existing `:pfs/`-style path metadata
- preserves explicit pfs mount index when boot path starts with `pfsN:`
- on timeout/unreadable path, returns empty argv0 so existing boot error handling can trigger

## Notes
- no new debug logging styles were introduced; existing output patterns remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bf267a948321a84c75dd5c78e3cb)