### PR TITLE
Apply BDMA only during settings saves

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -841,7 +841,7 @@ function PLDR.ApplyBDMAOnSettingsSave(mode)
         end
       end
     end
-  elseif mode == 2 or mode == 3 or mode == 4 then
+  elseif entry.action == "copy" then
     if not EnsureDirectory(dest_root) then
       ok = false
     else

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -425,22 +425,22 @@ PLDR.DEFAULT_DKWDRV_PATH = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
 local BDMA_MODES = {
   {
     label = "USBFAT32(None)",
-    ext = nil,
+    source_suffix = nil,
     action = "delete"
   },
   {
     label = "USBEXFAT",
-    ext = ".usbexfat",
+    source_suffix = ".exfat",
     action = "copy"
   },
   {
     label = "MMCE",
-    ext = ".mmce",
+    source_suffix = ".mmce",
     action = "copy"
   },
   {
     label = "MX4SIO",
-    ext = ".mx4sio",
+    source_suffix = ".mx4sio",
     action = "copy"
   }
 }
@@ -811,57 +811,62 @@ local function RemoveDirectoryRecursive(path)
   return true
 end
 
-function PLDR.ApplyBDMAMode()
-  local mode = PLDR.GetBDMAMode()
+function PLDR.ApplyBDMAOnSettingsSave(mode)
+  local selected_mode = tonumber(mode) or PLDR.GetBDMAMode()
+  local count = PLDR.GetBDMAModeCount()
+  if selected_mode < 1 then selected_mode = 1 end
+  if selected_mode > count then selected_mode = count end
+  local mode = selected_mode
   local entry = BDMA_MODES[mode] or BDMA_MODES[1]
   local label = entry.label
-  LOG("BDMA apply start: "..label)
+  local dest_root = NormalizeDirPath("mc0:/POPSTARTER/")
+  local targets = {
+    {
+      dest = JoinPath(dest_root, "usbd.irx"),
+      source = "usbd.irx"
+    },
+    {
+      dest = JoinPath(dest_root, "usbhdfsd.irx"),
+      source = "usbhdfsd.irx"
+    }
+  }
   local ok = true
   if entry.action == "delete" then
-    LOG("BDMA delete: mc0:/POPSTARTER/")
-    if doesFolderExist("mc0:/POPSTARTER/") then
-      local rm_ok, rm_err = RemoveDirectoryRecursive("mc0:/POPSTARTER/")
-      if not rm_ok then
-        LOG("BDMA delete failed:", rm_err)
-        ok = false
-      end
-      local dir_ok, dir_err = pcall(System.removeDirectory, "mc0:/POPSTARTER/")
-      if not dir_ok then
-        LOG("BDMA remove dir failed:", dir_err)
-        ok = false
+    for i = 1, #targets do
+      local target = targets[i]
+      if doesFileExist(target.dest) then
+        local rm_ok = pcall(System.removeFile, target.dest)
+        if not rm_ok then
+          ok = false
+        end
       end
     end
-  else
-    local dest_root = NormalizeDirPath("mc0:/POPSTARTER/")
+  elseif mode == 2 or mode == 3 or mode == 4 then
     if not EnsureDirectory(dest_root) then
       ok = false
-    end
-    local source_root = NormalizeDirPath(APP_DIR_LOCAL)
-    local ok_list, entries = pcall(System.listDirectory, source_root)
-    if not ok_list or entries == nil then
-      LOG("BDMA list failed:", source_root, entries)
-      ok = false
     else
-      local suffix = entry.ext
-      for i = 1, #entries do
-        local file = entries[i]
-        if file ~= nil and not file.directory and file.name ~= nil then
-          local dest_name = StripSuffixCaseInsensitive(file.name, suffix)
-          if dest_name ~= nil and dest_name ~= "" then
-            local src = JoinPath(source_root, file.name)
-            local dst = JoinPath(dest_root, dest_name)
-            LOG("BDMA copy: "..src.." -> "..dst)
-            local ok_copy, copy_err = pcall(System.copyFile, src, dst)
-            if not ok_copy then
-              LOG("BDMA copy failed:", copy_err)
-              ok = false
-            end
+      local source_root = NormalizeDirPath(APP_DIR_LOCAL)
+      for i = 1, #targets do
+        local target = targets[i]
+        local src = JoinPath(source_root, target.source..entry.source_suffix)
+        if doesFileExist(src) then
+          local removed = true
+          if doesFileExist(target.dest) then
+            removed = pcall(System.removeFile, target.dest)
           end
