### PR TITLE
Perf: localize mass index nudges to device discovery; stop doing it in hot paths

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -269,6 +269,9 @@ local function ResolvePopstarterPath(path)
     if PLDR ~= nil and PLDR.EnsureMassReady ~= nil then
       PLDR.EnsureMassReady()
     end
+    if PLDR ~= nil and PLDR.TouchMassIndices ~= nil then
+      PLDR.TouchMassIndices(9)
+    end
     local suffix = string.sub(candidate, 7)
     for i = 0, 9 do
       local c = "mass"..tostring(i)..":/"..suffix
@@ -362,7 +365,6 @@ function PLDR.GetPopstarterProbeStatus()
   local path = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
   if string.match(path or "", "^mass%d*:/") or string.match(path or "", "^mass:/") then
     PLDR.EnsureMassReady()
-    PLDR.TouchMassIndices(9)
   end
   return path, OpenProbe(path)
 end
@@ -376,7 +378,6 @@ function PLDR.PopstarterExists(path)
   local target = ResolvePopstarterPath(path or PLDR.POPSTARTER_PATH)
   if string.match(target or "", "^mass%d*:/") or string.match(target or "", "^mass:/") then
     PLDR.EnsureMassReady()
-    PLDR.TouchMassIndices(9)
   end
   local exists = FileExistsOpenProbe(target)
   if exists then
@@ -489,7 +490,11 @@ function PLDR.EnsureUsbReady()
 end
 
 function PLDR.TouchMassIndices(max_index)
-  max_index = tonumber(max_index) or 9
+  if max_index == nil then
+    max_index = 9
+  else
+    max_index = tonumber(max_index) or 9
+  end
   if max_index < 0 then max_index = 0 end
   if max_index > 9 then max_index = 9 end
   pcall(System.listDirectory, "mass:/")
@@ -500,26 +505,31 @@ end
 
 function PLDR.EnsureMassReady()
   if PLDR._mass_ready then
-    PLDR.TouchMassIndices(9)
     return true
   end
   PLDR.EnsureUsbReady()
   PLDR.DetectMassBackends()
-  PLDR.TouchMassIndices(9)
 
-  local any = false
-  for i = 0, 9 do
-    local root = "mass"..tostring(i)..":/"
-    if doesFolderExist(root) or OpenProbe(root) then
-      any = true
-      break
-    end
+  local detected_index = nil
+  if PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.MASSINDX ~= nil then
+    detected_index = tonumber(PLDR.USB.MASSINDX)
+  end
+  if detected_index == nil and PLDR ~= nil and PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil then
+    detected_index = tonumber(PLDR.MX4SIO.MASSINDX)
+  end
+  if detected_index ~= nil and detected_index >= 0 and detected_index <= 9 then
+    pcall(System.listDirectory, "mass"..tostring(detected_index)..":/")
+  else
+    pcall(System.listDirectory, "mass:/")
   end
 
+  local any = false
+  if detected_index ~= nil and detected_index >= 0 and detected_index <= 9 then
+    local root = "mass"..tostring(detected_index)..":/"
+    any = doesFolderExist(root) or OpenProbe(root)
+  end
   if not any then
-    if doesFolderExist("mass:/") or OpenProbe("mass:/") then
-      any = true
-    end
+    any = doesFolderExist("mass:/") or OpenProbe("mass:/")
   end
 
   PLDR._mass_ready = (any == true)
@@ -537,9 +547,7 @@ function PLDR.CanonicalizeMassRoot(root)
 
   PLDR.EnsureMassReady()
 
-  for i = 0, 9 do
-    pcall(System.listDirectory, "mass"..tostring(i)..":/")
-  end
+  PLDR.TouchMassIndices(9)
 
   for i = 0, 9 do
     local dn = PLDR.MassDriverName(i)
@@ -1432,9 +1440,7 @@ function PLDR.GetActiveUsbRoots(max_index)
   end
 
   for attempt = 1, 2 do
