### PR TITLE
Make embedded PNG decoding match file-based loader

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1289,7 +1289,6 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 	png_infop info_ptr;
 	png_uint_32 width, height;
 	png_bytep *row_pointers;
-	pngtest_error_parameters error_parameters;
 
 	u32 sig_read = 0;
         int row, i, k=0, j, bit_depth, color_type, interlace_type;
@@ -1310,10 +1309,8 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 		png_destroy_read_struct(&png_ptr, (png_infopp)NULL, (png_infopp)NULL);
 		return NULL;
 	}
-	png_set_error_fn(png_ptr, &error_parameters, pngtest_error, pngtest_warning);
 	if(setjmp(png_jmpbuf(png_ptr)))
 	{
-		DPRINTF("%s: Got PNG Error!\n", __func__);
 		png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
 		return NULL;
 	}
@@ -1322,8 +1319,6 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 	d.buf = data;
 	d.size = size;
 	d.cur = 0;
-	//png_set_error_fn(png_ptr, &error_parameters, pngtest_error, pngtest_warning);
-	DPRINTF("%s: Info: %p %d \n",__func__, d.buf, d.size);
 	png_set_read_fn(png_ptr, (png_voidp)&d, (png_rw_ptr)PNG_read_data);
 
 	//png_init_io(png_ptr, hwc_credits_png);
@@ -1335,13 +1330,8 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
 	png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type,&interlace_type, NULL, NULL);
 
-	png_set_strip_16(png_ptr);
-
-	if (color_type == PNG_COLOR_TYPE_PALETTE)
-		png_set_expand(png_ptr);
-
-	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
-		png_set_expand(png_ptr);
+	if (bit_depth == 16) png_set_strip_16(png_ptr);
+	if (color_type == PNG_COLOR_TYPE_GRAY || bit_depth < 4) png_set_expand(png_ptr);
 
 	if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS))
 		png_set_tRNS_to_alpha(png_ptr);
@@ -1407,9 +1397,123 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
 		free(row_pointers);
 	}
+	else if(png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE)
+	{
+		struct png_clut { u8 r, g, b, a; };
+
+		png_colorp palette = NULL;
+		int num_pallete = 0;
+		png_bytep trans = NULL;
+		int num_trans = 0;
+
+		png_get_PLTE(png_ptr, info_ptr, &palette, &num_pallete);
+		png_get_tRNS(png_ptr, info_ptr, &trans, &num_trans, NULL);
+		tex->ClutPSM = GS_PSM_CT32;
+
+		if (bit_depth == 4) {
+
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T4;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+
+			for (i = num_pallete; i < 16; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+
+			for (i = 0; i < num_trans; i++)
+				clut[i].a = trans[i] >> 1;
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width / 2; j++)
+					memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+			}
+
+			int byte;
+			unsigned char *tmpdst = (unsigned char *)tex->Mem;
+			unsigned char *tmpsrc = (unsigned char *)pixel;
+
+			for (byte = 0; byte < gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM); byte++) tmpdst[byte] = (tmpsrc[byte] << 4) | (tmpsrc[byte] >> 4);
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+
+			free(row_pointers);
+
+		} else if (bit_depth == 8) {
+			int row_bytes = png_get_rowbytes(png_ptr, info_ptr);
+			tex->PSM = GS_PSM_T8;
+			tex->Mem = (u32*)memalign(128, gsKit_texture_size_ee(tex->Width, tex->Height, tex->PSM));
+
+			row_pointers = (png_byte**)calloc(height, sizeof(png_bytep));
+
+			for(row = 0; row < height; row++) row_pointers[row] = (png_bytep)malloc(row_bytes);
+
+			png_read_image(png_ptr, row_pointers);
+
+			tex->Clut = (u32*)memalign(128, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+			memset(tex->Clut, 0, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
+
+			unsigned char *pixel = (unsigned char *)tex->Mem;
+			struct png_clut *clut = (struct png_clut *)tex->Clut;
+
+			int i, j, k = 0;
+
+			for (i = num_pallete; i < 256; i++) {
+				memset(&clut[i], 0, sizeof(clut[i]));
+			}
+
+			for (i = 0; i < num_pallete; i++) {
+				clut[i].r = palette[i].red;
+				clut[i].g = palette[i].green;
+				clut[i].b = palette[i].blue;
+				clut[i].a = 0x80;
+			}
+
+			for (i = 0; i < num_trans; i++)
+				clut[i].a = trans[i] >> 1;
+
+			for (i = 0; i < num_pallete; i++) {
+				if ((i & 0x18) == 8) {
+					struct png_clut tmp = clut[i];
+					clut[i] = clut[i + 8];
+					clut[i + 8] = tmp;
+				}
+			}
+
+			for (i = 0; i < tex->Height; i++) {
+				for (j = 0; j < tex->Width; j++) {
+					memcpy(&pixel[k++], &row_pointers[i][1 * j], 1);
+				}
+			}
+
+			for(row = 0; row < height; row++) free(row_pointers[row]);
+
+			free(row_pointers);
+		}
+	}
 	else
 	{
-		DPRINTF("%s: This texture depth is not supported yet!\n", __func__);
+		DPRINTF("This texture depth is not supported yet!\n");
 		return NULL;
 	}
 	png_read_end(png_ptr, NULL);


### PR DESCRIPTION
### Motivation
- Embedded PNGs failed to decode because `loadEmbeddedPNG()` used different libpng transforms and lacked palette handling compared to the file-based `loadpng(FILE*)` implementation.
- The change aims to make embedded PNG decoding behavior identical to the file-path loader so embedded PNG backgrounds render the same as external PNGs.

### Description
- Adjusted libpng transform calls in `loadEmbeddedPNG()` to only call `png_set_strip_16` when `bit_depth == 16` and to call `png_set_expand` only for grayscale or very low bit depths (`color_type == PNG_COLOR_TYPE_GRAY || bit_depth < 4`), removing the previous palette-triggered expansion.
- Added the missing `PNG_COLOR_TYPE_PALETTE` branch to `loadEmbeddedPNG()` and copied the T4/T8 CLUT decoding logic from `loadpng(FILE*)`, including palette/tRNS handling, T4 nibble swap, and T8 CLUT rotation.
- Kept upload and memory lifetime semantics consistent with `loadpng(FILE*)`: allocate VRAM/CLUT VRAM, call `gsKit_texture_upload`, then free `Mem` and `Clut` after upload.
- Removed embedded-PNG debug/info prints from `loadEmbeddedPNG()` to silence extraneous logging.

### Testing
- Ran whitespace and diff checks (`git diff --check`) with no reported issues.
- Performed repository searches to verify the palette branch and debug-print removals were added/removed as intended, which matched expectations.
- Recorded the changes locally and created the PR for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e14cea76483219231adf5f0c9dd92)