### PR TITLE
Fix PNG/Lua alpha handling and UI fade logic; make settings save atomic and add diagnostics

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -118,9 +118,6 @@ local function SafeOpenForWrite(path)
   if EnsureDir(dir) == nil then
     return nil, "mkdir_failed"
   end
-  if doesFileExist(path) then
-    pcall(System.removeFile, path)
-  end
   local ok_open, fd = pcall(System.openFile, path, FCREATE)
   if not ok_open or type(fd) ~= "number" or fd < 0 then
     return nil, "open_failed"
@@ -140,6 +137,69 @@ local function SafeWriteAll(fd, data)
     return false, "short_write"
   end
   return true, nil
+end
+
+local function SerializeSettingsLua(settings)
+  local lines = {
+    "return {",
+    string.format("  bdma_mode = %d,", tonumber(settings.bdma_mode) or 1),
+    string.format("  hide_ui = %s,", tostring(settings.hide_ui == true)),
+    string.format("  show_cover = %s,", tostring(settings.show_cover ~= false)),
+    string.format("  profile_index = %s,", settings.profile_index ~= nil and tostring(tonumber(settings.profile_index) or 0) or "nil"),
+    string.format("  bdma_last_label = %s,", settings.bdma_last_label ~= nil and string.format("%q", tostring(settings.bdma_last_label)) or "nil"),
+    string.format("  dkwdrv_path = %s,", settings.dkwdrv_path ~= nil and string.format("%q", tostring(settings.dkwdrv_path)) or "nil"),
+    string.format("  popstarter_path = %s,", settings.popstarter_path ~= nil and string.format("%q", tostring(settings.popstarter_path)) or "nil"),
+    "}",
+    ""
+  }
+  return table.concat(lines, "\n")
+end
+
+local function CopyFileContents(source, dest)
+  local ok_copy, copy_err = pcall(System.copyFile, source, dest)
+  if not ok_copy then
+    return false, tostring(copy_err)
+  end
+  return true, nil
+end
+
+local function AtomicWriteFile(path, data)
+  local tmp_path = path..".tmp"
+  local fd, open_err = SafeOpenForWrite(tmp_path)
+  if fd == nil then
+    return false, "tmp_open_failed:"..tostring(open_err)
+  end
+  local ok_write, write_err = SafeWriteAll(fd, data)
+  local ok_close, close_err = pcall(System.closeFile, fd)
+  if not ok_write or not ok_close then
+    pcall(System.removeFile, tmp_path)
+    return false, tostring(write_err or close_err)
+  end
+
+  local ok_rename, rename_err = pcall(System.rename, tmp_path, path)
+  if ok_rename then
+    return true, nil
+  end
+
+  pcall(System.removeFile, path)
+  local ok_copy, copy_err = CopyFileContents(tmp_path, path)
+  pcall(System.removeFile, tmp_path)
+  if not ok_copy then
+    return false, "rename_failed:"..tostring(rename_err).." copy_failed:"..tostring(copy_err)
+  end
+  return true, nil
+end
+
+local function NextBadSettingsPath(base_path)
+  local idx = 1
+  while idx < 1000 do
+    local bad = string.format("%s.bad.%d", base_path, idx)
+    if not doesFileExist(bad) then
+      return bad
+    end
+    idx = idx + 1
+  end
+  return base_path..".bad"
 end
 
 local function IsAbsoluteDevicePath(path)
