### PR TITLE
Limit pre-Lua boot path resolution to argv0-derived paths

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,38 +153,6 @@ static void BootStamp(const char *stage)
     DPRINTF("BOOT: %s %u\n", stage, boot_ms());
 }
 
-static void ResolveMassLaunchPath(int argc, char **argv)
-{
-    if (argc <= 0 || argv == NULL || argv[0] == NULL) {
-        return;
-    }
-
-    const char *prefix = "mass:/";
-    if (strncmp(argv[0], prefix, strlen(prefix)) != 0) {
-        return;
-    }
-
-    const char *suffix = argv[0] + strlen(prefix);
-    struct stat path_stat;
-    char probe[255];
-
-    for (int tick = 0; tick < 100; ++tick) {
-        for (int idx = 0; idx < 10; ++idx) {
-            snprintf(probe, sizeof(probe), "mass%d:/%s", idx, suffix);
-            if (stat(probe, &path_stat) == 0) {
-                size_t len = strlen(probe) + 1;
-                char *resolved = (char *)malloc(len);
-                if (resolved != NULL) {
-                    memcpy(resolved, probe, len);
-                    argv[0] = resolved;
-                }
-                return;
-            }
-        }
-        usleep(250000);
-    }
-}
-
 static void NormalizeArgv0Path(char *path)
 {
     if (path == NULL || path[0] == '\0') {
@@ -218,6 +186,22 @@ static bool BootPathMatchesLaunchPath(const char *launch_path)
     }
 
     return strncmp(launch_path, boot_path, boot_len) == 0;
+}
+
+static const char *GetLaunchPath(int argc, char **argv)
+{
+    if (argc > 0 && argv != NULL && argv[0] != NULL && argv[0][0] != '\0') {
+        NormalizeArgv0Path(argv[0]);
+        return argv[0];
+    }
+
+    static char cwd_path[255];
+    if (getcwd(cwd_path, sizeof(cwd_path)) != NULL) {
+        NormalizeDirPath(cwd_path, sizeof(cwd_path));
+        return cwd_path;
+    }
+
+    return NULL;
 }
 
 void setLuaBootPath(int argc, char ** argv, int idx)
@@ -502,13 +486,20 @@ int main(int argc, char * argv[])
 
     LOAD_IRX_NARG(audsrv_irx);
 
-    ResolveMassLaunchPath(argc, argv);
-    setLuaBootPath (argc, argv, 0);
-    if (argc > 0 && argv[0]) {
-        setAppDirFromPath(argv[0]);
+    const char *launch_path = GetLaunchPath(argc, argv);
+    if (launch_path != NULL && (argc <= 0 || argv == NULL || argv[0] == NULL)) {
+        setAppDirFromPath(launch_path);
+        snprintf(boot_path, sizeof(boot_path), "%s", app_dir);
     } else {
-        setAppDirFromPath(boot_path);
+        setLuaBootPath(argc, argv, 0);
+        if (launch_path != NULL) {
+            setAppDirFromPath(launch_path);
+        } else {
+            setAppDirFromPath(boot_path);
+        }
     }
+    NormalizeDirPath(boot_path, sizeof(boot_path));
+    NormalizeDirPath(app_dir, sizeof(app_dir));
 
     // waitUntilDeviceIsReady by fjtrujy (root path derived from boot path when possible)
     char device_root[16];
@@ -517,22 +508,12 @@ int main(int argc, char * argv[])
         ready_root = device_root;
     }
     WaitUntilDeviceRootIsReady(ready_root, 50);
-	
-        ResolveMassLaunchPath(argc, argv);
-        if (argc > 0 && argv[0]) {
-            NormalizeArgv0Path(argv[0]);
-        }
-        setLuaBootPath (argc, argv, 0);
-        if (argc > 0 && argv[0]) {
-            setAppDirFromPath(argv[0]);
-        } else {
-            setAppDirFromPath(boot_path);
-        }
-        if (!BootPathMatchesLaunchPath((argc > 0) ? argv[0] : NULL)) {
-            DPRINTF("boot_path verification failed for argv0=%s; using app_dir fallback\n", (argc > 0 && argv[0]) ? argv[0] : "<null>");
-            snprintf(boot_path, sizeof(boot_path), "%s", app_dir);
-            NormalizeDirPath(boot_path, sizeof(boot_path));
-        }
+
+    if (!BootPathMatchesLaunchPath(launch_path)) {
+        DPRINTF("boot_path verification failed for argv0=%s; using app_dir fallback\n", launch_path ? launch_path : "<null>");
+        snprintf(boot_path, sizeof(boot_path), "%s", app_dir);
+        NormalizeDirPath(boot_path, sizeof(boot_path));
+    }
 	// Lua init
 	// init internals library
     


### PR DESCRIPTION
### Motivation
- Prevent long sleep/slot-probing loops during early boot by removing the mass0..mass9 scanning path.
- Derive the boot/app directory only from `argv[0]` (normalized) or a safe `getcwd()` fallback so early boot is deterministic and fast.
- Keep `boot_path` and `app_dir` stable after initialization while preserving existing MC/HDD/host compatibility helpers. 

### Description
- Removed `ResolveMassLaunchPath()` and its nested `mass0..mass9` probe loop and sleeps. 
- Added `GetLaunchPath()` which returns a normalized `argv[0]` when available and falls back to `getcwd()` only when `argv[0]` is not present. 
- Reworked `main()` initialization to use `GetLaunchPath()` to initialize `boot_path`/`app_dir`, to normalize them once, and to avoid repeated slot probing; retained the existing fallback that sets `boot_path = app_dir` when verification fails. 
- Kept existing helpers and behaviors intact: `NormalizeArgv0Path`, `setLuaBootPath`, and `setAppDirFromPath` are still used for compatibility; `WaitUntilDeviceRootIsReady()` now operates only on the extracted boot-device root (with `mass:/` as a fallback if extraction fails). 

### Testing
- Ran a targeted code search with `rg -n "mass%d|ResolveMassLaunchPath|usleep\(250000\)|for \(int idx = 0; idx < 10" src/main.cpp` and confirmed no matches (the probing code was removed). 
- Attempted `make all` in this environment but the build fails due to missing PS2SDK/samples include files (`/samples/Makefile.eeglobal`) so a full CI build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699906b0733c8321bf04c2cef428219e)