### PR TITLE
Gate MX4SIO init behind strict boot/enumerator preconditions

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -231,6 +231,8 @@ PLDR = {
   }
 }
 
+PLDR.BOOT_DEVICE_KIND = nil
+
 PLDR.MASS_ENUM = {
   cache = nil,
   stamp = 0,
@@ -332,6 +334,26 @@ function PLDR.GetMassSlotsCached()
     return PLDR.RefreshMassSlots("auto")
   end
   return state.cache
+end
+
+function PLDR.HasClassifiedMassSlot(kind, classified_slots)
+  if type(kind) ~= "string" or kind == "" then
+    return false
+  end
+
+  local slots = classified_slots
+  if type(slots) ~= "table" then
+    slots = PLDR.GetMassSlotsCached() or {}
+  end
+
+  for i = 1, #slots do
+    local slot = slots[i]
+    if slot ~= nil and slot.kind == kind and slot.present == true then
+      return true
+    end
+  end
+
+  return false
 end
 
 function PLDR.MarkMassSlotsDirty(reason)
@@ -625,6 +647,7 @@ UI.LASTSCENE = UI.SCENES.MMAIN
 
 if UI.DEVLOCK ~= nil then
   local boot_name, boot_path, boot_prefix = DetectBootDevice()
+  PLDR.BOOT_DEVICE_KIND = boot_name
   UI.boot_device = UI.DEVLOCK.NONE
   UI.boot_locks = {}
   if boot_name == "MX4SIO" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2365,6 +2365,23 @@ function UI.RefreshMassDevicePage(device_kind)
       return true
     end
 
+    local boot_is_mx4sio = (PLDR ~= nil and PLDR.BOOT_DEVICE_KIND == "MX4SIO")
+    local scene_is_mx4sio = UI.IsMx4sioScene(UI.CURSCENE)
+    local enum_has_mx4sio = false
+    if PLDR ~= nil and type(PLDR.HasClassifiedMassSlot) == "function" then
+      enum_has_mx4sio = PLDR.HasClassifiedMassSlot("MX4SIO")
+    end
+
+    if not boot_is_mx4sio and not (scene_is_mx4sio and enum_has_mx4sio) then
+      if PLDR.MX4SIO ~= nil then
+        PLDR.MX4SIO.READY = false
+        PLDR.MX4SIO.MASSINDX = nil
+        PLDR.MX4SIO.ROOT = nil
+      end
+      UI.Notif_queue.add("MX4SIO not detected (searched mass0..mass9)")
+      return false
+    end
+
     local hint = nil
     if PLDR.MX4SIO ~= nil then
       hint = PLDR.MX4SIO.PREFIX_HINT


### PR DESCRIPTION
### Motivation

- Prevent spurious attempts to initialize MX4SIO when the boot origin and enumerator do not indicate an MX4SIO device, and avoid promoting `UNKNOWN/OTHER` slots to MX4SIO.
- Reuse the cached mass-slot enumerator result to make a deterministic, low-cost precondition check before calling `System.initMX4SIO`.

### Description

- Add `PLDR.BOOT_DEVICE_KIND` and populate it from `DetectBootDevice()` during startup so boot-origin is available to later logic (`bin/POPSLDR/system.lua`).
- Implement `PLDR.HasClassifiedMassSlot(kind, classified_slots)` which inspects the cached mass-slot classification and returns true only for exact `slot.kind` matches with `present == true` (`bin/POPSLDR/system.lua`).
- In `UI.RefreshMassDevicePage("MX4SIO")` gate the call to `System.initMX4SIO` so it runs only when the boot device kind is `MX4SIO` or when entering the MX4SIO scene and the cached enumerator reports at least one `kind == "MX4SIO"` slot; otherwise skip init and surface the existing "MX4SIO not detected (searched mass0..mass9)" handling (`bin/POPSLDR/ui.lua`).
- Ensure `UNKNOWN/OTHER` is not treated as MX4SIO by using exact-kind checks and cached enumeration, and keep existing error messages/cleanup paths intact.

### Testing

- Verified the edited files contain the expected additions by inspecting the updated source (`nl`/`sed` file excerpts were reviewed). 
- Attempted Lua syntax checks with `luac -p bin/POPSLDR/system.lua && luac -p bin/POPSLDR/ui.lua`, but `luac` is not available in this environment so the check could not be completed.
- Attempted to run a load-time check with `lua -e 'assert(loadfile("bin/POPSLDR/system.lua")); assert(loadfile("bin/POPSLDR/ui.lua"))'`, but `lua` is not installed here so the runtime validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990e35311c8321abc4965f220c8545)