### PR TITLE
Fix unsafe CLAMP usage with luaL_checkinteger; prevent overflow and double evaluation

### DIFF
--- a/src/luaScreen.cpp
+++ b/src/luaScreen.cpp
@@ -155,7 +155,16 @@ static int lua_color(lua_State *L) {
 	int g = luaL_checkinteger(L, 2);
 	int b = luaL_checkinteger(L, 3);
 	int a = 0x80;
-	if (argc==4) a = CLAMP((int)luaL_checkinteger(L, 4), 0, 128);
+	if (argc == 4) {
+		const lua_Integer alpha = luaL_checkinteger(L, 4);
+
+		// Clamp in lua_Integer domain to avoid overflow
+		lua_Integer clamped = alpha;
+		if (clamped < 0) clamped = 0;
+		else if (clamped > 128) clamped = 128;
+
+		a = (int)clamped;
+	}
 	int color = r | (g << 8) | (b << 16) | (a << 24);
 	lua_pushinteger(L,color);
 	return 1;


### PR DESCRIPTION
### Motivation
- Prevent macro double-evaluation and integer overflow by avoiding passing `luaL_checkinteger()` (or casts) directly into the `CLAMP` macro.

### Description
- In `src/luaScreen.cpp` read `luaL_checkinteger(L, 4)` exactly once into `const lua_Integer alpha`, clamp `alpha` in the `lua_Integer` domain with explicit bounds checks to `[0, 128]`, then cast the clamped value to `int`, preserving the default `a = 0x80`.

### Testing
- Ran the repository sweep `rg -n "CLAMP\(luaL_|CLAMP\(\(int\)|CLAMP\(\(float\)|CLAMP\(\(double\)"` which returned no remaining matches and committed the fix (commit created), indicating the unsafe pattern was removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7b8b64588321bd73414a22962085)