### PR TITLE
Fix fullscreen image loading under VRAM pressure

### DIFF
--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -255,12 +255,6 @@ static int lua_loadimg(lua_State *L) {
 	const char* text = luaL_checkstring(L, 1);
 	bool delayed = true;
 	if (argc == 2) delayed = lua_toboolean(L, 2);
-	bool force_immediate = isKnownFullscreenBackgroundKey(text);
-	if (force_immediate && delayed) {
-		delayed = false;
-		printf("IMGMODE key=%s delayed=0 reason=fullscreen_bg\n", text);
-	}
-
 	const void* ptr = NULL;
 	size_t sz = 0;
 	bool isEmbedded = false;


### PR DESCRIPTION
## Summary
- remove the forced immediate-upload path for fullscreen background assets in `lua_loadimg`
- keep caller-provided delayed-loading behavior intact so large backgrounds can bind/upload on demand instead of requiring upfront VRAM allocation

## Root cause
Fullscreen assets (`IMG/PSL.png`, `IMG/BKG.png`, `IMG/BG.png`, `IMG/BGM.png`) were being forced to `delayed=false` inside `src/luagraphics.cpp`. That path allocates VRAM immediately during load, which can fail under tight VRAM and return `nil` despite successful file decode.

## Why this fixes it
With forced immediate mode removed, these images stay delayed by default and are managed through texture binding at draw time, avoiding the early-allocation failure mode shown in logs (`Not enough VRAM for this allocation`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d114b8e68832181413ff8a677c59c)