+          local ok_copy = false
+          if removed then
+            ok_copy = pcall(System.copyFile, src, target.dest)
+          end
+          if not ok_copy then
+            ok = false
+          end
+        else
+          ok = false
         end
       end
     end
   end
-  LOG("BDMA apply done: "..label.." ("..(ok and "ok" or "fail")..")")
   if ok then
     if entry.action == "delete" then
       PLDR.SETTINGS.bdma_last_label = nil
@@ -869,10 +874,11 @@ function PLDR.ApplyBDMAMode()
       PLDR.SETTINGS.bdma_last_label = label
     end
   end
-  if ok and UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
-    UI.Notif_queue.add("BDMA Applied")
-  end
   return ok
+end
+
+function PLDR.ApplyBDMAMode(mode)
+  return PLDR.ApplyBDMAOnSettingsSave(mode)
 end
 
 function PLDR.ApplyPopstarterPack(pack_key)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1675,7 +1675,7 @@ end
         local profcnt = #PLDR.PROFILES
         local hide_ui = UI.ShouldHideUI()
         if UI.ProfileQuery.bdma_mode == nil then
-          if PLDR.GetBDMAMode ~= nil then
+          if PLDR.GetBDMAMode then
             UI.ProfileQuery.bdma_mode = PLDR.GetBDMAMode()
           else
             UI.ProfileQuery.bdma_mode = 1
@@ -1769,7 +1769,7 @@ end
             PLDR.SETTINGS.profile_index = UI.ProfileQuery.curopt
             PLDR.SETTINGS.dkwdrv_path = PLDR.DEFAULT_DKWDRV_PATH or "mc0:/PS1_DKWDRV/DKWDRV.ELF"
           end
-          if PLDR.GetBDMAMode ~= nil then
+          if PLDR.GetBDMAMode then
             UI.ProfileQuery.bdma_mode = PLDR.GetBDMAMode()
           end
           local save_ok = false
@@ -1777,7 +1777,7 @@ end
             save_ok = PLDR.SaveSettings()
           end
           if save_ok and PLDR.ApplyBDMAOnSettingsSave ~= nil then
-            PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
+            PLDR.ApplyBDMAOnSettingsSave((PLDR.GetBDMAMode and PLDR.GetBDMAMode()) or nil)
           end
           if save_ok then
             UI.Notif_queue.add("Profile defaults restored")
@@ -1792,7 +1792,7 @@ end
               if PLDR.SaveSettings ~= nil then
                 if PLDR.SaveSettings() then
                   if PLDR.ApplyBDMAOnSettingsSave ~= nil then
-                    PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
+                    PLDR.ApplyBDMAOnSettingsSave((PLDR.GetBDMAMode and PLDR.GetBDMAMode()) or nil)
                   end
                   if UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
                     UI.Notif_queue.add("DKWDRV path saved")
@@ -1828,7 +1828,7 @@ end
             pop_ok = doesFileExist(PLDR.POPSTARTER_PATH)
           end
           if save_ok and PLDR.ApplyBDMAOnSettingsSave ~= nil then
-            PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
+            PLDR.ApplyBDMAOnSettingsSave((PLDR.GetBDMAMode and PLDR.GetBDMAMode()) or nil)
           end
           if not pop_ok then
             UI.Notif_queue.add("POPStarter ELF missing")
@@ -1889,7 +1889,7 @@ end
             return "NONE"
           end
           local mode = nil
