### PR TITLE
Phase A: single POPStarter profile, centralize path resolution, disable runtime autosaves

### DIFF
--- a/bin/POPSLDR/pops_profiles.lua
+++ b/bin/POPSLDR/pops_profiles.lua
@@ -6,10 +6,8 @@
   Licensed under GNU General public license v3.0
 --]]
 LOG("Registering POPStarter profiles...")
-local DEFAULT_PROFILE = 1 -- change this for a different default profile. default package points to local popstarter path
+local DEFAULT_PROFILE = 1
 PLDR.DEFAULT_PROFILE = DEFAULT_PROFILE
--- to register an ELF that is stored on the same folder than POPSLOADER, please do it this way:
--- System.currentDirectory().."/POPSTARTER.ELF"
 
 local function NormalizeDirPathCompat(path)
   if NormalizeDirPath ~= nil then
@@ -38,34 +36,10 @@ end
 
 local APP_DIR_LOCAL = NormalizeDirPathCompat(APP_DIR or System.currentDirectory())
 
-local function ResolveProfilePath(rel)
-  return System.resolveAsset(rel) or JoinPathCompat(APP_DIR_LOCAL, rel)
-end
-
 PLDR.PROFILES = {
   {
-    ELF="POPSTARTER.ELF";
+    ELF=JoinPathCompat(APP_DIR_LOCAL, "POPSTARTER.ELF");
     DESC="PopStarter located next to POPSLOADER.ELF";
-  },
-  {
-    ELF=ResolveProfilePath("PROFILES/MAIN/POPSTARTER.ELF");
-    DESC="Latest popstarter without any modifications";
-  },
-  {
-    ELF=ResolveProfilePath("PROFILES/DEBUG/POPSTARTER.ELF");
-    DESC="Latest popstarter with debug menus enabled";
-  },
-  {
-    ELF=ResolveProfilePath("PROFILES/USBDELAY/POPSTARTER.ELF");
-    DESC="Latest popstarter with increased USB delay";
-  },
-  {
-    ELF=ResolveProfilePath("PROFILES/USBDELAY_DEBUG/POPSTARTER.ELF");
-    DESC="Latest popstarter with increased USB delay & debug menus enabled";
-  },
-  {
-    ELF="mass:/POPS/POPSTARTER.ELF";
-    DESC="the POPSTARTER ELF located on the POPS folder";
   },
 }
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -203,6 +203,10 @@ PLDR = {
   }
 }
 
+function PLDR.ResolvePopstarterPath(path)
+  return ResolvePopstarterPath(path)
+end
+
 -- Mass backend detection via USBMASS_IOCTL_GET_DRIVERNAME (requires fileXio + ps2sdk usbhdfsd-common.h support).
 -- Returns a short driver code like: "usb" (USB), "sdc" (MX4SIO SD), "udp" (UDPBD), "sd" (iLink SD), "ata" (HDD).
 function PLDR.GetMassDriverName(index)
@@ -438,7 +442,9 @@ function PLDR.ApplyProfileSetting()
   end
   PLDR.SETTINGS.profile_index = index
   if PLDR.PROFILES[index] ~= nil and PLDR.PROFILES[index].ELF ~= nil then
-    PLDR.POPSTARTER_PATH = PLDR.PROFILES[index].ELF
+    PLDR.POPSTARTER_PATH = ResolvePopstarterPath(PLDR.PROFILES[index].ELF)
+  else
+    PLDR.POPSTARTER_PATH = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
   end
 end
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1482,9 +1482,6 @@ end
         UI.HideUI = not UI.HideUI
         if PLDR ~= nil and PLDR.SETTINGS ~= nil then
           PLDR.SETTINGS.hide_ui = UI.HideUI
-          if PLDR.SaveSettings ~= nil then
-            PLDR.SaveSettings()
-          end
         end
         return true
       end
