### PR TITLE
Refactor mass slot enumeration to cache-backed API

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -231,6 +231,12 @@ PLDR = {
   }
 }
 
+PLDR.MASS_ENUM = {
+  cache = nil,
+  stamp = 0,
+  dirty = true
+}
+
 -- Mass backend detection via USBMASS_IOCTL_GET_DRIVERNAME (requires fileXio + ps2sdk usbhdfsd-common.h support).
 -- Returns a short driver code like: "usb" (USB), "sdc" (MX4SIO SD), "udp" (UDPBD), "sd" (iLink SD), "ata" (HDD).
 function PLDR.GetMassDriverName(index)
@@ -279,7 +285,7 @@ function PLDR.EnumerateMassSlots(max_index)
     if driver == "usb" then
       kind = "USB"
       present = true
-    elseif driver == "sdc" then
+    elseif driver == "sdc" or driver == "mx4sio" then
       kind = "MX4SIO"
       present = true
     elseif type(driver) == "string" and driver ~= "" then
@@ -299,6 +305,47 @@ function PLDR.EnumerateMassSlots(max_index)
   return slots
 end
 
+function PLDR.RefreshMassSlots(reason)
+  local state = PLDR.MASS_ENUM
+  if type(state) ~= "table" then
+    state = { cache = nil, stamp = 0, dirty = true }
+    PLDR.MASS_ENUM = state
+  end
+
+  local slots = PLDR.EnumerateMassSlots(9) or {}
+  state.cache = slots
+  state.stamp = (state.stamp or 0) + 1
+  state.dirty = false
+  if reason ~= nil then
+    LOG("Mass slot cache refreshed:", tostring(reason), "stamp:", tostring(state.stamp))
+  end
+  return slots
+end
+
+function PLDR.GetMassSlotsCached()
+  local state = PLDR.MASS_ENUM
+  if type(state) ~= "table" then
+    PLDR.MASS_ENUM = { cache = nil, stamp = 0, dirty = true }
+    state = PLDR.MASS_ENUM
+  end
+  if state.dirty or type(state.cache) ~= "table" then
+    return PLDR.RefreshMassSlots("auto")
+  end
+  return state.cache
+end
+
+function PLDR.MarkMassSlotsDirty(reason)
+  local state = PLDR.MASS_ENUM
+  if type(state) ~= "table" then
+    PLDR.MASS_ENUM = { cache = nil, stamp = 0, dirty = true }
+    state = PLDR.MASS_ENUM
+  end
+  state.dirty = true
+  if reason ~= nil then
+    LOG("Mass slot cache marked dirty:", tostring(reason))
+  end
+end
+
 -- Route classified mass slots to a specific device page.
 -- Only USB/MX4SIO are eligible targets; UNKNOWN/OTHER and all non-target kinds are dropped.
 function PLDR.RouteMassSlotsForPage(device_page, classified_slots)
@@ -314,7 +361,7 @@ function PLDR.RouteMassSlotsForPage(device_page, classified_slots)
 
   local slots = classified_slots
   if type(slots) ~= "table" then
-    slots = PLDR.EnumerateMassSlots(9) or {}
+    slots = PLDR.GetMassSlotsCached() or {}
   end
 
   local routed = {}

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2348,6 +2348,14 @@ function UI.RefreshMassDevicePage(device_kind)
     return false
   end
 
+  if device_kind == "USB" and type(PLDR.RefreshMassSlots) == "function" then
+    local state = PLDR.MASS_ENUM
+    if type(state) == "table" and not state.usb_init_refresh_done then
+      PLDR.RefreshMassSlots("usb-stack-init")
+      state.usb_init_refresh_done = true
+    end
+  end
+
   PLDR.CleanupGameList()
 
   if device_kind == "MX4SIO" then
@@ -2401,7 +2409,12 @@ function UI.RefreshMassDevicePage(device_kind)
     return false
   end
 
-  local slots = PLDR.EnumerateMassSlots(9) or {}
+  local slots = nil
+  if type(PLDR.GetMassSlotsCached) == "function" then
+    slots = PLDR.GetMassSlotsCached() or {}
+  else
+    slots = PLDR.EnumerateMassSlots(9) or {}
+  end
   local routed = PLDR.RouteMassSlotsForPage(device_kind, slots) or {}
 
   if routed[1] == nil then
@@ -2450,7 +2463,15 @@ function UI.RefreshCurrentMassScene(scene)
   return false
 end
 function UI.OnSceneEnter(previous_scene, next_scene)
-  if UI.IsUsbScene(next_scene) or UI.IsMx4sioScene(next_scene) then
+  if UI.IsUsbScene(next_scene) then
+    if PLDR ~= nil and type(PLDR.RefreshMassSlots) == "function" then
+      PLDR.RefreshMassSlots("scene-enter-usb")
+    end
+    UI.RefreshCurrentMassScene(next_scene)
+  elseif UI.IsMx4sioScene(next_scene) then
+    if PLDR ~= nil and type(PLDR.RefreshMassSlots) == "function" then
+      PLDR.RefreshMassSlots("scene-enter-mx4sio")
+    end
     UI.RefreshCurrentMassScene(next_scene)
   end
 end


### PR DESCRIPTION
### Motivation
- Reduce expensive or repeated mass-driver queries by caching mass-slot classification and refresh only at safe points in the UI flow.
- Provide a single source-of-truth for mass slot state to avoid duplicated logic and make future invalidation hooks simple and explicit.

### Description
- Added cache state `PLDR.MASS_ENUM = { cache=nil, stamp=0, dirty=true }` and helpers `PLDR.RefreshMassSlots(reason)`, `PLDR.GetMassSlotsCached()`, and `PLDR.MarkMassSlotsDirty(reason)` in `bin/POPSLDR/system.lua` to compute and serve cached slot lists.
- Kept existing driver→kind classification and extended it to treat both `sdc` and `mx4sio` driver names as `MX4SIO` (previously only `sdc`) in `PLDR.EnumerateMassSlots`.
- Updated `PLDR.RouteMassSlotsForPage` to use `PLDR.GetMassSlotsCached()` when no pre-classified table is provided, avoiding per-call enumeration.
- Wired safe refresh triggers in `bin/POPSLDR/ui.lua` to call `PLDR.RefreshMassSlots` only on USB page enter, MX4SIO page enter, and a guarded one-time post-USB-stack-init path, and switched `UI.RefreshMassDevicePage` to consume the cached slots.

### Testing
- Performed static validation with repository queries and diffs (grep/rg and `git diff`) to confirm the new symbols and call sites were added and wired; these checks succeeded.
- Attempted to run a Lua parse/loadcheck (`lua -e 'assert(loadfile(...)'`) but the environment lacks the `lua` binary so runtime load checks could not be executed and are TODO: verify in CI or a host with Lua available.
- Committed the changes with message `Refactor mass slot enumeration to cache-backed API` and generated PR metadata; no automated unit tests exist for this area and no new tests were added in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990d3414288321a3259aa5e4fc3061)