-          if PLDR.GetBDMAMode ~= nil then
+          if PLDR.GetBDMAMode then
             mode = PLDR.GetBDMAMode()
           end
           local raw = PLDR.GetBDMAModeText(mode)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1776,6 +1776,9 @@ end
           if PLDR.SaveSettings ~= nil then
             save_ok = PLDR.SaveSettings()
           end
+          if save_ok and PLDR.ApplyBDMAOnSettingsSave ~= nil then
+            PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
+          end
           if save_ok then
             UI.Notif_queue.add("Profile defaults restored")
           else
@@ -1788,6 +1791,9 @@ end
               PLDR.SETTINGS.dkwdrv_path = new_value
               if PLDR.SaveSettings ~= nil then
                 if PLDR.SaveSettings() then
+                  if PLDR.ApplyBDMAOnSettingsSave ~= nil then
+                    PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
+                  end
                   if UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
                     UI.Notif_queue.add("DKWDRV path saved")
                   end
@@ -1801,9 +1807,6 @@ end
         if UI.Pad.Events.CONFIRM then
           if PLDR.SetBDMAMode ~= nil then
             PLDR.SetBDMAMode(UI.ProfileQuery.bdma_mode)
-          end
-          if PLDR.ApplyBDMAMode ~= nil then
-            PLDR.ApplyBDMAMode()
           end
           if PLDR.SETTINGS ~= nil then
             PLDR.SETTINGS.profile_index = UI.ProfileQuery.curopt
@@ -1823,6 +1826,9 @@ end
             pop_ok, PLDR.POPSTARTER_PATH = PLDR.PopstarterExists(PLDR.POPSTARTER_PATH)
           else
             pop_ok = doesFileExist(PLDR.POPSTARTER_PATH)
+          end
+          if save_ok and PLDR.ApplyBDMAOnSettingsSave ~= nil then
+            PLDR.ApplyBDMAOnSettingsSave(PLDR.GetBDMAMode ~= nil and PLDR.GetBDMAMode() or nil)
           end
           if not pop_ok then
             UI.Notif_queue.add("POPStarter ELF missing")


### PR DESCRIPTION
### Motivation
- BDMA was previously coupled into the launch flow and could stage/verify files during game launches, which contradicts the authoritative design requiring BDMA to run only when saving settings.
- The change must apply BDMA mechanics strictly to the two POPStarter IRX targets and must not gate or verify launches.

### Description
- Added `PLDR.ApplyBDMAOnSettingsSave(mode)` implementing authoritative BDMA mechanics that operate only on `mc0:/POPSTARTER/usbd.irx` and `mc0:/POPSTARTER/usbhdfsd.irx`, deleting them for FAT32 (BDMA OFF) or copying/overwriting from exact variant sidecars (`.exfat`, `.mmce`, `.mx4sio`) for BDMA ON modes after ensuring `mc0:/POPSTARTER/` exists.
- Updated `BDMA_MODES` metadata to map explicit source suffixes used by the new copy logic and removed the previous directory-sweep/copy behavior.
- Kept `PLDR.ApplyBDMAMode(mode)` as a compatibility wrapper that forwards to the new function.
- Removed BDMA staging from the settings UI pre-save code path and now invoke `PLDR.ApplyBDMAOnSettingsSave(...)` only after successful `PLDR.SaveSettings()` in all settings/profile save flows (restore defaults, DKWDRV edit, and confirm/save).
- Preserved hard rules: no debug prints/logs were added; launch logic and gating remain untouched and BDMA failures are non-blocking for launches.

### Testing
- Ran code searches with `rg` to confirm BDMA references were updated and that BDMA is no longer invoked from launch paths; the searches returned the expected updated locations (success).
- Ran `rg` to confirm `PLDR.ApplyBDMAMode` still exists as a wrapper and that `PLDR.ApplyBDMAOnSettingsSave` is referenced only from settings save flows (success).
- Attempted a quick syntax/load check with `lua -e "assert(loadfile('bin/POPSLDR/system.lua')); assert(loadfile('bin/POPSLDR/ui.lua'))"` but the `lua` binary is not available in this environment (check failed); manual inspection of the modified files was performed to validate the diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f44636a448321827a6d2c92a5f170)