### PR TITLE
UI: fix launch precheck nil concat; validate selection and use computed launch_path

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2486,13 +2486,24 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
       prefix_used = ""
     end
   end
-  local argv = {argv0_selector}
+  local argv = {}
 
   if policy.name ~= "HDD" then
-    -- bootparam_basename_used is the authoritative "XX.<VCDNAME>" string
-    if bootparam_basename_used ~= nil and bootparam_basename_used ~= "" then
-      table.insert(argv, bootparam_basename_used)
+    -- Use the already computed basename; ensure it ends with ".ELF"
+    local bootarg = bootparam_basename_used
+    if bootarg == nil or bootarg == "" then
+      if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
+        UI.Notif_queue.add("Launch failed: missing boot basename")
+      end
+      return
     end
+    if not string.match(bootarg, "%.ELF$") then
+      bootarg = bootarg..".ELF"
+    end
+    argv = {bootarg}
+  else
+    -- Preserve existing HDD argv behavior.
+    argv = {argv0_selector}
   end
 
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -446,6 +446,60 @@ function PLDR.MassHasPops(i)
   return false
 end
 
+function PLDR.MassHasPopsAlias()
+  local base = "mass:/POPS"
+
+  local ok1, d1 = pcall(System.listDirectory, base.."/")
+  if ok1 and type(d1) == "table" then return true end
+
+  local ok2, d2 = pcall(System.listDirectory, base)
+  if ok2 and type(d2) == "table" then return true end
+
+  if OpenProbe(base.."/") or OpenProbe(base) then return true end
+  return false
+end
+
+function PLDR.GetMassAliasDriverName()
+  if System == nil then
+    return nil
+  end
+
+  pcall(System.listDirectory, "mass:/")
+
+  local function normalize(name)
+    if type(name) ~= "string" then
+      return nil
+    end
+    name = string.lower(name)
+    if name == "" then
+      return nil
+    end
+    return name
+  end
+
+  if type(System.getMassAliasDriverName) == "function" then
+    local ok_alias, alias = pcall(System.getMassAliasDriverName)
+    if ok_alias then
+      local parsed = normalize(alias)
+      if parsed ~= nil then return parsed end
+    end
+  end
+
+  if type(System.getMassDriverName) == "function" then
+    local probes = {-1, "mass:", "mass"}
+    for _, probe in ipairs(probes) do
+      local ok_dn, dn = pcall(System.getMassDriverName, probe)
+      if ok_dn then
+        local parsed = normalize(dn)
+        if parsed ~= nil then return parsed end
+      end
+    end
+  end
+
+  return nil
+end
+
+
 function PLDR.ProbeMassHasPops(i)
   return PLDR.MassHasPops(i)
 end
@@ -1459,6 +1513,18 @@ function PLDR.GetUsbMassRoots(max_index)
         table.insert(roots, "mass"..tostring(i)..":/")
       end
       ::continue2::
+    end
+  end
+
+  if #roots == 0 then
+    local alias_dn = nil
+    if PLDR.GetMassAliasDriverName ~= nil then
+      alias_dn = PLDR.GetMassAliasDriverName()
+    end
+    if alias_dn ~= nil and alias_dn ~= "" and alias_dn ~= "sdc" then
+      if PLDR.MassHasPopsAlias ~= nil and PLDR.MassHasPopsAlias() then
+        return {"mass:/"}
+      end
     end
   end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2500,7 +2500,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     if not string.match(bootarg, "%.ELF$") then
       bootarg = bootarg..".ELF"
     end
-    argv = {bootarg}
+    argv = {bootarg, bootarg}
   else
     -- Preserve existing HDD argv behavior.
     argv = {argv0_selector}

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2486,25 +2486,17 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
       prefix_used = ""
     end
   end
-  local argv = {}
-
-  if policy.name ~= "HDD" then
-    -- Use the already computed basename; ensure it ends with ".ELF"
-    local bootarg = bootparam_basename_used
-    if bootarg == nil or bootarg == "" then
-      if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
-        UI.Notif_queue.add("Launch failed: missing boot basename")
-      end
-      return
+  local bootarg = bootparam_basename_used
+  if bootarg == nil or bootarg == "" then
+    if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
+      UI.Notif_queue.add("Launch failed: missing boot selector")
     end
