### PR TITLE
Fix Graphics Lua contract: textures are lightuserdata, not integers

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -42,23 +42,12 @@ jobs:
         run: |
           make clean elfloader all package
 
-      - name: Locate and normalize APP_POPSLOADER.zip
+      - name: Verify APP_POPSLOADER.zip exists
         shell: sh
         run: |
           set -eu
-
-          echo "== Workspace contents (top-level) =="
-          ls -lah
-
-          EXACT="$(find . -maxdepth 6 -type f -name 'APP_POPSLOADER.zip' -print | head -n 1 || true)"
-          if [ -z "$EXACT" ]; then
-            echo "ERROR: APP_POPSLOADER.zip not found after build."
-            exit 1
-          fi
-
-          cp -f "$EXACT" "./APP_POPSLOADER.zip"
-          echo "== Final normalized artifact =="
-          ls -lah "./APP_POPSLOADER.zip"
+          test -f APP_POPSLOADER.zip
+          ls -lh APP_POPSLOADER.zip
 
       - name: Upload artifact (no release)
         if: ${{ success() }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -42,9 +42,7 @@ jobs:
         run: |
           make clean elfloader all package
 
-      # This step is the key: it discovers wherever your Makefile put the .7z,
-      # then copies it to repo root as POPSLoader.7z so upload-artifact is stable.
-      - name: Locate and normalize POPSLoader.7z
+      - name: Locate and normalize APP_POPSLOADER.zip
         shell: sh
         run: |
           set -eu
@@ -52,38 +50,21 @@ jobs:
           echo "== Workspace contents (top-level) =="
           ls -lah
 
-          echo "== Searching for .7z artifacts (up to 6 levels deep) =="
-          # Show all matches for debugging
-          find . -maxdepth 6 -type f -name '*.7z' -print || true
-
-          # Prefer an exact name match first (any location)
-          EXACT="$(find . -maxdepth 6 -type f -name 'POPSLoader.7z' -print | head -n 1 || true)"
-
-          if [ -n "$EXACT" ]; then
-            echo "Found exact artifact: $EXACT"
-            cp -f "$EXACT" "./POPSLoader.7z"
-          else
-            # Otherwise pick the newest .7z produced (common when Makefile names differ)
-            NEWEST="$(find . -maxdepth 6 -type f -name '*.7z' -print -exec ls -t {} + 2>/dev/null | head -n 1 || true)"
-
-            if [ -z "$NEWEST" ]; then
-              echo "ERROR: No .7z artifact found after build."
-              echo "Hint: your Makefile 'package' target may be outputting a different extension or skipping packaging."
-              exit 1
-            fi
-
-            echo "No exact POPSLoader.7z found. Using newest .7z: $NEWEST"
-            cp -f "$NEWEST" "./POPSLoader.7z"
+          EXACT="$(find . -maxdepth 6 -type f -name 'APP_POPSLOADER.zip' -print | head -n 1 || true)"
+          if [ -z "$EXACT" ]; then
+            echo "ERROR: APP_POPSLOADER.zip not found after build."
+            exit 1
           fi
 
+          cp -f "$EXACT" "./APP_POPSLOADER.zip"
           echo "== Final normalized artifact =="
-          ls -lah "./POPSLoader.7z"
+          ls -lah "./APP_POPSLOADER.zip"
 
       - name: Upload artifact (no release)
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: POPSLoader
-          path: POPSLoader.7z
+          name: APP_POPSLOADER
+          path: APP_POPSLOADER.zip
           if-no-files-found: error
           compression-level: 0

--- a/Makefile
+++ b/Makefile
@@ -229,19 +229,15 @@ run:
 reset:
 	ps2client -h $(PS2LINK_IP) reset   
 
-POPSLDR_PKG = POPSLoader.7z
-PKG_DIR = bin/package
+POPSLDR_PKG = APP_POPSLOADER.zip
+PKG_DIR = dist
+PKG_APP_DIR = $(PKG_DIR)/APP_POPSLOADER
 package: $(EE_BIN_PKD)
 	rm -f $(POPSLDR_PKG)
 	rm -rf $(PKG_DIR)
-	mkdir -p $(PKG_DIR)
-	cp $(EE_BIN_PKD) $(PKG_DIR)/
-	cp bin/changelog LICENSE README.md $(PKG_DIR)/
-	find bin/POPSLDR -maxdepth 1 -type f -exec cp {} $(PKG_DIR)/ \;
-	@if [ -d bin/POPSTARTER ]; then cp -r bin/POPSTARTER $(PKG_DIR)/; fi
-	@if ls bin/POPSLDR/IMG/*.png >/dev/null 2>&1; then cp bin/POPSLDR/IMG/*.png $(PKG_DIR)/; fi
-	@if ls bin/POPSLDR/IRX/*.irx >/dev/null 2>&1; then cp bin/POPSLDR/IRX/*.irx $(PKG_DIR)/; fi
-	cd $(PKG_DIR); 7z a ../$(POPSLDR_PKG) .
+	mkdir -p $(PKG_APP_DIR)
+	cp $(EE_BIN_PKD) $(PKG_APP_DIR)/POPSLOADER.ELF
+	cd $(PKG_DIR); 7z a -tzip ../$(POPSLDR_PKG) APP_POPSLOADER
 
 dummys:
 	touch $(BINDIR)A.vcd

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ EE_INCS += -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports
 EE_INCS += -Imodules/ds34bt/ee -Imodules/ds34usb/ee
 
 EE_CFLAGS   += -Wno-sign-compare -fno-strict-aliasing -fno-exceptions -DLUA_USE_PS2
-EE_CXXFLAGS += -Wno-sign-compare -fno-strict-aliasing -fno-exceptions -DLUA_USE_PS2
+EE_CXXFLAGS += -Wno-sign-compare -fno-strict-aliasing -fno-exceptions -DLUA_USE_PS2 -DPOPSLOADER_DIAG=1
 EE_ASFLAGS += -call_shared
 ifeq ($(RESET_IOP),1)
 EE_CXXFLAGS += -DRESET_IOP

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -12,9 +12,6 @@ local function ResolveImage(name)
   return System.resolveAssetType(name, ASSET_IMG) or System.resolveAsset(logical) or logical
 end
 
-local function IsBootBgKey(key)
-  return key == "BG" or key == "BGM" or key == "BKG" or key == "PSL"
-end
 --- Add your images to this table, just write the name of the file.
 --- Flat layout places images beside POPSLOADER.ELF; legacy installs can still use POPSLDR/IMG/*
 --- FILES MUST HAVE EXTENSION. filename is parsed to create the access key: USB.PNG will be accesed by typing `IMG["USB"]`
@@ -71,10 +68,6 @@ IMG = setmetatable({}, {
     end
     local path = ResolveImage(source)
     local img = Graphics.loadImage(path)
-    if IsBootBgKey(key) then
-      LOGF("IMGLOAD: key=IMG/%s handle=%s", tostring(source), tostring(img))
-      LOGF("IMGTYPE key=%s type=%s", tostring(key), type(img))
-    end
     if img == nil then
       LOGF("Image load failed: %s", path)
       IMG_FAILED[key] = true

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -744,18 +744,20 @@ if UI.DEVLOCK ~= nil then
   PLDR.BOOT_DEVICE_KIND = boot_name
   UI.boot_device = UI.DEVLOCK.NONE
   UI.boot_locks = {}
+  UI.BOOT_STATE = UI.BOOT_STATE or {}
+  UI.BOOT_STATE.detected = false
+  UI.BOOT_STATE.finalized = false
   if boot_name == "MX4SIO" then
     UI.boot_device = UI.DEVLOCK.MX4SIO
+    UI.BOOT_STATE.detected = true
   elseif boot_name == "USB" then
     UI.boot_device = UI.DEVLOCK.USB
+    UI.BOOT_STATE.detected = true
   elseif boot_name == "MMCE" then
     UI.boot_device = UI.DEVLOCK.MMCE
+    UI.BOOT_STATE.detected = true
   end
-  if boot_name ~= nil then
-    LOG("Boot device detected:", boot_name, "prefix:", tostring(boot_prefix), "path:", tostring(boot_path))
-  else
-    LOG("Boot device detection ambiguous; no boot locks set.", "prefix:", tostring(boot_prefix), "path:", tostring(boot_path))
-  end
+  UI.BOOT_STATE.finalized = true
 end
 local POPSTARTER_PACK_ROOT = "mc0:/POPSTARTER"
 local POPSTARTER_PACK_FILES = {

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -82,9 +82,9 @@ local function ResolveAsset(rel)
   return System.resolveAsset(rel) or JoinPath(APP_DIR_LOCAL, rel)
 end
 
-local SETTINGS_ROOT = NormalizeDirPath((System and System.getSettingsRoot and System.getSettingsRoot()) or "mc0:/POPSTARTER/")
+local SETTINGS_ROOT = NormalizeDirPath((System and System.getSettingsRoot and System.getSettingsRoot()) or "mc0:/POPSLOADER/")
 if SETTINGS_ROOT == nil or SETTINGS_ROOT == "" then
-  SETTINGS_ROOT = "mc0:/POPSTARTER/"
+  SETTINGS_ROOT = "mc0:/POPSLOADER/"
 end
 if not doesFolderExist(SETTINGS_ROOT) then
   pcall(System.createDirectory, SETTINGS_ROOT)
@@ -456,7 +456,9 @@ local function LoadSettingsTable(path)
 end
 
 function PLDR.LoadSettings()
-  local path = ResolveWritablePath("settings.lua")
+  local root = (System and System.getSettingsRoot and System.getSettingsRoot()) or SETTINGS_ROOT
+  if root == nil or root == "" then return end
+  local path = NormalizeDirPath(root) .. "settings.lua"
   local data = LoadSettingsTable(path)
   if type(data) == "table" then
     local mode = tonumber(data.bdma_mode)
@@ -507,8 +509,17 @@ function System.GetPOPStarterElfPath()
 end
 
 function PLDR.SaveSettings()
-  local path = ResolveWritablePath("settings.lua")
+  local root = (System and System.getSettingsRoot and System.getSettingsRoot()) or SETTINGS_ROOT
+  if root == nil or root == "" then
+    return false, "cannot open settings root"
+  end
+  root = NormalizeDirPath(root)
+  pcall(System.createDirectory, root)
+  local path = root .. "settings.lua"
   local fd = System.openFile(path, FCREATE)
+  if fd == nil or fd < 0 then
+    return false, "cannot open " .. path
+  end
   local mode = tonumber(PLDR.SETTINGS.bdma_mode) or 1
   local hide_ui = PLDR.SETTINGS.hide_ui == true
   local show_cover = PLDR.SETTINGS.show_cover ~= false
@@ -527,6 +538,7 @@ function PLDR.SaveSettings()
     .."}\n"
   System.writeFile(fd, line, #line)
   System.closeFile(fd)
+  return true
 end
 
 function PLDR.GetBDMAModeCount()
@@ -557,7 +569,8 @@ function PLDR.GetBDMAMode()
 end
 
 function PLDR.GetBDMADetectedLabel()
-  if not doesFolderExist("mc0:/POPSTARTER/") then
+  local settings_root = (System and System.getSettingsRoot and System.getSettingsRoot()) or SETTINGS_ROOT
+  if settings_root == nil or not doesFolderExist(settings_root) then
     return "NONE"
   end
   if type(PLDR.SETTINGS.bdma_last_label) == "string" and PLDR.SETTINGS.bdma_last_label ~= "" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -44,11 +44,14 @@ local function GetDeviceIconKey(mode)
   return mode
 end
 
+local _BG_PROBE_ENABLED = false
+
 local function DrawFullScreen(tex, alpha)
   if tex == nil then return false end
   local a = alpha or 128
   if a < 0 then a = 0 end
   if a > 128 then a = 128 end
+  if _BG_PROBE_ENABLED then a = 128 end
   Graphics.drawScaleImage(tex, 0, 0, UI.SCR.X, UI.SCR.Y, Color.new(128, 128, 128, a))
   return true
 end
@@ -825,7 +828,7 @@ UI = {
           Screen.clear(UI.SCR.BGCOL)
           local bg = nil
           if scene == UI.SCENES.MMAIN then
-            bg = IMG.BGM or IMG.BKG
+            bg = IMG.BG or IMG.BGM or IMG.BKG
           elseif scene == UI.SCENES.MPROFILE or scene == UI.SCENES.CREDITS then
             bg = IMG.BG or IMG.BKG
           else
@@ -1096,7 +1099,7 @@ end
 	        Screen.clear(UI.SCR.BGCOL)
         local bg = nil
         if UI.CURSCENE == UI.SCENES.MMAIN then
-          bg = IMG.BGM or IMG.BKG
+          bg = IMG.BG or IMG.BGM or IMG.BKG
         elseif UI.CURSCENE == UI.SCENES.MPROFILE or UI.CURSCENE == UI.SCENES.CREDITS then
           bg = IMG.BG or IMG.BKG
         else
@@ -1105,9 +1108,12 @@ end
         if bg ~= nil then
           local alpha = 128
           DrawFullScreen(bg, alpha)
+          if _BG_PROBE_ENABLED and IMG.triangle ~= nil then
+            Graphics.drawImage(IMG.triangle, 10, 10, UI.CCOL.GREY)
+          end
           if UI._BG_LOG_SCENE ~= UI.CURSCENE then
             UI._BG_LOG_SCENE = UI.CURSCENE
-            LOG(string.format("BG_DRAW scene=%s handle=%s alpha=%d", tostring(UI.CURSCENE), tostring(bg), alpha))
+            LOG(string.format("BG_STATE key=%s bgTex=%s alpha=%d overlayAlpha=%d", tostring(UI.CURSCENE), tostring(bg), alpha, 0))
           end
         end
       end;
@@ -1962,10 +1968,13 @@ end
           return value
         end
         local function ResolveIcon(mode, key)
+          if mode ~= "USB" and key == "USB" then
+            LogOnce("ICON_REVERT:"..tostring(mode), string.format("ICON_REVERT mode=%s path=ResolveIcon", tostring(mode)))
+          end
           local icon = IMG[key]
           if icon ~= nil then return icon end
-          LogOnce("ICONFALLBACK:"..tostring(mode), string.format("ICONFALLBACK mode=%s missing IMG/%s.png -> IMG/USB.png", tostring(mode), tostring(key)))
-          return IMG.USB or IMG["MISSING"]
+          LogOnce("ICONFALLBACK:"..tostring(mode), string.format("ICONFALLBACK mode=%s missing IMG/%s.png -> IMG/MISSING.png", tostring(mode), tostring(key)))
+          return IMG["MISSING"]
         end
         if not UI.MainMenu.icons_ready then
           for i, key in ipairs(icon_keys) do

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1843,6 +1843,15 @@ end
         end
       end;
     };
+    ResolveDeviceIcon = function (mode)
+      local key = GetDeviceIconKey(mode)
+      local tex = IMG[key]
+      if tex ~= nil then
+        return key, tex
+      end
+      LogOnce("ICONFALLBACK:"..tostring(mode), string.format("ICONFALLBACK mode=%s missing IMG/%s.png -> IMG/MISSING.png", tostring(mode), tostring(key)))
+      return "MISSING", IMG["MISSING"]
+    end;
     MainMenu = {
       OPT = 1;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
@@ -1967,24 +1976,22 @@ end
           if value > max_val then return max_val end
           return value
         end
-        local function ResolveIcon(mode, key)
+        local function ResolveIcon(mode)
+          local key, tex = UI.ResolveDeviceIcon(mode)
           if mode ~= "USB" and key == "USB" then
             LogOnce("ICON_REVERT:"..tostring(mode), string.format("ICON_REVERT mode=%s path=ResolveIcon", tostring(mode)))
           end
-          local icon = IMG[key]
-          if icon ~= nil then return icon end
-          LogOnce("ICONFALLBACK:"..tostring(mode), string.format("ICONFALLBACK mode=%s missing IMG/%s.png -> IMG/MISSING.png", tostring(mode), tostring(key)))
-          return IMG["MISSING"]
+          return key, tex
         end
         if not UI.MainMenu.icons_ready then
-          for i, key in ipairs(icon_keys) do
-            ResolveIcon(icon_modes[i] or key, key)
+          for i, mode in ipairs(icon_modes) do
+            ResolveIcon(mode)
           end
           UI.MainMenu.icons_ready = true
         end
         local function DrawIcon(index, x, y, color)
-          local key = icon_keys[index]
-          local icon = ResolveIcon(icon_modes[index] or key, key)
+          local mode = icon_modes[index] or icon_keys[index]
+          local _, icon = ResolveIcon(mode)
           if icon == nil then return end
           local icon_w = Graphics.getImageWidth(icon)
           local icon_h = Graphics.getImageHeight(icon)
@@ -1992,7 +1999,7 @@ end
           local pos_y = Round(y - (icon_h / 2))
           Graphics.drawImage(icon, pos_x, pos_y, color)
         end
-        local first_icon = ResolveIcon(icon_modes[1] or "MISSING", icon_keys[1] or "MISSING")
+        local _, first_icon = ResolveIcon(icon_modes[1] or "MISSING")
         local base_icon_w = 0
         if first_icon ~= nil then
           base_icon_w = Graphics.getImageWidth(first_icon)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -340,6 +340,7 @@ UI = {
     device_lock = DEVLOCK.NONE;
     boot_device = DEVLOCK.NONE;
     boot_locks = {};
+    BOOT_STATE = { detected = false, finalized = false };
     BOOT_SOUND = {
       ENABLED = true,
       PATH = "boot.adp",      -- relative to CWD (same folder as ui.lua on HostFS)
@@ -820,6 +821,10 @@ UI = {
     end;
     WelcomeDraw = {
       Play = function (next_scene)
+        UI.WelcomeDraw._state = UI.WelcomeDraw._state or { finished = false }
+        if UI.WelcomeDraw._state.finished then
+          return
+        end
 	        -- Boot splash fades in from black, then fades out into the next scene.
 	        local function DrawBackground()
 	          Screen.clear(Color.new(0, 0, 0))
@@ -1085,6 +1090,8 @@ end
         end
         DrawTargetScene(final_scene)
         Screen.flip()
+
+        UI.WelcomeDraw._state.finished = true
 
         -- Cleanup boot sound resource (safe if audio backend ignores it).
         if boot_sound_loaded ~= nil and type(Sound) == "table" and type(Sound.freeADPCM) == "function" then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -26,6 +26,32 @@ local function Clamp(v, lo, hi)
   if v > hi then return hi end
   return v
 end
+local _LOG_ONCE = {}
+local function LogOnce(tag, msg)
+  if _LOG_ONCE[tag] then return end
+  _LOG_ONCE[tag] = true
+  LOG(msg)
+end
+
+local function GetDeviceIconKey(mode)
+  if mode == "USB" then return "USB" end
+  if mode == "MMCE" then return "MMCE" end
+  if mode == "MX4SIO" then return "MX4SIO" end
+  if mode == "HDD (PFS)" or mode == "HDD" then return "APAHDD" end
+  if mode == "HDD (exFAT)" then return "BDHDD" end
+  if mode == "SMB (v1)" then return "SMB" end
+  if mode == "Disc (DKWDRV)" then return "DISC" end
+  return mode
+end
+
+local function DrawFullScreen(tex, alpha)
+  if tex == nil then return false end
+  local a = alpha or 128
+  if a < 0 then a = 0 end
+  if a > 128 then a = 128 end
+  Graphics.drawScaleImage(tex, 0, 0, UI.SCR.X, UI.SCR.Y, Color.new(128, 128, 128, a))
+  return true
+end
 local function EaseInOutCubic(t)
   t = Clamp01(t)
   if t < 0.5 then
@@ -604,7 +630,10 @@ UI = {
           if icon ~= nil then
             local w = Graphics.getImageWidth(icon)
             local h = Graphics.getImageHeight(icon)
-            Graphics.drawImage(icon, x - (w / 2), y - (h / 2), UI.CCOL.GREY)
+            local scale = 0.70
+            local draw_w = Round(w * scale)
+            local draw_h = Round(h * scale)
+            Graphics.drawScaleImage(icon, x - (draw_w / 2), y - (draw_h / 2), draw_w, draw_h, UI.CCOL.GREY)
           end
           local label = labels and labels[key] or nil
           if label ~= nil then
@@ -803,7 +832,7 @@ UI = {
             bg = IMG.BKG
           end
           if bg ~= nil then
-            Graphics.drawScaleImage(bg, 0, 0, UI.SCR.X, UI.SCR.Y, Color.new(128, 128, 128, 128))
+            DrawFullScreen(bg, 128)
           end
         end
         local function DrawTargetScene(scene)
@@ -965,7 +994,8 @@ end
 local function DrawSplash(alpha)
   -- Standard splash: single logical asset IMG/PSL.png, non-fatal fallback to solid color.
   if IMG.PSL ~= nil then
-    DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, alpha)
+    DrawFullScreen(IMG.PSL, alpha)
+    LogOnce("SPLASH_DRAW", string.format("SPLASH_DRAW key=IMG/PSL.png handle=%s alpha=%d", tostring(IMG.PSL), alpha or 128))
     return
   end
   Screen.clear(Color.new(0, 0, 0))
@@ -1074,11 +1104,10 @@ end
         end
         if bg ~= nil then
           local alpha = 128
-          Graphics.drawScaleImage(bg, 0, 0, UI.SCR.X, UI.SCR.Y, Color.new(128, 128, 128, alpha))
-          UI._BG_LOG_FRAMES = (UI._BG_LOG_FRAMES or 0) + 1
-          if (UI._BG_LOG_FRAMES % 60) == 0 then
-            LOGF("DRAWBG handle=%s alpha=%s", tostring(bg), tostring(alpha))
-            LOGF("DRAWTYPE type=%s", type(bg))
+          DrawFullScreen(bg, alpha)
+          if UI._BG_LOG_SCENE ~= UI.CURSCENE then
+            UI._BG_LOG_SCENE = UI.CURSCENE
+            LOG(string.format("BG_DRAW scene=%s handle=%s alpha=%d", tostring(UI.CURSCENE), tostring(bg), alpha))
           end
         end
       end;
@@ -1872,20 +1901,12 @@ end
           Font.ftPrint(UI.FONT.STATUS, UI.SCR.X_MID, status_y, 8, UI.SCR.X, 16, "ACTIVE BDMA: "..ResolveActiveBDMALabel(), UI.COLORS.TEXT_PRIMARY)
         end
 	        -- Pages are no longer presented as "locked" in the UI.
-        local icon_map = {
-          ["MMCE"] = "MMCE",
-          ["MX4SIO"] = "MX4SIO",
-          ["HDD (exFAT)"] = "BDHDD",
-          ["HDD (PFS)"] = "APAHDD",
-          ["USB"] = "USB",
-          ["SMB (v1)"] = "SMB",
-          ["Disc (DKWDRV)"] = "DISC"
-        }
         local icon_keys = {}
+        local icon_modes = {}
         for x = 1, #UI.MainMenu.opts do
           local opt = UI.MainMenu.opts[x]
-          local key = icon_map[opt] or opt
-          icon_keys[x] = key
+          icon_modes[x] = opt
+          icon_keys[x] = GetDeviceIconKey(opt)
         end
         local function WrapIndex(index, count)
           return ((index - 1) % count) + 1
@@ -1940,18 +1961,21 @@ end
           if value > max_val then return max_val end
           return value
         end
-        local function ResolveIcon(key)
-          return IMG[key] or IMG["MISSING"]
+        local function ResolveIcon(mode, key)
+          local icon = IMG[key]
+          if icon ~= nil then return icon end
+          LogOnce("ICONFALLBACK:"..tostring(mode), string.format("ICONFALLBACK mode=%s missing IMG/%s.png -> IMG/USB.png", tostring(mode), tostring(key)))
+          return IMG.USB or IMG["MISSING"]
         end
         if not UI.MainMenu.icons_ready then
-          for _, key in ipairs(icon_keys) do
-            ResolveIcon(key)
+          for i, key in ipairs(icon_keys) do
+            ResolveIcon(icon_modes[i] or key, key)
           end
           UI.MainMenu.icons_ready = true
         end
         local function DrawIcon(index, x, y, color)
           local key = icon_keys[index]
-          local icon = ResolveIcon(key)
+          local icon = ResolveIcon(icon_modes[index] or key, key)
           if icon == nil then return end
           local icon_w = Graphics.getImageWidth(icon)
           local icon_h = Graphics.getImageHeight(icon)
@@ -1959,7 +1983,7 @@ end
           local pos_y = Round(y - (icon_h / 2))
           Graphics.drawImage(icon, pos_x, pos_y, color)
         end
-        local first_icon = ResolveIcon(icon_keys[1] or "MISSING")
+        local first_icon = ResolveIcon(icon_modes[1] or "MISSING", icon_keys[1] or "MISSING")
         local base_icon_w = 0
         if first_icon ~= nil then
           base_icon_w = Graphics.getImageWidth(first_icon)

--- a/src/assets.cpp
+++ b/src/assets.cpp
@@ -156,13 +156,13 @@ void Asset_FreeIfNeeded(const void* ptr, bool isEmbedded) {
     if (!isEmbedded && ptr) free((void*)ptr);
 }
 
-static char g_settings_root[255] = "mc0:/POPSTARTER/";
+static char g_settings_root[255] = "mc0:/POPSLOADER/";
 
 void Asset_InitSettingsRoot(const char* bootPath) {
     struct stat st;
-    mkdir("mc0:/POPSTARTER", 0777);
-    if (stat("mc0:/POPSTARTER/", &st) == 0) {
-        snprintf(g_settings_root, sizeof(g_settings_root), "mc0:/POPSTARTER/");
+    mkdir("mc0:/POPSLOADER", 0777);
+    if (stat("mc0:/POPSLOADER/", &st) == 0) {
+        snprintf(g_settings_root, sizeof(g_settings_root), "mc0:/POPSLOADER/");
         return;
     }
     char root[64] = {0};
@@ -174,8 +174,8 @@ void Asset_InitSettingsRoot(const char* bootPath) {
                 memcpy(root, bootPath, n);
                 root[n] = '/';
                 root[n+1] = 0;
-                snprintf(g_settings_root, sizeof(g_settings_root), "%sPOPSTARTER/", root);
-                char mk[255]; snprintf(mk, sizeof(mk), "%sPOPSTARTER", root);
+                snprintf(g_settings_root, sizeof(g_settings_root), "%sPOPSLOADER/", root);
+                char mk[255]; snprintf(mk, sizeof(mk), "%sPOPSLOADER", root);
                 mkdir(mk, 0777);
             }
         }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -15,6 +15,7 @@
 
 #define DEG2RAD(x) ((x)*0.01745329251)
 
+
 static const u64 BLACK_RGBAQ   = GS_SETREG_RGBAQ(0x00,0x00,0x00,0x80,0x00);
 static const u64 TEXTURE_RGBAQ = GS_SETREG_RGBAQ(0x80,0x80,0x80,0x80,0x00);
 
@@ -28,6 +29,7 @@ static float fps = 0.0f;
 
 static int frames = 0;
 static int frame_interval = -1;
+
 
 typedef struct {
 	uint8_t *buf;
@@ -208,7 +210,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
 		for (i = 0; i < tex->Height; i++) {
 			for (j = 0; j < tex->Width; j++) {
 				memcpy(&Pixels[k], &row_pointers[i][4 * j], 3);
-				Pixels[k++].a = row_pointers[i][4 * j + 3] >> 1;
+				Pixels[k++].a = (row_pointers[i][4 * j + 3] + 1) >> 1;
 			}
 		}
 
@@ -286,7 +288,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
     		}
 
     		for (i = 0; i < num_trans; i++)
-    		    clut[i].a = trans[i] >> 1;
+    		    clut[i].a = (trans[i] + 1) >> 1;
 
     		for (i = 0; i < tex->Height; i++) {
     		    for (j = 0; j < tex->Width / 2; j++)
@@ -334,7 +336,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
     		}
 
     		for (i = 0; i < num_trans; i++)
-    		    clut[i].a = trans[i] >> 1;
+    		    clut[i].a = (trans[i] + 1) >> 1;
 
     		// rotate clut
     		for (i = 0; i < num_pallete; i++) {
@@ -1009,6 +1011,7 @@ int getFreeVRAM(){
 void drawImageCentered(GSTEXTURE* source, float x, float y, float width, float height, float startx, float starty, float endx, float endy, Color color)
 {
 	if (!ensureTextureReady(source)) return;
+	gsKit_set_test(gsGlobal, GS_ATEST_OFF);
 	gsKit_prim_sprite_texture(gsGlobal, source,
 					x-width/2, // X1
 					y-height/2, // Y1
@@ -1026,6 +1029,7 @@ void drawImageCentered(GSTEXTURE* source, float x, float y, float width, float h
 void drawImage(GSTEXTURE* source, float x, float y, float width, float height, float startx, float starty, float endx, float endy, Color color)
 {
 	if (!ensureTextureReady(source)) return;
+	gsKit_set_test(gsGlobal, GS_ATEST_OFF);
 	gsKit_prim_sprite_texture(gsGlobal, source,
 					x-0.5f, // X1
 					y-0.5f, // Y1
@@ -1046,6 +1050,7 @@ void drawImageRotate(GSTEXTURE* source, float x, float y, float width, float hei
 	float s = sinf(angle);
 
 	if (!ensureTextureReady(source)) return;
+	gsKit_set_test(gsGlobal, GS_ATEST_OFF);
 	gsKit_prim_quad_texture(gsGlobal, source,
 							(-width/2)*c - (-height/2)*s+x, (-height/2)*c + (-width/2)*s+y, startx, starty,
 							(-width/2)*c - height/2*s+x, height/2*c + (-width/2)*s+y, startx, endy,
@@ -1437,7 +1442,7 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 		for (i = 0; i < tex->Height; i++) {
 			for (j = 0; j < tex->Width; j++) {
 				memcpy(&Pixels[k], &row_pointers[i][4 * j], 3);
-				Pixels[k++].a = row_pointers[i][4 * j + 3] >> 1;
+				Pixels[k++].a = (row_pointers[i][4 * j + 3] + 1) >> 1;
 			}
 		}
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -38,6 +38,77 @@ typedef struct {
 static int error_count = 0;
 static int warning_count = 0;
 
+static bool was_texupload_logged(GSTEXTURE* source)
+{
+	static GSTEXTURE* logged[32] = {0};
+	static int logged_count = 0;
+
+	for (int i = 0; i < logged_count; i++) {
+		if (logged[i] == source) return true;
+	}
+
+	if (logged_count < (int)(sizeof(logged) / sizeof(logged[0]))) {
+		logged[logged_count++] = source;
+	}
+
+	return false;
+}
+
+static bool ensureTextureReady(GSTEXTURE* source)
+{
+	if (source == NULL) return false;
+	if (source->Width <= 0 || source->Height <= 0) return false;
+
+	if (source->Vram != 0) return true;
+
+	if (source->Delayed == true) {
+		gsKit_TexManager_bind(gsGlobal, source);
+	}
+
+	if (source->Vram == 0) {
+		if (source->Mem == NULL) {
+			DPRINTF("TEXUPLOAD_FAIL tex=%p mem=NULL w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
+			return false;
+		}
+
+		source->Vram = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(source->Width, source->Height, source->PSM), GSKIT_ALLOC_USERBUFFER);
+		if (source->Vram == GSKIT_ALLOC_ERROR) {
+			DPRINTF("TEXUPLOAD_FAIL tex=%p vram_alloc_failed w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
+			source->Vram = 0;
+			return false;
+		}
+
+		if (source->Clut != NULL && source->VramClut == 0) {
+			if (source->PSM == GS_PSM_T4)
+				source->VramClut = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(8, 2, GS_PSM_CT32), GSKIT_ALLOC_USERBUFFER);
+			else
+				source->VramClut = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(16, 16, GS_PSM_CT32), GSKIT_ALLOC_USERBUFFER);
+
+			if (source->VramClut == GSKIT_ALLOC_ERROR) {
+				DPRINTF("TEXUPLOAD_FAIL tex=%p vram_clut_alloc_failed\n", source);
+				source->VramClut = 0;
+				return false;
+			}
+		}
+
+		gsKit_texture_upload(gsGlobal, source);
+		if (source->Delayed == false) {
+			free(source->Mem);
+			source->Mem = NULL;
+			if (source->Clut != NULL) {
+				free(source->Clut);
+				source->Clut = NULL;
+			}
+		}
+	}
+
+	if (!was_texupload_logged(source)) {
+		DPRINTF("TEXUPLOAD tex=%p w=%d h=%d psm=%d vram=%u\n", source, source->Width, source->Height, source->PSM, source->Vram);
+	}
+
+	return source->Vram != 0;
+}
+
 typedef struct
 {
    const char *file_name;
@@ -937,10 +1008,7 @@ int getFreeVRAM(){
 
 void drawImageCentered(GSTEXTURE* source, float x, float y, float width, float height, float startx, float starty, float endx, float endy, Color color)
 {
-
-	if (source->Delayed == true) {
-		gsKit_TexManager_bind(gsGlobal, source);
-	}
+	if (!ensureTextureReady(source)) return;
 	gsKit_prim_sprite_texture(gsGlobal, source,
 					x-width/2, // X1
 					y-height/2, // Y1
@@ -957,10 +1025,7 @@ void drawImageCentered(GSTEXTURE* source, float x, float y, float width, float h
 
 void drawImage(GSTEXTURE* source, float x, float y, float width, float height, float startx, float starty, float endx, float endy, Color color)
 {
-
-	if (source->Delayed == true) {
-		gsKit_TexManager_bind(gsGlobal, source);
-	}
+	if (!ensureTextureReady(source)) return;
 	gsKit_prim_sprite_texture(gsGlobal, source,
 					x-0.5f, // X1
 					y-0.5f, // Y1
@@ -980,9 +1045,7 @@ void drawImageRotate(GSTEXTURE* source, float x, float y, float width, float hei
 	float c = cosf(angle);
 	float s = sinf(angle);
 
-	if (source->Delayed == true) {
-		gsKit_TexManager_bind(gsGlobal, source);
-	}
+	if (!ensureTextureReady(source)) return;
 	gsKit_prim_quad_texture(gsGlobal, source,
 							(-width/2)*c - (-height/2)*s+x, (-height/2)*c + (-width/2)*s+y, startx, starty,
 							(-width/2)*c - height/2*s+x, height/2*c + (-width/2)*s+y, startx, endy,

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -50,6 +50,55 @@ typedef struct {
 static int error_count = 0;
 static int warning_count = 0;
 
+typedef struct {
+	GSTEXTURE* tex;
+	char key[96];
+} diag_tex_owner_t;
+
+static const char* g_diag_pending_key = NULL;
+static diag_tex_owner_t g_diag_tex_owner[128] = {{0}};
+static int g_diag_tex_owner_count = 0;
+
+void Graphics_SetDiagKey(const char* key)
+{
+	g_diag_pending_key = key;
+}
+
+static const char* diag_tex_key(const GSTEXTURE* tex)
+{
+	for (int i = 0; i < g_diag_tex_owner_count; i++) {
+		if (g_diag_tex_owner[i].tex == tex) return g_diag_tex_owner[i].key;
+	}
+	return g_diag_pending_key ? g_diag_pending_key : "<unknown>";
+}
+
+const char* Graphics_GetDiagKeyForTexture(const GSTEXTURE* tex)
+{
+	return diag_tex_key(tex);
+}
+
+static void diag_register_texture(GSTEXTURE* tex, const char* key)
+{
+#if POPSLOADER_DIAG
+	const char* use_key = (key && key[0]) ? key : "<unknown>";
+	for (int i = 0; i < g_diag_tex_owner_count; i++) {
+		if (g_diag_tex_owner[i].tex == tex) {
+			if (strncmp(g_diag_tex_owner[i].key, use_key, sizeof(g_diag_tex_owner[i].key) - 1) != 0) {
+				DIAGF("TEXREUSE BUG: tex=%p old=%s new=%s\n", tex, g_diag_tex_owner[i].key, use_key);
+				abort();
+			}
+			return;
+		}
+	}
+	if (g_diag_tex_owner_count < (int)(sizeof(g_diag_tex_owner) / sizeof(g_diag_tex_owner[0]))) {
+		g_diag_tex_owner[g_diag_tex_owner_count].tex = tex;
+		strncpy(g_diag_tex_owner[g_diag_tex_owner_count].key, use_key, sizeof(g_diag_tex_owner[g_diag_tex_owner_count].key) - 1);
+		g_diag_tex_owner[g_diag_tex_owner_count].key[sizeof(g_diag_tex_owner[g_diag_tex_owner_count].key) - 1] = 0;
+		g_diag_tex_owner_count++;
+	}
+#endif
+}
+
 static bool was_texupload_logged(GSTEXTURE* source)
 {
 	static GSTEXTURE* logged[32] = {0};
@@ -115,7 +164,7 @@ static bool ensureTextureReady(GSTEXTURE* source)
 	}
 
 	if (!was_texupload_logged(source)) {
-		DIAGF("TEXUPLOAD tex=%p w=%d h=%d psm=%d vram=%u\n", source, source->Width, source->Height, source->PSM, source->Vram);
+		DIAGF("TEXUP  key=%s tex=%p vram=%u clut=%u\n", diag_tex_key(source), source, source->Vram, source->VramClut);
 	}
 
 	return source->Vram != 0;
@@ -924,7 +973,7 @@ GSTEXTURE* load_image(const char* path, bool delayed){
 	else if (magic == 0xD8FF) image = loadjpeg(file, false, delayed);
 	else if (magic == 0x5089) image = loadpng(file, delayed);
 	if (image == NULL) DPRINTF("Failed to load image %s.", path);
-	if (image != NULL) DIAGF("TEXNEW key=%s tex=%p w=%d h=%d psm=%d vram=%u clut=%u\n", path, image, image->Width, image->Height, image->PSM, image->Vram, image->VramClut);
+	if (image != NULL) { diag_register_texture(image, path); DIAGF("TEXNEW key=%s tex=%p w=%d h=%d psm=%d vram=%u clut=%u\n", path, image, image->Width, image->Height, image->PSM, image->Vram, image->VramClut); }
 
 	return image;
 }
@@ -1041,6 +1090,9 @@ void drawImage(GSTEXTURE* source, float x, float y, float width, float height, f
 {
 	if (!ensureTextureReady(source)) return;
 	gsKit_set_test(gsGlobal, GS_ATEST_OFF);
+	if (x <= 1.0f && y <= 1.0f && width >= (float)(gsGlobal->Width - 1) && height >= (float)(gsGlobal->Height - 1)) {
+		DIAGF("TEXDRW key=%s tex=%p alpha=%d\n", diag_tex_key(source), source, A(color));
+	}
 	gsKit_prim_sprite_texture(gsGlobal, source,
 					x-0.5f, // X1
 					y-0.5f, // Y1

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -13,6 +13,16 @@
 #include "include/dprintf.h"
 #include "include/assets.h"
 
+#ifndef POPSLOADER_DIAG
+#define POPSLOADER_DIAG 0
+#endif
+
+#if POPSLOADER_DIAG
+#define DIAGF(...) printf(__VA_ARGS__)
+#else
+#define DIAGF(...) do {} while (0)
+#endif
+
 #define DEG2RAD(x) ((x)*0.01745329251)
 
 
@@ -69,13 +79,13 @@ static bool ensureTextureReady(GSTEXTURE* source)
 
 	if (source->Vram == 0) {
 		if (source->Mem == NULL) {
-			DPRINTF("TEXUPLOAD_FAIL tex=%p mem=NULL w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
+			DIAGF("TEXUPLOAD_FAIL tex=%p mem=NULL w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
 			return false;
 		}
 
 		source->Vram = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(source->Width, source->Height, source->PSM), GSKIT_ALLOC_USERBUFFER);
 		if (source->Vram == GSKIT_ALLOC_ERROR) {
-			DPRINTF("TEXUPLOAD_FAIL tex=%p vram_alloc_failed w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
+			DIAGF("TEXUPLOAD_FAIL tex=%p vram_alloc_failed w=%d h=%d psm=%d\n", source, source->Width, source->Height, source->PSM);
 			source->Vram = 0;
 			return false;
 		}
@@ -87,7 +97,7 @@ static bool ensureTextureReady(GSTEXTURE* source)
 				source->VramClut = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(16, 16, GS_PSM_CT32), GSKIT_ALLOC_USERBUFFER);
 
 			if (source->VramClut == GSKIT_ALLOC_ERROR) {
-				DPRINTF("TEXUPLOAD_FAIL tex=%p vram_clut_alloc_failed\n", source);
+				DIAGF("TEXUPLOAD_FAIL tex=%p vram_clut_alloc_failed\n", source);
 				source->VramClut = 0;
 				return false;
 			}
@@ -105,7 +115,7 @@ static bool ensureTextureReady(GSTEXTURE* source)
 	}
 
 	if (!was_texupload_logged(source)) {
-		DPRINTF("TEXUPLOAD tex=%p w=%d h=%d psm=%d vram=%u\n", source, source->Width, source->Height, source->PSM, source->Vram);
+		DIAGF("TEXUPLOAD tex=%p w=%d h=%d psm=%d vram=%u\n", source, source->Width, source->Height, source->PSM, source->Vram);
 	}
 
 	return source->Vram != 0;
@@ -914,6 +924,7 @@ GSTEXTURE* load_image(const char* path, bool delayed){
 	else if (magic == 0xD8FF) image = loadjpeg(file, false, delayed);
 	else if (magic == 0x5089) image = loadpng(file, delayed);
 	if (image == NULL) DPRINTF("Failed to load image %s.", path);
+	if (image != NULL) DIAGF("TEXNEW key=%s tex=%p w=%d h=%d psm=%d vram=%u clut=%u\n", path, image, image->Width, image->Height, image->PSM, image->Vram, image->VramClut);
 
 	return image;
 }

--- a/src/include/graphics.h
+++ b/src/include/graphics.h
@@ -88,6 +88,9 @@ extern void setVideoMode(s16 mode, int width, int height, int psm, s16 interlace
 extern GSTEXTURE* load_image(const char* path, bool delayed);
 extern GSTEXTURE* loadImageFromBuffer(const void* data, size_t size, bool delayed);
 extern GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed);
+extern void Graphics_SetDiagKey(const char* key);
+extern const char* Graphics_GetDiagKeyForTexture(const GSTEXTURE* tex);
+
 
 
 extern void drawImage(GSTEXTURE* source, float x, float y, float width, float height, float startx, float starty, float endx, float endy, Color color);

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -50,7 +50,9 @@ static int imgThread(void* data)
 {
 	char* text = (char*)data;
 	bool delayed = asyncDelayed;
+	Graphics_SetDiagKey(text);
 	GSTEXTURE* image = load_image(text, delayed);
+	Graphics_SetDiagKey(NULL);
 	if (image == NULL) 
 	{
 		imgThreadResult = 1;
@@ -248,7 +250,9 @@ static int lua_loadimgfrombuffer(lua_State *L) {
 	const void* data = luaL_checklstring(L, 1, &sz);
 	bool delayed = true;
 	if (argc == 2) delayed = lua_toboolean(L, 2);
+	Graphics_SetDiagKey("<buffer>");
 	GSTEXTURE* image = loadImageFromBuffer(data, sz, delayed);
+	Graphics_SetDiagKey(NULL);
 	if (image != NULL) lua_pushlightuserdata(L, image); else lua_pushnil(L);
 	return 1;
 }
@@ -265,10 +269,14 @@ static int lua_loadimg(lua_State *L) {
 	bool isEmbedded = false;
 	GSTEXTURE* image = NULL;
 	if (Asset_ReadAll(text, &ptr, &sz, &isEmbedded) == 0 && isEmbedded) {
+		Graphics_SetDiagKey(text);
 		image = loadImageFromBuffer(ptr, sz, delayed);
+		Graphics_SetDiagKey(NULL);
 	}
 	if (image == NULL) {
+		Graphics_SetDiagKey(text);
 		image = load_image(text, delayed);
+		Graphics_SetDiagKey(NULL);
 	}
 
 	if (image != NULL && (image->Width <= 0 || image->Height <= 0)) {
@@ -571,7 +579,9 @@ static int lua_load_embedded_png(lua_State *L) {
 	uint8_t* ptr = (uint8_t *)luaL_checkstring(L, 1);
 	size_t siz = luaL_checkinteger(L, 2);
 	GSTEXTURE* image = NULL;
+	Graphics_SetDiagKey("<embedded>");
 	image = loadEmbeddedPNG(ptr, siz, true);
+	Graphics_SetDiagKey(NULL);
 	lua_pushlightuserdata(L, image);
 	return 1;
 }

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -10,6 +10,16 @@
 #include "include/luaplayer.h"
 #include "include/assets.h"
 
+#ifndef POPSLOADER_DIAG
+#define POPSLOADER_DIAG 0
+#endif
+
+#if POPSLOADER_DIAG
+#define DIAGF(...) printf(__VA_ARGS__)
+#else
+#define DIAGF(...) do {} while (0)
+#endif
+
 static bool asyncDelayed = true;
 
 volatile int imgThreadResult = 1;
@@ -262,11 +272,11 @@ static int lua_loadimg(lua_State *L) {
 	}
 
 	if (image != NULL && (image->Width <= 0 || image->Height <= 0)) {
-		printf("IMGFAIL key=%s decode=ok upload=unknown w=%d h=%d psm=%d\n", text, image->Width, image->Height, image->PSM);
+		DIAGF("IMGFAIL key=%s decode=ok upload=unknown w=%d h=%d psm=%d\n", text, image->Width, image->Height, image->PSM);
 		image = NULL;
 	}
 	if (image != NULL) {
-		printf("IMGUPLOAD key=%s tex=%p w=%d h=%d psm=%d vram=%u\n", text, (void*)image, image->Width, image->Height, image->PSM, image->Vram);
+		DIAGF("IMGUPLOAD key=%s tex=%p w=%d h=%d psm=%d vram=%u\n", text, (void*)image, image->Width, image->Height, image->PSM, image->Vram);
 		lua_pushlightuserdata(L, image);
 	}
 	else

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -13,10 +13,25 @@
 static bool asyncDelayed = true;
 
 volatile int imgThreadResult = 1;
-unsigned char* imgThreadData = NULL;
-uint32_t imgThreadSize = 0;
+GSTEXTURE* imgThreadData = NULL;
 
 static u8 imgThreadStack[4096] __attribute__((aligned(16)));
+
+static GSTEXTURE* lua_checktexture(lua_State* L, int idx)
+{
+	if (!lua_islightuserdata(L, idx) && !lua_isuserdata(L, idx)) {
+		luaL_error(L, "texture argument %d must be lightuserdata", idx);
+		return NULL;
+	}
+
+	GSTEXTURE* texture = (GSTEXTURE*)lua_touserdata(L, idx);
+	if (texture == NULL) {
+		luaL_error(L, "texture argument %d is NULL", idx);
+		return NULL;
+	}
+
+	return texture;
+}
 
 // Extern symbol 
 extern void *_gp;
@@ -29,14 +44,11 @@ static int imgThread(void* data)
 	if (image == NULL) 
 	{
 		imgThreadResult = 1;
+		imgThreadData = NULL;
 		ExitDeleteThread();
 		return 0;
 	}
-	char* buffer = (char*)malloc(16);
-	memset(buffer, 0, 16);
-	sprintf(buffer, "%i", (int)image);
-	imgThreadData = (unsigned char*)buffer;
-	imgThreadSize = strlen(buffer);
+	imgThreadData = image;
 	imgThreadResult = 1;
 	ExitDeleteThread();
 	return 0;
@@ -227,7 +239,7 @@ static int lua_loadimgfrombuffer(lua_State *L) {
 	bool delayed = true;
 	if (argc == 2) delayed = lua_toboolean(L, 2);
 	GSTEXTURE* image = loadImageFromBuffer(data, sz, delayed);
-	if (image != NULL) lua_pushinteger(L, (uint32_t)(image)); else lua_pushnil(L);
+	if (image != NULL) lua_pushlightuserdata(L, image); else lua_pushnil(L);
 	return 1;
 }
 
@@ -254,8 +266,8 @@ static int lua_loadimg(lua_State *L) {
 		image = NULL;
 	}
 	if (image != NULL) {
-		printf("IMGUPLOAD key=%s w=%d h=%d psm=%d vram=%u\n", text, image->Width, image->Height, image->PSM, image->Vram);
-		lua_pushinteger(L, (uint32_t)(image));
+		printf("IMGUPLOAD key=%s tex=%p w=%d h=%d psm=%d vram=%u\n", text, (void*)image, image->Width, image->Height, image->PSM, image->Vram);
+		lua_pushlightuserdata(L, image);
 	}
 	else
 		lua_pushnil(L);
@@ -265,7 +277,7 @@ static int lua_loadimg(lua_State *L) {
 static int lua_drawimg(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 3 && argc != 4) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	float x = luaL_checknumber(L, 2);
 	float y = luaL_checknumber(L, 3);
 	Color color = 0x80808080;
@@ -285,7 +297,7 @@ static int lua_drawimg(lua_State *L) {
 static int lua_drawimg_rotate(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 4 && argc != 5) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	float x = luaL_checknumber(L, 2);
 	float y = luaL_checknumber(L, 3);
 	float radius = luaL_checknumber(L, 4);
@@ -306,7 +318,7 @@ static int lua_drawimg_rotate(lua_State *L) {
 static int lua_drawimg_scale(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 5 && argc != 6) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	float x = luaL_checknumber(L, 2);
 	float y = luaL_checknumber(L, 3);
 	float width = luaL_checknumber(L, 4);
@@ -326,7 +338,7 @@ static int lua_drawimg_scale(lua_State *L) {
 static int lua_drawimg_part(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 7 && argc != 8) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	float x = luaL_checknumber(L, 2);
 	float y = luaL_checknumber(L, 3);
 	float startx = (float)luaL_checknumber(L, 4);
@@ -346,7 +358,7 @@ static int lua_drawimg_part(lua_State *L) {
 static int lua_drawimg_full(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 10 && argc != 11) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	float x = luaL_checknumber(L, 2);
 	float y = luaL_checknumber(L, 3);
 	float startx = (float)luaL_checknumber(L, 4);
@@ -367,7 +379,7 @@ static int lua_drawimg_full(lua_State *L) {
 static int lua_width(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 1) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	lua_pushinteger(L, (uint32_t)(source->Width));
 	return 1;
 }
@@ -375,7 +387,7 @@ static int lua_width(lua_State *L) {
 static int lua_height(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 1) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	lua_pushinteger(L, (uint32_t)(source->Height));
 	return 1;
 }
@@ -383,7 +395,7 @@ static int lua_height(lua_State *L) {
 static int lua_filters(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 2) return luaL_error(L, "wrong number of arguments");
-    GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+    GSTEXTURE* source = lua_checktexture(L, 1);
 	source->Filter = luaL_checknumber(L, 2);
 	return 0;
 }
@@ -500,7 +512,7 @@ static int lua_free(lua_State *L) {
 	if (argc != 1) return luaL_error(L, "wrong number of arguments");
 #endif
 	
-	GSTEXTURE* source = (GSTEXTURE*)(luaL_checkinteger(L, 1));
+	GSTEXTURE* source = lua_checktexture(L, 1);
 
 	UnloadTexture(source);
 
@@ -536,8 +548,7 @@ static int lua_getloaddata(lua_State *L){
 	if(argc != 0) return luaL_error(L, "wrong number of arguments.");
 #endif
 	if (imgThreadData != NULL){
-		lua_pushlstring(L,(const char*)imgThreadData,imgThreadSize);
-		free(imgThreadData);
+		lua_pushlightuserdata(L, imgThreadData);
 		imgThreadData = NULL;
 		return 1;
 	}else return 0;
@@ -551,7 +562,7 @@ static int lua_load_embedded_png(lua_State *L) {
 	size_t siz = luaL_checkinteger(L, 2);
 	GSTEXTURE* image = NULL;
 	image = loadEmbeddedPNG(ptr, siz, true);
-	lua_pushinteger(L, (uint32_t)(image));
+	lua_pushlightuserdata(L, image);
 	return 1;
 }
 //Register our Graphics Functions


### PR DESCRIPTION
### Motivation
- The Lua/C graphics contract was inconsistent: texture pointers were being pushed as integer handles while draw paths expected userdata, causing cases where `handle != nil` but nothing rendered.
- Standardize the contract so `Graphics.loadImage` and related loaders always return a Lua `lightuserdata` that contains a valid `GSTEXTURE*` pointer to remove ambiguity and silent failures.

### Description
- Add `lua_checktexture(lua_State*, int)` helper that enforces texture args are `lightuserdata`/`userdata` and returns a non-NULL `GSTEXTURE*` or raises a clear Lua error. 
- Change `loadImage`, `loadImageFromBuffer`, and `loadImageEmbedded` to `lua_pushlightuserdata(L, image)` on success and `nil` on failure, and update the `IMGUPLOAD` diagnostic to log the pointer with `%p` plus metadata. 
- Replace all consumer calls that previously used `luaL_checkinteger` casts for textures (draw/rotate/scale/partial/extended, `getImageWidth`/`getImageHeight`, `setImageFilters`, and `freeImage`) to use `lua_checktexture(...)`. 
- Fix the async image loader contract by storing the `GSTEXTURE*` in `imgThreadData` and returning it as `lightuserdata` from `getLoadData` instead of stringified integer data.

### Testing
- Confirmed via `rg` searches that texture loaders now use `lua_pushlightuserdata` and draw/free paths use `lua_checktexture` (searches executed in the repo). 
- Attempted an automated build with `make -j2`, but the build failed in this environment due to a missing file (`/samples/Makefile.eeglobal`), so a full compile/test could not be completed here. 
- No unit tests were present or run in this container beyond the above automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9cd585148321a19244d822a805ed)