-    for i = 0, max do
-      pcall(System.listDirectory, "mass"..tostring(i)..":/")
-    end
+    PLDR.TouchMassIndices(max)
     roots = pass()
     if #roots > 0 then
       return roots

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1691,10 +1691,13 @@ end
         if #dkwdrv_label > 52 then
           dkwdrv_label = "..."..string.sub(dkwdrv_label, -49)
         end
-        local popstarter_path = (PLDR and PLDR.GetResolvedPopstarterPath and PLDR.GetResolvedPopstarterPath()) or (PLDR and PLDR.POPSTARTER_PATH) or "POPSTARTER.ELF"
+        local popstarter_path = (PLDR and PLDR.POPSTARTER_PATH) or "POPSTARTER.ELF"
         local popstarter_ok = false
-        if PLDR ~= nil and PLDR.GetPopstarterProbeStatus ~= nil then
-          popstarter_path, popstarter_ok = PLDR.GetPopstarterProbeStatus()
+        if type(popstarter_path) == "string" and popstarter_path ~= "" then
+          popstarter_ok = doesFileExist(popstarter_path)
+          if not popstarter_ok and PLDR ~= nil and PLDR.OpenProbe ~= nil then
+            popstarter_ok = PLDR.OpenProbe(popstarter_path)
+          end
         end
         local boot_elf_path = (PLDR and PLDR.GetLaunchElfPath and PLDR.GetLaunchElfPath()) or "POPSLOADER.ELF"
         local boot_elf_ok = false
@@ -2171,8 +2174,8 @@ end
             end
 
             if not ready then
-              for i = 0, 9 do
-                pcall(System.listDirectory, "mass"..tostring(i)..":/")
+              if PLDR.TouchMassIndices ~= nil then
+                PLDR.TouchMassIndices(9)
               end
               local mx = nil
               for i = 0, 9 do


### PR DESCRIPTION
### Motivation
- Settings open/close experienced heavy lag caused by repeated mass index nudges (`mass0..9`) run from hot paths like `EnsureMassReady()` and POPSTARTER probes. 
- The goal is to keep `EnsureMassReady()` lightweight and only perform broad `mass0..9` nudges during explicit device discovery flows (USB roots, MX4SIO fallback, POPSTARTER canonicalization).

### Description
- Stopped unconditional mass0..9 nudging inside `PLDR.EnsureMassReady()` so it no longer iterates 0..9 on every call and instead probes only `mass:/` or a single detected index derived from `PLDR.USB.MASSINDX` or `PLDR.MX4SIO.MASSINDX`.
- Made `PLDR.TouchMassIndices(max_index)` the single explicit helper for broad nudging, added robust parameter handling, and used it where broad nudging is appropriate.
- Localized broad nudges to explicit discovery/canonicalization flows by calling `PLDR.TouchMassIndices(...)` from `ResolvePopstarterPath` (when candidate starts with `mass:/`), `PLDR.CanonicalizeMassRoot`, and the retry path in `PLDR.GetActiveUsbRoots` instead of leaving them in hot helpers.
- Removed redundant direct `PLDR.TouchMassIndices(9)` calls from probe helpers (`PLDR.GetPopstarterProbeStatus`, `PLDR.PopstarterExists`) so UI/hot paths do not trigger mass-wide touches.

### Testing
- Ran repository searches to validate remaining `mass` nudges with `rg -n "listDirectory\(\"mass\"\.|for i.?=.?0, 9" bin/POPSLDR/system.lua` and inspected results to confirm broad nudges are now constrained to discovery/canonicalization paths; the search completed successfully.
- Performed a diff and committed the change with `git commit -m "Perf: localize mass index nudges to device discovery; stop doing it in hot paths"` and verified the commit with `git show --stat --oneline HEAD`.
- Applied a small automated patch/replace step using a Python helper script to update `ResolvePopstarterPath` and remove redundant nudges; the script ran successfully and the file was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05957e0288321aae64f14697d86ac)