-    if not string.match(bootarg, "%.ELF$") then
-      bootarg = bootarg..".ELF"
-    end
-    argv = {bootarg, bootarg}
-  else
-    -- Preserve existing HDD argv behavior.
-    argv = {argv0_selector}
+    return
   end
+  if not string.match(bootarg, "%.ELF$") then
+    bootarg = bootarg..".ELF"
+  end
+  local argv = {argv0_selector, bootarg, bootarg}
 
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
   LOG("PopStarter selected: "..popstarter)
@@ -2550,20 +2542,32 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     bootparam_source = boot_source_mode,
     hdd_init = hdd_init
   }
-  local reboot_iop = PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER
-  if policy.name == "HDD" then
-    reboot_iop = 0
-  end
+  local reboot_iop = 0
   if UI ~= nil and UI.CoverCache ~= nil and UI.CoverCache.Clear ~= nil then
     UI.CoverCache:Clear()
   end
   PLDR.CleanupGameList()
   collectgarbage("collect")
-  if policy.name ~= "HDD" then
-    System.loadELF(popstarter, 0, vcd_path)
+
+  popstarter = PLDR.ResolvePopstarterPath()
+  if popstarter == nil or popstarter == "" or not OpenProbe(popstarter) then
+    if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
+      UI.Notif_queue.add("POPSTARTER missing:\n"..tostring(popstarter))
+    end
     return
   end
-  LaunchEngine(popstarter, argv, reboot_iop, context)
+
+  local ok, rc = pcall(System.loadELF, popstarter, reboot_iop, unpack(argv))
+  if not ok then
+    if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
+      UI.Notif_queue.add("POPSTARTER launch failed:\n"..tostring(rc))
+    end
+    return
+  end
+  if UI ~= nil and UI.Notif_queue ~= nil and UI.Notif_queue.add ~= nil then
+    UI.Notif_queue.add("POPSTARTER returned unexpectedly")
+  end
+  return
 end
 
 function Touch(FILE, warn_key)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2488,6 +2488,13 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   end
   local argv = {argv0_selector}
 
