### PR TITLE
Force embedded IMG assets, restore embedded-first reads, add palette PNG support and VRAM release

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -8,8 +8,8 @@
 
 LOG("Registering images")
 local function ResolveImage(name)
-  local logical = "IMG/"..name
-  return System.resolveAssetType(name, ASSET_IMG) or System.resolveAsset(logical) or JoinPath(APP_DIR_LOCAL, logical)
+  -- Force logical embedded image key first; this ensures bundled IMG/* assets are used.
+  return "IMG/"..name
 end
 
 local function IsBootBgKey(key)
@@ -114,6 +114,17 @@ IMG = setmetatable({}, {
     return img
   end
 })
+function IMG.ReleaseKey(key)
+  if key == nil then return end
+  local img = rawget(IMG, key)
+  if img ~= nil then
+    if type(Graphics) == "table" and type(Graphics.freeImage) == "function" then
+      pcall(Graphics.freeImage, img)
+    end
+    rawset(IMG, key, nil)
+  end
+  IMG_FAILED[key] = nil
+end
 function IMG.ReleaseAll()
   local free_ok = type(Graphics) == "table" and type(Graphics.freeImage) == "function"
   for key, _ in pairs(IMG_SOURCES) do

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2517,6 +2517,19 @@ function UI.OnSceneEnter(previous_scene, next_scene)
   if UI.BOOT_SOUND ~= nil and UI.BOOT_SOUND.STATE ~= nil and UI.BOOT_SOUND.STATE.path_resolved ~= true then
     return
   end
+
+  -- Keep VRAM pressure low: release large splash/background textures that are not needed
+  -- for the scene we are entering. This avoids accumulation across splash->credits->menu.
+  if IMG ~= nil and type(IMG.ReleaseKey) == "function" then
+    if next_scene == UI.SCENES.MMAIN or next_scene == UI.SCENES.MPROFILE or next_scene == UI.SCENES.CREDITS then
+      IMG.ReleaseKey("PSL")
+    end
+    if next_scene == UI.SCENES.MMAIN then
+      IMG.ReleaseKey("BG")
+    elseif next_scene == UI.SCENES.MPROFILE or next_scene == UI.SCENES.CREDITS then
+      IMG.ReleaseKey("BGM")
+    end
+  end
   if UI.IsUsbScene(next_scene) then
     if PLDR ~= nil and type(PLDR.RefreshMassSlots) == "function" then
       PLDR.RefreshMassSlots("scene-enter-usb")

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1341,9 +1341,6 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
 	png_set_strip_16(png_ptr);
 
-	if (color_type == PNG_COLOR_TYPE_PALETTE)
-		png_set_expand(png_ptr);
-
 	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
 		png_set_expand(png_ptr);
 
@@ -1411,6 +1408,106 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 		for(row = 0; row < height; row++) free(row_pointers[row]);
 
 		free(row_pointers);
+	}
+	else if(png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE){
+
+		struct png_clut { u8 r, g, b, a; };
+
+		png_colorp palette = NULL;
+		int num_pallete = 0;
+		png_bytep trans = NULL;
+		int num_trans = 0;
+
+		png_get_PLTE(png_ptr, info_ptr, &palette, &num_pallete);
+		png_get_tRNS(png_ptr, info_ptr, &trans, &num_trans, NULL);
+		tex->ClutPSM = GS_PSM_CT32;
+
+		if (bit_depth == 4) {
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T4;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+			for (i = num_pallete; i < 16; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+			for (i = 0; i < num_trans; i++) clut[i].a = (trans[i] + 1) >> 1;
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width / 2; j++) memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+			}
+
+			int byte;
+			unsigned char *tmpdst = (unsigned char *)tex->Mem;
+			unsigned char *tmpsrc = (unsigned char *)pixel;
+			for (byte = 0; byte < gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM); byte++)
+				tmpdst[byte] = (tmpsrc[byte] << 4) | (tmpsrc[byte] >> 4);
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+			free(row_pointers);
+		} else if (bit_depth == 8) {
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T8;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+			for (i = num_pallete; i < 256; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+			for (i = 0; i < num_trans; i++) clut[i].a = (trans[i] + 1) >> 1;
+
+			for (i = 0; i < num_pallete; i++) {
+				if ((i & 0x18) == 8) {
+					struct png_clut tmp = clut[i];
+					clut[i] = clut[i + 8];
+					clut[i + 8] = tmp;
+				}
+			}
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width; j++) {
+					memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+				}
+			}
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+			free(row_pointers);
+		} else {
+			DPRINTF("%s: Palette bit depth %d not supported yet!\n", __func__, bit_depth);
+			return NULL;
+		}
 	}
 	else
 	{

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -19,23 +19,6 @@ uint32_t imgThreadSize = 0;
 static u8 imgThreadStack[4096] __attribute__((aligned(16)));
 
 
-static bool isKnownFullscreenBackgroundKey(const char* key) {
-	if (key == NULL) return false;
-	return strcmp(key, "IMG/PSL.png") == 0 ||
-	       strcmp(key, "IMG/BKG.png") == 0 ||
-	       strcmp(key, "IMG/BG.png") == 0 ||
-	       strcmp(key, "IMG/BGM.png") == 0;
-}
-
-static void forceTextureOpaqueAlpha(GSTEXTURE* image) {
-	if (image == NULL || image->PSM != GS_PSM_CT32 || image->Mem == NULL) return;
-	struct pixel { u8 r, g, b, a; };
-	struct pixel* pixels = (struct pixel*)image->Mem;
-	int total = image->Width * image->Height;
-	for (int i = 0; i < total; ++i) {
-		pixels[i].a = 0x80;
-	}
-}
 // Extern symbol 
 extern void *_gp;
 
@@ -269,10 +252,6 @@ static int lua_loadimg(lua_State *L) {
 	if (image != NULL && (image->Width <= 0 || image->Height <= 0)) {
 		printf("IMGFAIL key=%s decode=ok upload=unknown w=%d h=%d psm=%d\n", text, image->Width, image->Height, image->PSM);
 		image = NULL;
-	}
-	if (image != NULL && isKnownFullscreenBackgroundKey(text)) {
-		forceTextureOpaqueAlpha(image);
-		printf("IMGALPHAFIX key=%s mode=force_opaque a=128\n", text);
 	}
 	if (image != NULL) {
 		printf("IMGUPLOAD key=%s w=%d h=%d psm=%d vram=%u\n", text, image->Width, image->Height, image->PSM, image->Vram);


### PR DESCRIPTION
### Motivation
- Ensure UI backgrounds and other `IMG/*` assets are always sourced from the embedded asset table when intended, eliminating accidental on-disk overrides. 
- Reduce VRAM pressure by releasing large splash/background textures between scenes to avoid accumulation and crashes. 
- Properly decode paletted embedded PNGs (4/8-bit) so bundled images upload to the GPU with correct CLUT/PSM handling.

### Description
- Restored embedded-first behavior in `Asset_ReadAll` by removing the previous `IMG/*` disk-preference branch so embedded assets are preferred when present. 
- Simplified `ResolveImage(name)` in `bin/POPSLDR/images.lua` to always return the logical embedded key `IMG/<name>` and added `IMG.ReleaseKey` to allow releasing individual cached images. 
- Added scene-driven texture release logic to `bin/POPSLDR/ui.lua` inside `UI.OnSceneEnter` to free large splash/background images (`PSL`, `BG`, `BGM`) when not needed. 
- Implemented paletted PNG handling in `src/graphics.cpp` (`loadEmbeddedPNG`) to support `PNG_COLOR_TYPE_PALETTE` with 4-bit and 8-bit CLUT upload and proper transparency mapping. 
- Cleaned up `src/luagraphics.cpp` image-loading logic to rely on embedded-read-first path and removed the previous forced-opaque alpha post-processing so palette alpha is preserved through the new CLUT handling.

### Testing
- Ran source searches with `rg -n "resolveAssetType|ASSET_IMG|resolveAsset\(" src -S` to verify affected call sites, which completed successfully. 
- Inspected bundled PNGs with a Python/Pillow script (checked palette entry counts and pixel extrema for `PSL.png`, `BG.png`, `BGM.png`, `BKG.png`, `USB.png`) and observed paletted images as expected. 
- Verified diffs and committed changes with `git diff` and `git commit`, which succeeded. 
- Note: runtime/emulator verification (PCSX2/PS2) could not be performed in this container; behavior should be validated in the target environment to confirm CLUT uploads and that embedded assets are used at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1732d4348321b8ac8bdaacfe6d77)