@@ -1618,9 +1615,6 @@ end
           UI.GameList.SHOW_COVER = not UI.GameList.SHOW_COVER
           if PLDR ~= nil and PLDR.SETTINGS ~= nil then
             PLDR.SETTINGS.show_cover = UI.GameList.SHOW_COVER
-            if PLDR.SaveSettings ~= nil then
-              PLDR.SaveSettings()
-            end
           end
         end
         UI.GameList.LAST_SQUARE_DOWN = square_down
@@ -1752,7 +1746,11 @@ end
           UI.ProfileQuery.curopt = CLAMP(default_profile, 1, profcnt)
           local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
           if profile ~= nil then
-            PLDR.POPSTARTER_PATH = profile.ELF
+            if PLDR.ResolvePopstarterPath ~= nil then
+              PLDR.POPSTARTER_PATH = PLDR.ResolvePopstarterPath(profile.ELF)
+            else
+              PLDR.POPSTARTER_PATH = profile.ELF
+            end
           end
           if PLDR.SETTINGS ~= nil then
             PLDR.SETTINGS.profile_index = UI.ProfileQuery.curopt
@@ -1792,10 +1790,15 @@ end
           if PLDR.SaveSettings ~= nil then
             PLDR.SaveSettings()
           end
-          if not doesFileExist(PLDR.PROFILES[UI.ProfileQuery.curopt].ELF) then
+          local selected_elf = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
+          if PLDR.ResolvePopstarterPath ~= nil then
+            PLDR.POPSTARTER_PATH = PLDR.ResolvePopstarterPath(selected_elf)
+          else
+            PLDR.POPSTARTER_PATH = selected_elf
+          end
+          if not doesFileExist(PLDR.POPSTARTER_PATH) then
             UI.Notif_queue.add("POPStarter ELF missing")
           else
-            PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
             UI.ProfileQuery.bdma_mode = nil
             UI.SceneChange(UI.SCENES.MMAIN)
           end


### PR DESCRIPTION
### Motivation
- Simplify POPStarter profile handling so only the default profile remains to avoid profile-indexing errors and confusion. 
- Fix false "missing POPSTARTER" reports by resolving relative POPSTARTER paths against the application directory once during initialization. 
- Prevent unintended/many filesystem writes by removing autosave calls from runtime toggles and restricting persistence to the settings page.

### Description
- Reduced `PLDR.PROFILES` to a single entry pointing to `POPSTARTER.ELF` next to `POPSLOADER.ELF` and set `PLDR.DEFAULT_PROFILE = 1`, ensuring `#PLDR.PROFILES == 1` (file: `bin/POPSLDR/pops_profiles.lua`).
- Added a centralized resolver and small API: the existing `ResolvePopstarterPath` function is exposed via `PLDR.ResolvePopstarterPath`, and `PLDR.ApplyProfileSetting()` now resolves and stores a fully-qualified POPSTARTER path once during initialization (file: `bin/POPSLDR/system.lua`).
- UI changes in `bin/POPSLDR/ui.lua` remove immediate `PLDR.SaveSettings()` calls from the runtime toggles for Select (Hide UI) and Square (Cover Art), while leaving settings-page save flows unchanged so only the Settings/Profile page persists to disk.
- Updated profile-selection and profile-confirm flows to use the centralized resolver and to validate existence using the resolved `PLDR.POPSTARTER_PATH` before accepting the profile.

### Testing
- Ran a Python static-check that asserts exactly one profile entry in `bin/POPSLDR/pops_profiles.lua`, which passed.
- Searched the UI code for `SaveSettings()` occurrences to confirm autosave calls were removed from runtime toggles and retained in settings/profile flows, which matched expectations (grep results inspected).
- Attempted to run a Lua syntax check (`luac -p`) but it could not be executed in this environment because `luac` is not installed (syntax check unavailable).
- Manual verification checklist prepared for runtime validation (toggle Cover Art with Square, toggle Hide UI with Select, reboot persistence only after save from Settings, confirm POPSTARTER detection when `POPSTARTER.ELF` is next to `POPSLOADER.ELF`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1fcb8d408321b0ede3c330069764)