@@ -482,30 +542,28 @@ local BDMA_MODES = {
 
 local function LoadSettingsTable(path)
   if path == nil or path == "" then
-    return nil
+    return nil, "missing_path"
   end
   if not doesFileExist(path) then
-    return nil
+    return nil, "missing"
   end
   local loader, load_err = loadfile(path)
   if loader == nil then
-    LOG("Settings load failed:", load_err)
-    return nil
+    return nil, "parse:"..tostring(load_err)
   end
   local ok, data = pcall(loader)
   if not ok then
-    LOG("Settings exec failed:", data)
-    return nil
+    return nil, "exec:"..tostring(data)
   end
   if type(data) ~= "table" then
-    return nil
+    return nil, "not_table"
   end
-  return data
+  return data, nil
 end
 
 function PLDR.LoadSettings()
   local path = ResolveWritablePath("settings.lua")
-  local data = LoadSettingsTable(path)
+  local data, load_err = LoadSettingsTable(path)
   if type(data) == "table" then
     local mode = tonumber(data.bdma_mode)
     if mode ~= nil then
@@ -530,6 +588,27 @@ function PLDR.LoadSettings()
     if type(data.popstarter_path) == "string" and data.popstarter_path ~= "" then
       PLDR.SETTINGS.popstarter_path = data.popstarter_path
     end
+  elseif load_err ~= "missing" then
+    LOG("Settings load failed: "..tostring(load_err))
+    if doesFileExist(path) then
+      local bad_path = NextBadSettingsPath(path)
+      local moved = false
+      local ok_rename = pcall(System.rename, path, bad_path)
+      if ok_rename then
+        moved = true
+      else
+        local ok_copy = pcall(System.copyFile, path, bad_path)
+        if ok_copy then
+          pcall(System.removeFile, path)
+          moved = true
+        end
+      end
+      if moved then
+        LOG("Settings quarantined to: "..tostring(bad_path))
+      else
+        LOG("Settings quarantine failed for: "..tostring(path))
+      end
+    end
   end
   if PLDR.SETTINGS.bdma_mode == nil then
     PLDR.SETTINGS.bdma_mode = 1
@@ -547,6 +626,9 @@ function PLDR.LoadSettings()
   if PLDR.SETTINGS.bdma_mode < 1 or PLDR.SETTINGS.bdma_mode > count then
     PLDR.SETTINGS.bdma_mode = 1
   end
+  if load_err ~= nil and load_err ~= "missing" then
+    PLDR.SaveSettings()
+  end
 end
 
 function System.GetPOPStarterElfPath()
@@ -556,34 +638,18 @@ end
 
 function PLDR.SaveSettings()
   local path = ResolveWritablePath("settings.lua")
-  local fd, open_err = SafeOpenForWrite(path)
-  if fd == nil then
-    LOG("SaveSettings failed: "..tostring(path).." fd=nil err="..tostring(open_err))
-    if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
-      UI.Notif_queue.add("Could not save settings to mc0:/POPSLOADER/")
-    end
-    return false
-  end
-  local mode = tonumber(PLDR.SETTINGS.bdma_mode) or 1
-  local hide_ui = PLDR.SETTINGS.hide_ui == true
-  local show_cover = PLDR.SETTINGS.show_cover ~= false
-  local profile_index = tonumber(PLDR.SETTINGS.profile_index)
-  local bdma_last_label = PLDR.SETTINGS.bdma_last_label
-  local dkwdrv_path = PLDR.SETTINGS.dkwdrv_path or PLDR.DEFAULT_DKWDRV_PATH
-  local popstarter_path = PLDR.SETTINGS.popstarter_path
-  local line = "return {\n"
-    ..string.format("  bdma_mode = %d,\n", mode)
-    ..string.format("  hide_ui = %s,\n", tostring(hide_ui))
-    ..string.format("  show_cover = %s,\n", tostring(show_cover))
-    ..string.format("  profile_index = %s,\n", profile_index ~= nil and tostring(profile_index) or "nil")
-    ..string.format("  bdma_last_label = %s,\n", bdma_last_label ~= nil and string.format("%q", bdma_last_label) or "nil")
-    ..string.format("  dkwdrv_path = %s,\n", dkwdrv_path ~= nil and string.format("%q", dkwdrv_path) or "nil")
-    ..string.format("  popstarter_path = %s,\n", popstarter_path ~= nil and string.format("%q", popstarter_path) or "nil")
-    .."}\n"
-  local ok_write, write_err = SafeWriteAll(fd, line)
-  local ok_close, close_err = pcall(System.closeFile, fd)
-  if not ok_write or not ok_close then
-    LOG("SaveSettings failed: "..tostring(path).." fd="..tostring(fd).." err="..tostring(write_err or close_err))
+  local payload = SerializeSettingsLua({
+    bdma_mode = tonumber(PLDR.SETTINGS.bdma_mode) or 1,
+    hide_ui = PLDR.SETTINGS.hide_ui == true,
+    show_cover = PLDR.SETTINGS.show_cover ~= false,
+    profile_index = tonumber(PLDR.SETTINGS.profile_index),
+    bdma_last_label = PLDR.SETTINGS.bdma_last_label,
+    dkwdrv_path = PLDR.SETTINGS.dkwdrv_path or PLDR.DEFAULT_DKWDRV_PATH,
+    popstarter_path = PLDR.SETTINGS.popstarter_path
+  })
+  local ok, save_err = AtomicWriteFile(path, payload)
+  if not ok then
+    LOG("SaveSettings failed: "..tostring(path).." err="..tostring(save_err))
     if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
       UI.Notif_queue.add("Could not save settings to mc0:/POPSLOADER/")
     end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -26,6 +26,9 @@ local function Clamp(v, lo, hi)
   if v > hi then return hi end
   return v
 end
+local function Alpha255FromT(t)
+  return Round(Clamp01(t) * 255)
+end
 local function EaseInOutCubic(t)
   t = Clamp01(t)
   if t < 0.5 then
@@ -789,6 +792,12 @@ UI = {
     WelcomeDraw = {
       Play = function (next_scene)
 	        -- Boot splash fades in from black, then fades out into the next scene.
+	        local phase_log_once = {}
+	        local function LogFadeOnce(phase, t, overlay_a)
+	          if phase_log_once[phase] == true then return end
+	          phase_log_once[phase] = true
+	          LOGF("DRAW_FADE: phase=%s t=%.3f overlay_a=%d", tostring(phase), t or 0, overlay_a or 0)
+	        end
 	        local function DrawBackground()
 	          Screen.clear(Color.new(0, 0, 0))
 	        end
@@ -803,6 +812,12 @@ UI = {
             bg = IMG.BKG
           end
           if bg ~= nil then
+            if phase_log_once["bg_"..tostring(scene)] ~= true then
+              local iw = Graphics.getImageWidth(bg)
+              local ih = Graphics.getImageHeight(bg)
+              LOGF("DRAW_BG: key=%s a=255 tint=255,255,255 w=%s h=%s", tostring(scene), tostring(iw), tostring(ih))
+              phase_log_once["bg_"..tostring(scene)] = true
+            end
             Graphics.drawScaleImage(bg, 0, 0, UI.SCR.X, UI.SCR.Y, Color.new(255, 255, 255, 255))
           end
         end
@@ -1008,9 +1023,14 @@ end
 
         -- Splash: slow fade in -> hold -> fade out to black.
         for i = 1, fade_in_frames do
-          local alpha = Round(255 * (i / fade_in_frames))
+          local alpha = Alpha255FromT(i / fade_in_frames)
+          local overlay_alpha = 255 - alpha
           DrawBackground()
-          DrawSplash(alpha)
+          DrawSplash(255)
+          if overlay_alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+          end
+          LogFadeOnce("splash_fade_in", i / fade_in_frames, overlay_alpha)
           Screen.flip()
         end
         for _ = 1, splash_hold_frames do
@@ -1020,19 +1040,22 @@ end
         end
         if fade_out_frames > 0 then
           for i = 1, fade_out_frames do
-            local alpha = Round(255 * (i / fade_out_frames))
+            local alpha = Alpha255FromT(1 - (i / fade_out_frames))
+            local overlay_alpha = 255 - alpha
             DrawBackground()
             DrawSplash(255)
-            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, overlay_alpha))
+            LogFadeOnce("splash_fade_out", i / fade_out_frames, overlay_alpha)
             Screen.flip()
           end
         end
 
         -- Credits: fade in from black -> hold -> fade out to black.
         for i = 1, credits_fade_in_frames do
-          local alpha = Round(255 * (1 - (i / credits_fade_in_frames)))
+          local alpha = Alpha255FromT(1 - (i / credits_fade_in_frames))
           DrawTargetScene(UI.SCENES.CREDITS)
           Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
+          LogFadeOnce("credits_fade_in", i / credits_fade_in_frames, alpha)
           Screen.flip()
         end
         for _ = 1, credits_hold_frames do
@@ -1041,9 +1064,10 @@ end
         end
         if credits_fade_out_frames > 0 then
           for i = 1, credits_fade_out_frames do
-            local alpha = Round(255 * (i / credits_fade_out_frames))
+            local alpha = Alpha255FromT(i / credits_fade_out_frames)
             DrawTargetScene(UI.SCENES.CREDITS)
             Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
+            LogFadeOnce("credits_fade_out", i / credits_fade_out_frames, alpha)
             Screen.flip()
           end
         end
@@ -1051,9 +1075,10 @@ end
         local final_scene = UI.SCENES.MMAIN
         -- Main menu: fade in from black.
         for i = 1, fade_in_frames do
-          local alpha = Round(255 * (1 - (i / fade_in_frames)))
+          local alpha = Alpha255FromT(1 - (i / fade_in_frames))
           DrawTargetScene(final_scene)
           Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
+          LogFadeOnce("menu_fade_in", i / fade_in_frames, alpha)
           Screen.flip()
         end
         DrawTargetScene(final_scene)
@@ -1304,6 +1329,9 @@ end
       elapsed = 0,
       last_time = nil,
       max_step = 33,
+      min_step = 16,
+      debug_frames = 0,
+      no_progress_frames = 0,
       duration_out = 140,
       duration_in = 120,
       Queue = function (target)
@@ -1327,6 +1355,9 @@ end
         UI.Transition.start = Timer.getTime(UI.Transition.timer)
         UI.Transition.elapsed = 0
         UI.Transition.last_time = UI.Transition.start
+        UI.Transition.debug_frames = 0
+        UI.Transition.no_progress_frames = 0
+        LOGF("TRANSITION_START: target=%s phase=out active=true", tostring(target))
       end,
       Update = function ()
         if not UI.Transition.active then
@@ -1336,6 +1367,14 @@ end
         local last = UI.Transition.last_time or now
         local delta = now - last
         if delta < 0 then delta = 0 end
+        if delta == 0 then
+          UI.Transition.no_progress_frames = (UI.Transition.no_progress_frames or 0) + 1
+          if UI.Transition.no_progress_frames >= 2 then
+            delta = UI.Transition.min_step or 16
+          end
+        else
+          UI.Transition.no_progress_frames = 0
+        end
         local max_step = UI.Transition.max_step or 33
         if delta > max_step then delta = max_step end
         UI.Transition.elapsed = (UI.Transition.elapsed or 0) + delta
@@ -1347,9 +1386,13 @@ end
         if t > 1 then t = 1 end
         local alpha
         if UI.Transition.phase == "out" then
-          alpha = Round(128 * t)
+          alpha = Alpha255FromT(t)
         else
-          alpha = Round(128 * (1 - t))
+          alpha = Alpha255FromT(1 - t)
+        end
+        UI.Transition.debug_frames = (UI.Transition.debug_frames or 0) + 1
+        if UI.Transition.debug_frames == 1 or (UI.Transition.debug_frames % 60) == 0 then
+          LOGF("TRANSITION_TICK: active=%s phase=%s t=%.3f alpha=%d elapsed=%d", tostring(UI.Transition.active), tostring(UI.Transition.phase), t, alpha, elapsed)
         end
         if t >= 1 then
           if UI.Transition.phase == "out" then
@@ -1368,7 +1411,10 @@ end
             UI.Transition.start = now
             UI.Transition.elapsed = 0
             UI.Transition.last_time = now
-            alpha = 128
+            UI.Transition.debug_frames = 0
+            UI.Transition.no_progress_frames = 0
+            alpha = 255
+            LOGF("TRANSITION_PHASE: phase=in active=true target=%s", tostring(UI.CURSCENE))
           else
             local queued = UI.Transition.next_target
             if queued ~= nil and queued ~= UI.CURSCENE then
@@ -1380,6 +1426,7 @@ end
               UI.Transition.target = nil
               UI.Transition.next_target = nil
               alpha = 0
+              LOG("TRANSITION_END: active=false")
             end
           end
         end

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -137,7 +137,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
 		for (i = 0; i < tex->Height; i++) {
 			for (j = 0; j < tex->Width; j++) {
 				memcpy(&Pixels[k], &row_pointers[i][4 * j], 3);
-				Pixels[k++].a = row_pointers[i][4 * j + 3] >> 1;
+				Pixels[k++].a = (row_pointers[i][4 * j + 3] + 1) >> 1;
 			}
 		}
 
@@ -215,7 +215,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
     		}
 
     		for (i = 0; i < num_trans; i++)
-    		    clut[i].a = trans[i] >> 1;
+    		    clut[i].a = (trans[i] + 1) >> 1;
 
     		for (i = 0; i < tex->Height; i++) {
     		    for (j = 0; j < tex->Width / 2; j++)
@@ -263,7 +263,7 @@ GSTEXTURE* loadpng(FILE* File, bool delayed)
     		}
 
     		for (i = 0; i < num_trans; i++)
-    		    clut[i].a = trans[i] >> 1;
+    		    clut[i].a = (trans[i] + 1) >> 1;
 
     		// rotate clut
     		for (i = 0; i < num_pallete; i++) {
@@ -1374,7 +1374,7 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 		for (i = 0; i < tex->Height; i++) {
 			for (j = 0; j < tex->Width; j++) {
 				memcpy(&Pixels[k], &row_pointers[i][4 * j], 3);
-				Pixels[k++].a = row_pointers[i][4 * j + 3] >> 1;
+				Pixels[k++].a = (row_pointers[i][4 * j + 3] + 1) >> 1;
 			}
 		}
 

--- a/src/luaScreen.cpp
+++ b/src/luaScreen.cpp
@@ -155,7 +155,7 @@ static int lua_color(lua_State *L) {
 	int g = luaL_checkinteger(L, 2);
 	int b = luaL_checkinteger(L, 3);
 	int a = 0x80;
-	if (argc==4) a = CLAMP(luaL_checkinteger(L, 4), 0, 128);
+	if (argc==4) a = CLAMP(luaL_checkinteger(L, 4), 0, 255);
 	int color = r | (g << 8) | (b << 16) | (a << 24);
 	lua_pushinteger(L,color);
 	return 1;


### PR DESCRIPTION
### Motivation
- Address persistent black-screen symptom by fixing mismatched alpha ranges and rounding in image decoding and Lua color packing that left overlays too opaque. 
- Make UI fade math and engine color packing consistent across codepaths so fades actually progress through the full 0..255 range. 
- Improve settings persistence robustness and add logging to make failures and transition behavior diagnosable.

### Description
- Corrected PNG alpha downscale rounding in `src/graphics.cpp` by replacing `a >> 1` with `(a + 1) >> 1` for RGBA decode and palette `tRNS` CLUT conversions so 0..255 maps to 0..128 with proper rounding. 
- Fixed Lua color constructor in `src/luaScreen.cpp` to clamp alpha to `0..255` instead of `0..128` so `Color.new(r,g,b,a)` uses the same alpha range as UI fade math. 
- Reworked UI fade logic in `bin/POPSLDR/ui.lua` by adding `Alpha255FromT`, using 0..255 overlay alphas for splash/credits/menu fades, and inserting logging (`LOGF`) to trace fade/transition progress. 
- Hardened settings I/O in `bin/POPSLDR/system.lua` by introducing `SerializeSettingsLua`, `AtomicWriteFile`, `NextBadSettingsPath`, safer `LoadSettingsTable` error returns, quarantining malformed settings, and switching `SaveSettings` to atomic write semantics.

### Testing
- Applied patches with `apply_patch` and committed the changes with `git commit`, and verified diffs via `git diff` and file excerpts using `nl -ba ... | sed -n ...`; these source-level checks succeeded. 
- Updated PR metadata using the `make_pr` helper to document root cause and expected behavior. 
- No automated build or runtime/visual rendering tests were executed in this run (manual / CI verification recommended to validate rendering results on device).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cfcab37b08321a1786992da53a2e6)