### PR TITLE
USB: bounded retry roots discovery and stronger POPS probe to include multi-USB

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -422,9 +422,25 @@ function PLDR.IsUsbMassIndex(i)
 end
 
 function PLDR.ProbeMassHasPops(i)
-  local path = "mass"..tostring(i)..":/POPS/"
-  local ok, dir = pcall(System.listDirectory, path)
-  return ok and type(dir) == "table"
+  local base = "mass"..tostring(i)..":/POPS"
+  local probes = {
+    { kind = "list", path = base.."/" },
+    { kind = "list", path = base },
+    { kind = "open", path = base.."/" },
+    { kind = "open", path = base },
+  }
+  for idx = 1, #probes do
+    local probe = probes[idx]
+    if probe.kind == "list" then
+      local ok, dir = pcall(System.listDirectory, probe.path)
+      if ok and type(dir) == "table" then
+        return true
+      end
+    elseif OpenProbe(probe.path) then
+      return true
+    end
+  end
+  return false
 end
 
 function PLDR.FindMassByDriver(driver, max_index)
@@ -1385,26 +1401,46 @@ function PLDR.GetPS1GameLists(path, updating)
 end
 
 function PLDR.GetActiveUsbRoots(max_index)
-  local roots = {}
   PLDR.EnsureMassReady()
   local max = tonumber(max_index) or 9
   if max < 0 then max = 0 end
   if max > 9 then max = 9 end
-  for i = 0, max do
-    pcall(System.listDirectory, "mass"..tostring(i)..":/")
-    local mx_index = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.MASSINDX or nil
-    if mx_index ~= nil and mx_index == i then
-      goto continue
+
+  local function pass()
+    local roots = {}
+    for i = 0, max do
+      pcall(System.listDirectory, "mass"..tostring(i)..":/")
+      local mx_index = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.MASSINDX or nil
+      if mx_index ~= nil and mx_index == i then
+        goto continue
+      end
+      local dn = PLDR.MassDriverName(i)
+      if dn == "sdc" then
+        goto continue
+      end
+      if PLDR.ProbeMassHasPops(i) then
+        table.insert(roots, "mass"..tostring(i)..":/")
+      end
+      ::continue::
     end
-    local dn = PLDR.MassDriverName(i)
-    if dn == "sdc" then
-      goto continue
-    end
-    if PLDR.ProbeMassHasPops(i) then
-      table.insert(roots, "mass"..tostring(i)..":/")
-    end
-    ::continue::
+    return roots
   end
+
+  local roots = pass()
+  if #roots > 0 then
+    return roots
+  end
+
+  for attempt = 1, 2 do
+    for i = 0, max do
+      pcall(System.listDirectory, "mass"..tostring(i)..":/")
+    end
+    roots = pass()
+    if #roots > 0 then
+      return roots
+    end
+  end
+
   return roots
 end
 


### PR DESCRIPTION
### Motivation
- The USB listing could miss a second USB device because mounts can appear after a single discovery pass, so discovery needs a bounded retry to catch late-mounted devices. 
- POPS presence checks were brittle because they only tested `massX:/POPS/` via `System.listDirectory`, which can miss valid targets with different trailing-slash semantics or when only file-open succeeds. 
- MX4SIO (`sdc`) must never be included on the USB page, and discovery must remain shallow without enumerating game files.

### Description
- Strengthened `PLDR.ProbeMassHasPops(i)` to probe both `mass{i}:/POPS/` and `mass{i}:/POPS` using `System.listDirectory` first and falling back to `OpenProbe`, returning `true` on any successful probe. 
- Reworked `PLDR.GetActiveUsbRoots(max_index)` to run a single-pass `pass()` function that nudges mounts via `pcall(System.listDirectory, "massN:/")`, skips the MX4SIO index and any `sdc` drivers, and collects roots where `PLDR.ProbeMassHasPops(i)` succeeds. 
- Added a bounded retry loop that performs up to two additional quick nudge+pass attempts if the initial pass finds no roots, with the probe range clamped to `0..9`. 
- Kept discovery shallow by only probing for POPS existence and nudging mount tables, avoiding any game-file enumeration during root detection.

### Testing
- Verified presence and locations of the new functions and probes with `rg -n "GetActiveUsbRoots|ProbeMassHasPops|mass\\d+:/POPS" bin/POPSLDR/system.lua` and confirmed matches. 
- Inspected the updated `bin/POPSLDR/system.lua` diff and confirmed the intended additions and removals (new multi-probe logic and bounded retry wrapper). 
- Local repository status and file-level review show the modification applied successfully to `bin/POPSLDR/system.lua`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a058c7be888321a6098ad4154cca3e)