### PR TITLE
Fix Color.new alpha range to 0..255

### DIFF
--- a/src/luaScreen.cpp
+++ b/src/luaScreen.cpp
@@ -155,7 +155,7 @@ static int lua_color(lua_State *L) {
 	int g = luaL_checkinteger(L, 2);
 	int b = luaL_checkinteger(L, 3);
 	int a = 0x80;
-	if (argc==4) a = CLAMP(luaL_checkinteger(L, 4), 0, 128);
+	if (argc==4) a = CLAMP(luaL_checkinteger(L, 4), 0, 255);
 	int color = r | (g << 8) | (b << 16) | (a << 24);
 	lua_pushinteger(L,color);
 	return 1;


### PR DESCRIPTION
### Motivation
- Lua `Color.new(r,g,b,a)` was clamping alpha to `0..128`, which mismatched the UI fade semantics that use `0..255`, causing embedded splash/background images to render nearly invisible during fades.

### Description
- Change the alpha clamp in `src/luaScreen.cpp` inside `static int lua_color(lua_State *L)` from `CLAMP(..., 0, 128)` to `CLAMP(..., 0, 255)` so explicit 0..255 alpha values are preserved.

### Testing
- Attempted automated build with `make all`, but the build could not complete in this environment due to a missing PS2SDK include (`/samples/Makefile.eeglobal`), so runtime ELF validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e41eaa900832193ba22c68a111fdd)