### PR TITLE
Fix embedded PNG palette handling for fullscreen textures (PSL/BKG/BGM/BG)

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1341,9 +1341,6 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
 	png_set_strip_16(png_ptr);
 
-	if (color_type == PNG_COLOR_TYPE_PALETTE)
-		png_set_expand(png_ptr);
-
 	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
 		png_set_expand(png_ptr);
 
@@ -1411,6 +1408,106 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 		for(row = 0; row < height; row++) free(row_pointers[row]);
 
 		free(row_pointers);
+	}
+	else if(png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE){
+
+		struct png_clut { u8 r, g, b, a; };
+
+		png_colorp palette = NULL;
+		int num_pallete = 0;
+		png_bytep trans = NULL;
+		int num_trans = 0;
+
+		png_get_PLTE(png_ptr, info_ptr, &palette, &num_pallete);
+		png_get_tRNS(png_ptr, info_ptr, &trans, &num_trans, NULL);
+		tex->ClutPSM = GS_PSM_CT32;
+
+		if (bit_depth == 4) {
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T4;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+			for (i = num_pallete; i < 16; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+			for (i = 0; i < num_trans; i++) clut[i].a = (trans[i] + 1) >> 1;
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width / 2; j++) memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+			}
+
+			int byte;
+			unsigned char *tmpdst = (unsigned char *)tex->Mem;
+			unsigned char *tmpsrc = (unsigned char *)pixel;
+			for (byte = 0; byte < gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM); byte++)
+				tmpdst[byte] = (tmpsrc[byte] << 4) | (tmpsrc[byte] >> 4);
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+			free(row_pointers);
+		} else if (bit_depth == 8) {
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T8;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+			for (i = num_pallete; i < 256; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+			for (i = 0; i < num_trans; i++) clut[i].a = (trans[i] + 1) >> 1;
+
+			for (i = 0; i < num_pallete; i++) {
+				if ((i & 0x18) == 8) {
+					struct png_clut tmp = clut[i];
+					clut[i] = clut[i + 8];
+					clut[i + 8] = tmp;
+				}
+			}
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width; j++) {
+					memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+				}
+			}
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+			free(row_pointers);
+		} else {
+			DPRINTF("%s: Palette bit depth %d not supported yet!\n", __func__, bit_depth);
+			return NULL;
+		}
 	}
 	else
 	{

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -19,23 +19,6 @@ uint32_t imgThreadSize = 0;
 static u8 imgThreadStack[4096] __attribute__((aligned(16)));
 
 
-static bool isKnownFullscreenBackgroundKey(const char* key) {
-	if (key == NULL) return false;
-	return strcmp(key, "IMG/PSL.png") == 0 ||
-	       strcmp(key, "IMG/BKG.png") == 0 ||
-	       strcmp(key, "IMG/BG.png") == 0 ||
-	       strcmp(key, "IMG/BGM.png") == 0;
-}
-
-static void forceTextureOpaqueAlpha(GSTEXTURE* image) {
-	if (image == NULL || image->PSM != GS_PSM_CT32 || image->Mem == NULL) return;
-	struct pixel { u8 r, g, b, a; };
-	struct pixel* pixels = (struct pixel*)image->Mem;
-	int total = image->Width * image->Height;
-	for (int i = 0; i < total; ++i) {
-		pixels[i].a = 0x80;
-	}
-}
 // Extern symbol 
 extern void *_gp;
 
@@ -269,10 +252,6 @@ static int lua_loadimg(lua_State *L) {
 	if (image != NULL && (image->Width <= 0 || image->Height <= 0)) {
 		printf("IMGFAIL key=%s decode=ok upload=unknown w=%d h=%d psm=%d\n", text, image->Width, image->Height, image->PSM);
 		image = NULL;
-	}
-	if (image != NULL && isKnownFullscreenBackgroundKey(text)) {
-		forceTextureOpaqueAlpha(image);
-		printf("IMGALPHAFIX key=%s mode=force_opaque a=128\n", text);
 	}
 	if (image != NULL) {
 		printf("IMGUPLOAD key=%s w=%d h=%d psm=%d vram=%u\n", text, image->Width, image->Height, image->PSM, image->Vram);


### PR DESCRIPTION
## Why this follow-up
The previous change removed a suspicious alpha rewrite, but the issue persisted. This patch addresses a deeper root cause in the **embedded PNG decode path**.

## Root cause
`loadEmbeddedPNG()` in `src/graphics.cpp` forced paletted PNGs through `png_set_expand`, then decoded as CT32 (RGB/RGBA).

For large fullscreen textures (`PSL/BKG/BGM/BG`), this increases texture memory pressure significantly versus indexed formats and can fail to render reliably under VRAM constraints.

This only affects embedded-asset loading path, which matches repros where assets are loaded from embedded data / extracted runtime flow.

## What changed
In `src/graphics.cpp` (`loadEmbeddedPNG`):
- Removed palette expansion (`png_set_expand`) for `PNG_COLOR_TYPE_PALETTE`.
- Added native palette decode branches for:
  - `bit_depth == 4` -> `GS_PSM_T4` + 16-entry CLUT
  - `bit_depth == 8` -> `GS_PSM_T8` + 256-entry CLUT
- Preserved tRNS alpha handling into CLUT alpha values when present.
- Kept existing RGB/RGBA decode behavior unchanged.

## Why this is durable
- Aligns embedded PNG behavior with existing file-based PNG loader behavior.
- Avoids unnecessary CT32 expansion for indexed images.
- Reduces VRAM use for large UI backgrounds/splash assets.
- Removes format-path divergence that made embedded assets behave differently from file assets.

## Expected impact
`PSL.png`, `BKG.png`, `BGM.png`, and `BG.png` should now render correctly when loaded through embedded assets as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1732d4348321b8ac8bdaacfe6d77)