### PR TITLE
Scan all routed USB mass slots for USB game refresh

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -885,6 +885,51 @@ local function ParseMassGameEntry(entry)
   return prefix, relpath
 end
 
+function PLDR.NormalizeMassGameEntry(entry)
+  local prefix, relpath = ParseMassGameEntry(entry)
+  if prefix == nil or relpath == nil then
+    return nil
+  end
+  local normalized_relpath = tostring(relpath)
+  normalized_relpath = string.gsub(normalized_relpath, "\\", "/")
+  normalized_relpath = string.gsub(normalized_relpath, "^/+", "")
+  return string.lower(prefix..normalized_relpath)
+end
+
+function PLDR.SortMassGames(list)
+  if type(list) ~= "table" then
+    return {}
+  end
+  table.sort(list, function(a, b)
+    local _, mass_rel_a = ParseMassGameEntry(a)
+    local _, mass_rel_b = ParseMassGameEntry(b)
+    local sort_a = string.lower(mass_rel_a or a or "")
+    local sort_b = string.lower(mass_rel_b or b or "")
+    if sort_a == sort_b then
+      return tostring(a) < tostring(b)
+    end
+    return sort_a < sort_b
+  end)
+  return list
+end
+
+function PLDR.DedupeAndSortMassGames(list)
+  if type(list) ~= "table" then
+    return {}
+  end
+  local merged = {}
+  local seen = {}
+  for i = 1, #list do
+    local entry = list[i]
+    local key = PLDR.NormalizeMassGameEntry(entry) or tostring(entry)
+    if not seen[key] then
+      seen[key] = true
+      table.insert(merged, entry)
+    end
+  end
+  return PLDR.SortMassGames(merged)
+end
+
 function PLDR.GetPS1GameLists(path, updating)
   LOG("Listing games on ", path)
   local RET = {}
@@ -917,16 +962,7 @@ function PLDR.GetPS1GameLists(path, updating)
     if not updating then
       PLDR.GAMES = RET
     end
-    table.sort(PLDR.GAMES, function(a, b)
-      local _, mass_rel_a = ParseMassGameEntry(a)
-      local _, mass_rel_b = ParseMassGameEntry(b)
-      local sort_a = string.lower(mass_rel_a or a or "")
-      local sort_b = string.lower(mass_rel_b or b or "")
-      if sort_a == sort_b then
-        return tostring(a) < tostring(b)
-      end
-      return sort_a < sort_b
-    end)
+    PLDR.GAMES = PLDR.DedupeAndSortMassGames(PLDR.GAMES)
     return PLDR.GAMES
   else
     return nil

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2403,9 +2403,8 @@ function UI.RefreshMassDevicePage(device_kind)
 
   local slots = PLDR.EnumerateMassSlots(9) or {}
   local routed = PLDR.RouteMassSlotsForPage(device_kind, slots) or {}
-  local target = routed[1]
 
-  if target == nil then
+  if routed[1] == nil then
     if device_kind ~= "MX4SIO" then
       if PLDR.USB ~= nil then
         PLDR.USB.MASSINDX = nil
@@ -2417,13 +2416,27 @@ function UI.RefreshMassDevicePage(device_kind)
   end
 
   if PLDR.USB ~= nil then
-    PLDR.USB.MASSINDX = target.source_slot
-    PLDR.USB.ROOT = target.source_prefix
+    PLDR.USB.MASSINDX = routed[1].source_slot
+    PLDR.USB.ROOT = routed[1].source_prefix
   end
-  PLDR.GetPS1GameLists(target.source_prefix.."POPS/", true)
+
+  local found_any = false
+  for i = 1, #routed do
+    local source_prefix = routed[i] and routed[i].source_prefix
+    if type(source_prefix) == "string" and source_prefix ~= "" then
+      local list = PLDR.GetPS1GameLists(source_prefix.."POPS/", true)
+      if type(list) == "table" and #list > 0 then
+        found_any = true
+      end
+    end
+  end
+
+  if type(PLDR.DedupeAndSortMassGames) == "function" then
+    PLDR.GAMES = PLDR.DedupeAndSortMassGames(PLDR.GAMES)
+  end
 
   UI.GameList.Reset()
-  return true
+  return found_any or (#PLDR.GAMES > 0)
 end
 
 function UI.RefreshCurrentMassScene(scene)


### PR DESCRIPTION
### Motivation
- The USB game page previously scanned only the first routed `massX:/` slot which missed games on other routed USB ports, so the refresh must consume all routed USB slots to present a complete list.
- Merging results from multiple `massX:/POPS/` sources can introduce duplicate entries, so a normalization + dedupe layer is needed before finalizing `PLDR.GAMES`.
- Preserve the boot-selected/default root as `PLDR.USB.ROOT` for launch fallback while decoupling it from scan coverage to avoid changing launch policy semantics.
- TODO: verify in a real runtime/emulator that merged scanning does not regress existing fallback behavior and that `PLDR.RouteMassSlotsForPage` provides concrete `massX:/` prefixes (see `bin/POPSLDR/system.lua` and `bin/POPSLDR/ui.lua`).

### Description
- Updated `UI.RefreshMassDevicePage` in `bin/POPSLDR/ui.lua` to enumerate all routed slots from `PLDR.RouteMassSlotsForPage` and call `PLDR.GetPS1GameLists(source_prefix.."POPS/", true)` for each routed `source_prefix`, rather than using only `routed[1]` for scanning.
- Kept `PLDR.USB.MASSINDX` and `PLDR.USB.ROOT` tied to the first routed slot as the boot/default fallback, but decoupled scanning from that single slot.
- Added helpers in `bin/POPSLDR/system.lua`: `PLDR.NormalizeMassGameEntry`, `PLDR.SortMassGames`, and `PLDR.DedupeAndSortMassGames` to normalize mass entries, deduplicate merged lists keyed by normalized `massX:/<file>`, and preserve the existing case-insensitive ordering semantics.
- Wired `PLDR.GetPS1GameLists` to run the merged `PLDR.GAMES` through `PLDR.DedupeAndSortMassGames` before returning, ensuring duplicates are removed and the list is sorted.

### Testing
- Verified the diff with `git diff -- bin/POPSLDR/system.lua bin/POPSLDR/ui.lua` and inspected the modified regions using `nl -ba` and `sed` to confirm the new logic is present and the old single-slot scan was replaced.
- Committed changes with `git commit` which succeeded and produced a commit describing the change.
- Attempted runtime/syntax checks by invoking `lua`/`luajit` to `loadfile` both scripts, but both binaries are unavailable in this environment so those checks could not be executed; this is a known limitation of the current environment.
- TODO: run full CI/build (`make clean elfloader all package`) and perform runtime validation on hardware or an emulator (e.g., PCSX2) to confirm multi-slot scanning and launch fallbacks behave as expected (see `bin/POPSLDR/system.lua` and `bin/POPSLDR/ui.lua`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990c3dd4b08321bab50c3498974a01)