+  if policy.name ~= "HDD" then
+    -- bootparam_basename_used is the authoritative "XX.<VCDNAME>" string
+    if bootparam_basename_used ~= nil and bootparam_basename_used ~= "" then
+      table.insert(argv, bootparam_basename_used)
+    end
+  end
+
   LOG("Boot APP_DIR: "..APP_DIR_LOCAL)
   LOG("PopStarter selected: "..popstarter)
   LOG("PopStarter:", popstarter, "VCD:", vcd_path, "mode:", source_mode, "argv_count:", #argv)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -422,26 +422,32 @@ function PLDR.IsUsbMassIndex(i)
   return n ~= nil and n ~= "sdc"
 end
 
-function PLDR.ProbeMassHasPops(i)
-  local base = "mass"..tostring(i)..":/POPS"
-  local probes = {
-    { kind = "list", path = base.."/" },
-    { kind = "list", path = base },
-    { kind = "open", path = base.."/" },
-    { kind = "open", path = base },
-  }
-  for idx = 1, #probes do
-    local probe = probes[idx]
-    if probe.kind == "list" then
-      local ok, dir = pcall(System.listDirectory, probe.path)
-      if ok and type(dir) == "table" then
-        return true
-      end
-    elseif OpenProbe(probe.path) then
-      return true
-    end
+function PLDR.MassWarmup(max_index)
+  max_index = tonumber(max_index) or 9
+  if max_index < 0 then max_index = 0 end
+  if max_index > 9 then max_index = 9 end
+
+  -- Nudge each index root; no POPS listing here.
+  for i = 0, max_index do
+    pcall(System.listDirectory, "mass"..tostring(i)..":/")
   end
+end
+
+function PLDR.MassHasPops(i)
+  local base = "mass"..tostring(i)..":/POPS"
+
+  local ok1, d1 = pcall(System.listDirectory, base.."/")
+  if ok1 and type(d1) == "table" then return true end
+
+  local ok2, d2 = pcall(System.listDirectory, base)
+  if ok2 and type(d2) == "table" then return true end
+
+  if OpenProbe(base.."/") or OpenProbe(base) then return true end
   return false
+end
+
+function PLDR.ProbeMassHasPops(i)
+  return PLDR.MassHasPops(i)
 end
 
 function PLDR.FindMassByDriver(driver, max_index)
@@ -1408,82 +1414,142 @@ function PLDR.GetPS1GameLists(path, updating)
   end
 end
 
-function PLDR.GetActiveUsbRoots(max_index)
-  PLDR.EnsureMassReady()
-  local max = tonumber(max_index) or 9
-  if max < 0 then max = 0 end
-  if max > 9 then max = 9 end
+function PLDR.GetUsbMassRoots(max_index)
+  max_index = tonumber(max_index) or 9
+  if max_index < 0 then max_index = 0 end
+  if max_index > 9 then max_index = 9 end
 
-  local function pass()
-    local roots = {}
-    for i = 0, max do
-      pcall(System.listDirectory, "mass"..tostring(i)..":/")
-      local mx_index = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.MASSINDX or nil
-      if mx_index ~= nil and mx_index == i then
-        goto continue
+  -- Warmup first, then probe POPS.
+  PLDR.EnsureUsbReady()
+  PLDR.MassWarmup(max_index)
+
+  local roots = {}
+
+  for i = 0, max_index do
+    -- Exclude MX4SIO by known index when available.
+    if PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil and PLDR.MX4SIO.MASSINDX == i then
+      goto continue
+    end
+
+    -- Also exclude by driver name if it is available (optional safety).
+    local dn = nil
+    if PLDR.GetMassDriverName ~= nil then dn = PLDR.GetMassDriverName(i) end
+    if dn == "sdc" then
+      goto continue
+    end
+
+    if PLDR.MassHasPops(i) then
+      table.insert(roots, "mass"..tostring(i)..":/")
+    end
+
+    ::continue::
+  end
+
+  -- Bounded retry: if nothing found, do one more warmup + probe pass.
+  if #roots == 0 then
+    PLDR.MassWarmup(max_index)
+    for i = 0, max_index do
+      if PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil and PLDR.MX4SIO.MASSINDX == i then
+        goto continue2
       end
-      local dn = PLDR.MassDriverName(i)
-      if dn == "sdc" then
-        goto continue
-      end
-      if PLDR.ProbeMassHasPops(i) then
+      local dn = nil
+      if PLDR.GetMassDriverName ~= nil then dn = PLDR.GetMassDriverName(i) end
+      if dn == "sdc" then goto continue2 end
+      if PLDR.MassHasPops(i) then
         table.insert(roots, "mass"..tostring(i)..":/")
       end
-      ::continue::
-    end
-    return roots
-  end
-
-  local roots = pass()
-  if #roots > 0 then
-    return roots
-  end
-
-  for attempt = 1, 2 do
-    PLDR.TouchMassIndices(max)
-    roots = pass()
-    if #roots > 0 then
-      return roots
+      ::continue2::
     end
   end
 
   return roots
 end
 
-function PLDR.GetPS1GameListsUSB(max_index)
-  PLDR.CleanupGameList()
-  local roots = PLDR.GetActiveUsbRoots(max_index)
-  PLDR.USB.ROOTS = roots
-  PLDR.USB.GAME_ENTRIES = {}
-  for _, root in ipairs(roots) do
-    root = PLDR.CanonicalizeMassRoot(root)
-    local list_path = root.."POPS/"
-    local dir = System.listDirectory(list_path)
-    local names = {}
-    if dir ~= nil then
-      for i = 1, #dir do
-        local entry = dir[i]
-        if not entry.directory and string.lower(string.sub(entry.name, -4)) == ".vcd" then
-          table.insert(names, entry.name)
-        end
+function PLDR.GetActiveUsbRoots(max_index)
+  return PLDR.GetUsbMassRoots(max_index)
+end
+
+function PLDR.GetPS1GameListsUSB(pops, root)
+  local list_path = pops
+  local mass_root = root
+  if root == nil and (type(pops) ~= "string" or not string.find(pops, "POPS", 1, true)) then
+    local roots = PLDR.GetUsbMassRoots(pops)
+    PLDR.USB.ROOTS = roots
+    PLDR.USB.GAME_ENTRIES = {}
+    PLDR.GAMES = {}
+    PLDR.GAMEART = {}
+    PLDR.GAMEPATH = nil
+    for _, usb_root in ipairs(roots) do
+      PLDR.GetPS1GameListsUSB(usb_root.."POPS/", usb_root)
+    end
+    if #PLDR.GAMES > 0 then
+      PLDR.GAMEPATH = (PLDR.USB.GAME_ENTRIES[1] and PLDR.USB.GAME_ENTRIES[1].pops_path) or nil
+      return PLDR.GAMES
+    end
+    return nil
+  end
+
+  if mass_root == nil then
+    if type(list_path) == "string" then
+      mass_root = string.match(list_path, "^(mass%d+:/)")
+    end
+    if mass_root == nil then
+      return nil
+    end
+  end
+
+  if type(list_path) ~= "string" then
+    list_path = mass_root.."POPS/"
+  end
+  mass_root = PLDR.CanonicalizeMassRoot(mass_root)
+  list_path = mass_root.."POPS/"
+
+  local dir = System.listDirectory(list_path)
+  local names = {}
+  if dir ~= nil then
+    for i = 1, #dir do
+      local entry = dir[i]
+      if not entry.directory and string.lower(string.sub(entry.name, -4)) == ".vcd" then
+        table.insert(names, entry.name)
       end
     end
-    table.sort(names)
-    for i = 1, #names do
-      table.insert(PLDR.GAMES, names[i])
-      table.insert(PLDR.USB.GAME_ENTRIES, {
-        root = root,
-        pops_path = list_path,
-        vcd_path = list_path..names[i],
-        name = names[i]
-      })
-    end
   end
-  if #PLDR.GAMES > 0 then
-    PLDR.GAMEPATH = (PLDR.USB.GAME_ENTRIES[1] and PLDR.USB.GAME_ENTRIES[1].pops_path) or "mass0:/POPS/"
-    return PLDR.GAMES
+  table.sort(names)
+  for i = 1, #names do
+    table.insert(PLDR.GAMES, names[i])
+    table.insert(PLDR.USB.GAME_ENTRIES, {
+      root = mass_root,
+      pops_path = list_path,
+      vcd_path = list_path..names[i],
+      name = names[i]
+    })
+  end
+  if #names > 0 then
+    return names
   end
   return nil
+end
+
+function PLDR.RefreshUsbGames(max_index)
+  PLDR.USB.GAME_ENTRIES = {}
+  PLDR.GAMES = {}
+  PLDR.GAMEART = {}
+  PLDR.GAMEPATH = nil
+
+  local roots = PLDR.GetUsbMassRoots(max_index or 9)
+  PLDR.USB.ROOTS = roots
+
+  -- Merge listing from each root's POPS folder.
+  for _, root in ipairs(roots) do
+    local pops = root.."POPS/"
+    PLDR.GetPS1GameListsUSB(pops, root)
+  end
+
+  if #PLDR.GAMES > 0 then
+    PLDR.GAMEPATH = (PLDR.USB.GAME_ENTRIES[1] and PLDR.USB.GAME_ENTRIES[1].pops_path) or nil
+  end
+
+  return #roots, #PLDR.GAMES
 end
 
 local function EncodeHddGameEntry(partition, relpath)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -255,6 +255,8 @@ UI = {
     };
     LAUNCHING = false;
     HideUI = (PLDR ~= nil and PLDR.SETTINGS ~= nil and PLDR.SETTINGS.hide_ui == true);
+    USBRefreshPending = false;
+    USBRefreshDelay = 0;
     BOOT_SOUND = {
       ENABLED = true,
       PATH = "embed:/POPSLDR/boot.adp",
@@ -267,6 +269,32 @@ UI = {
       ADPCM_VOLUME = 100      -- per-channel ADPCM volume (0-100 typical, scaled to audsrv range)
     };
     CoverCache = CoverCache;
+    ScheduleUsbDelayedRefresh = function (delay_frames)
+      local delay = tonumber(delay_frames) or 30
+      if delay < 0 then delay = 0 end
+      UI.USBRefreshPending = true
+      UI.USBRefreshDelay = delay
+    end;
+    ClearUsbDelayedRefresh = function ()
+      UI.USBRefreshPending = false
+      UI.USBRefreshDelay = 0
+    end;
+    UpdateUsbDelayedRefresh = function ()
+      if not UI.IsUsbScene(UI.CURSCENE) then
+        return
+      end
+      if UI.USBRefreshPending ~= true then
+        return
+      end
+      UI.USBRefreshDelay = (tonumber(UI.USBRefreshDelay) or 0) - 1
+      if UI.USBRefreshDelay <= 0 then
+        if PLDR ~= nil and PLDR.RefreshUsbGames ~= nil then
+          PLDR.RefreshUsbGames(9)
+        end
+        UI.USBRefreshPending = false
+        UI.USBRefreshDelay = 0
+      end
+    end;
     ShouldHideUI = function ()
       if not UI.HideUI then return false end
       if UI.CURSCENE == UI.SCENES.MPROFILE or UI.CURSCENE == UI.SCENES.CREDITS then
@@ -1549,6 +1577,7 @@ end
           end
           return
         end
+        UI.UpdateUsbDelayedRefresh()
         local ammount = #PLDR.GAMES
         if UI.CURSCENE == UI.SCENES.GMMCE and not hide_ui then
           local slots = PLDR.GetMMCESlots()
@@ -2245,22 +2274,6 @@ end
             end
             UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
-            local roots_count = 0
-            local games_count = 0
-            if PLDR.RefreshUsbGames ~= nil then
-              roots_count, games_count = PLDR.RefreshUsbGames(9)
-            elseif PLDR.GetPS1GameListsUSB ~= nil then
-              local found = PLDR.GetPS1GameListsUSB(9)
-              roots_count = (PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.ROOTS ~= nil) and #PLDR.USB.ROOTS or 0
-              games_count = (found ~= nil and #found) or 0
-            end
-            if games_count <= 0 then
-              if roots_count > 0 then
-                UI.Notif_queue.add("No games found on USB (POPS/)")
-              else
-                UI.Notif_queue.add("No USB device found")
-              end
-            end
             UI.SceneChange(UI.SCENES.GUSBFAT)
           elseif UI.MainMenu.OPT == 6 then
             UI.Notif_queue.add("Not Implemented Yet")
@@ -2520,11 +2533,35 @@ end
 function UI.IsUsbScene(scene)
   return scene == UI.SCENES.GUSBFAT or scene == UI.SCENES.GUSBEXFAT
 end
+function UI.OnSceneEnter(previous_scene, current_scene)
+  if UI.IsUsbScene(current_scene) then
+    local roots_count = 0
+    local games_count = 0
+    if PLDR ~= nil and PLDR.RefreshUsbGames ~= nil then
+      roots_count, games_count = PLDR.RefreshUsbGames(9)
+    elseif PLDR ~= nil and PLDR.GetPS1GameListsUSB ~= nil then
+      local found = PLDR.GetPS1GameListsUSB(9)
+      roots_count = (PLDR.USB ~= nil and PLDR.USB.ROOTS ~= nil) and #PLDR.USB.ROOTS or 0
+      games_count = (found ~= nil and #found) or 0
+    end
+    if games_count <= 0 then
+      if roots_count > 0 then
+        UI.Notif_queue.add("No games found on USB (POPS/)")
+      else
+        UI.Notif_queue.add("No USB device found")
+      end
+    end
+    UI.ScheduleUsbDelayedRefresh(30)
+  end
+end
 function UI.OnSceneExit(previous_scene, next_scene)
   if UI.IsGameScene(previous_scene) and previous_scene ~= next_scene then
     if UI.CoverCache ~= nil and UI.CoverCache.Clear ~= nil then
       UI.CoverCache:Clear()
     end
+  end
+  if UI.IsUsbScene(previous_scene) and previous_scene ~= next_scene then
+    UI.ClearUsbDelayedRefresh()
   end
 end
 UI.RecalcLayout()

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2245,21 +2245,17 @@ end
             end
             UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
-            if PLDR.EnsureUsbReady ~= nil then
-              PLDR.EnsureUsbReady()
+            local roots_count = 0
+            local games_count = 0
+            if PLDR.RefreshUsbGames ~= nil then
+              roots_count, games_count = PLDR.RefreshUsbGames(9)
+            elseif PLDR.GetPS1GameListsUSB ~= nil then
+              local found = PLDR.GetPS1GameListsUSB(9)
+              roots_count = (PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.ROOTS ~= nil) and #PLDR.USB.ROOTS or 0
+              games_count = (found ~= nil and #found) or 0
             end
-            if PLDR.DetectMassBackends ~= nil then
-              PLDR.DetectMassBackends()
-            end
-            local found = nil
-            if PLDR.GetPS1GameListsUSB ~= nil then
-              found = PLDR.GetPS1GameListsUSB(9)
-            else
-              PLDR.CleanupGameList()
-              found = PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
-            end
-            if found == nil then
-              if PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.ROOTS ~= nil and #PLDR.USB.ROOTS > 0 then
+            if games_count <= 0 then
+              if roots_count > 0 then
                 UI.Notif_queue.add("No games found on USB (POPS/)")
               else
                 UI.Notif_queue.add("No USB device found")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1622,6 +1622,23 @@ end
           if ammount <= 0 then
             UI.Notif_queue.add("No games found")
           else
+            local game = nil
+            if PLDR ~= nil and PLDR.GAMES ~= nil then
+              game = PLDR.GAMES[UI.GameList.CURR]
+            end
+            if game == nil then
+              UI.Notif_queue.add("Invalid game selection")
+              return
+            end
+            local launch_path = PLDR.GAMEPATH or ""
+            if UI.CURSCENE == UI.SCENES.GHDD then
+              launch_path = ""
+            elseif UI.IsUsbScene(UI.CURSCENE) and PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.GAME_ENTRIES ~= nil then
+              local usb_entry = PLDR.USB.GAME_ENTRIES[UI.GameList.CURR]
+              if usb_entry ~= nil and usb_entry.root ~= nil then
+                launch_path = usb_entry.root
+              end
+            end
             local pop_ok = false
             if PLDR.PopstarterExists ~= nil then
               pop_ok, PLDR.POPSTARTER_PATH = PLDR.PopstarterExists(PLDR.POPSTARTER_PATH)
@@ -1633,20 +1650,13 @@ end
               return
             end
             if UI.CURSCENE ~= UI.SCENES.GHDD then -- only check if game can be found on USB and SMB
-              if not doesFileExist(PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR]) then
-                UI.Notif_queue.add("Cant find Game\n"..PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR])
+              local full = tostring(launch_path) .. tostring(game)
+              if not doesFileExist(full) then
+                UI.Notif_queue.add("Cant find Game\n"..full)
+                return
               end
             end
-            local launch_path = PLDR.GAMEPATH
-            if UI.CURSCENE == UI.SCENES.GHDD then
-              launch_path = ""
-            elseif UI.IsUsbScene(UI.CURSCENE) and PLDR ~= nil and PLDR.USB ~= nil and PLDR.USB.GAME_ENTRIES ~= nil then
-              local usb_entry = PLDR.USB.GAME_ENTRIES[UI.GameList.CURR]
-              if usb_entry ~= nil and usb_entry.root ~= nil then
-                launch_path = usb_entry.root
-              end
-            end
-            PLDR.RunPOPStarterGame(launch_path, PLDR.GAMES[UI.GameList.CURR], UI.CURSCENE)
+            PLDR.RunPOPStarterGame(launch_path, game, UI.CURSCENE)
           end
         end
         local cross_label = UI.Footer.labels.cross_launch


### PR DESCRIPTION
### Motivation
- The GameList confirm handler could attempt to concatenate `nil` when `PLDR.GAMEPATH` or the selected `PLDR.GAMES[...]` entry was missing, causing a crash on confirm; precheck logic also did not reuse the same `launch_path` resolution used for launching.

### Description
- Resolve `game` safely into a local `game` variable with guards against `PLDR`/`PLDR.GAMES` being `nil`, and show `"Invalid game selection"` then return if missing.
- Compute `launch_path` early using `PLDR.GAMEPATH or ""`, the GHDD override, and the USB entry `root` override so prechecks and launch use the same path resolution.
- Replace the nil-unsafe concat check with `local full = tostring(launch_path) .. tostring(game)` and return after notifying `"Cant find Game\n"..full` if the file check fails.
- Pass the validated `game` into `PLDR.RunPOPStarterGame(launch_path, game, UI.CURSCENE)` and ensure POPSTARTER notifications use `tostring(PLDR.POPSTARTER_PATH)` to avoid nil concatenation.

### Testing
- Inspected the modified handler lines with `nl -ba bin/POPSLDR/ui.lua` to confirm the new guards and `launch_path` resolution are present (succeeded).
- Verified the diff of `bin/POPSLDR/ui.lua` to ensure old nil-unsafe concatenations were removed and the new `full = tostring(launch_path) .. tostring(game)` check was added (succeeded).
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/ui.lua`, but `luac` is not installed in this environment so that check could not be performed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05f89be70832188dedf585cda0854)