### PR TITLE
Fix missing PSL/BKG/BGM/BG textures by removing unsafe alpha mutation in image loader

### DIFF
--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -19,23 +19,6 @@ uint32_t imgThreadSize = 0;
 static u8 imgThreadStack[4096] __attribute__((aligned(16)));
 
 
-static bool isKnownFullscreenBackgroundKey(const char* key) {
-	if (key == NULL) return false;
-	return strcmp(key, "IMG/PSL.png") == 0 ||
-	       strcmp(key, "IMG/BKG.png") == 0 ||
-	       strcmp(key, "IMG/BG.png") == 0 ||
-	       strcmp(key, "IMG/BGM.png") == 0;
-}
-
-static void forceTextureOpaqueAlpha(GSTEXTURE* image) {
-	if (image == NULL || image->PSM != GS_PSM_CT32 || image->Mem == NULL) return;
-	struct pixel { u8 r, g, b, a; };
-	struct pixel* pixels = (struct pixel*)image->Mem;
-	int total = image->Width * image->Height;
-	for (int i = 0; i < total; ++i) {
-		pixels[i].a = 0x80;
-	}
-}
 // Extern symbol 
 extern void *_gp;
 
@@ -269,10 +252,6 @@ static int lua_loadimg(lua_State *L) {
 	if (image != NULL && (image->Width <= 0 || image->Height <= 0)) {
 		printf("IMGFAIL key=%s decode=ok upload=unknown w=%d h=%d psm=%d\n", text, image->Width, image->Height, image->PSM);
 		image = NULL;
-	}
-	if (image != NULL && isKnownFullscreenBackgroundKey(text)) {
-		forceTextureOpaqueAlpha(image);
-		printf("IMGALPHAFIX key=%s mode=force_opaque a=128\n", text);
 	}
 	if (image != NULL) {
 		printf("IMGUPLOAD key=%s w=%d h=%d psm=%d vram=%u\n", text, image->Width, image->Height, image->PSM, image->Vram);


### PR DESCRIPTION
## Summary
This PR fixes the regression where `PSL.png`, `BKG.png`, `BGM.png`, and `BG.png` load but do not render.

## Root cause
`src/luagraphics.cpp` had a special-case path in `lua_loadimg()` that mutated pixel alpha data for those four files only:
- `IMG/PSL.png`
- `IMG/BKG.png`
- `IMG/BG.png`
- `IMG/BGM.png`

That forced rewrite (`forceTextureOpaqueAlpha`) was not applied to any other textures, which matches the observed behavior: all other images render, only these four fail.

## What changed
- Removed the fullscreen-background key matcher (`isKnownFullscreenBackgroundKey`)
- Removed the per-pixel alpha rewrite helper (`forceTextureOpaqueAlpha`)
- Removed the call site in `lua_loadimg()` that altered those textures after decode

Now these images follow the same decode/upload path as every other PNG, eliminating the one-off processing path that was causing rendering failure.

## Why this is a durable fix
- Eliminates a divergent code path affecting only four assets
- Restores consistency across all PNG loading behavior
- Avoids future breakage from format/layout assumptions during raw pixel mutation

## Validation
- Static inspection confirms the special-case alpha mutation and associated log (`IMGALPHAFIX`) are fully removed from `src/luagraphics.cpp`.

Runtime verification should now show those textures rendering in places where `IMG.PSL`, `IMG.BG`, `IMG.BGM`, and `IMG.BKG` are used in `bin/POPSLDR/ui.lua`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1732d4348321b8ac8bdaacfe6d77)