### PR TITLE
USB: enumerate mass indices via System.listMassIndices and probe POPS deterministically

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1470,67 +1470,36 @@ function PLDR.GetPS1GameLists(path, updating)
   end
 end
 
-function PLDR.GetUsbMassRoots(max_index)
-  max_index = tonumber(max_index) or 9
-  if max_index < 0 then max_index = 0 end
-  if max_index > 9 then max_index = 9 end
-
-  -- Warmup first, then probe POPS.
-  PLDR.EnsureUsbReady()
-  PLDR.MassWarmup(max_index)
-
+function PLDR.GetUsbRootsFromPresentMass()
   local roots = {}
-
-  for i = 0, max_index do
-    -- Exclude MX4SIO by known index when available.
-    if PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil and PLDR.MX4SIO.MASSINDX == i then
-      goto continue
-    end
-
-    -- Also exclude by driver name if it is available (optional safety).
-    local dn = nil
-    if PLDR.GetMassDriverName ~= nil then dn = PLDR.GetMassDriverName(i) end
-    if dn == "sdc" then
-      goto continue
-    end
-
-    if PLDR.MassHasPops(i) then
-      table.insert(roots, "mass"..tostring(i)..":/")
-    end
-
-    ::continue::
+  if System == nil or System.listMassIndices == nil then
+    return roots
   end
 
-  -- Bounded retry: if nothing found, do one more warmup + probe pass.
-  if #roots == 0 then
-    PLDR.MassWarmup(max_index)
-    for i = 0, max_index do
-      if PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil and PLDR.MX4SIO.MASSINDX == i then
-        goto continue2
-      end
-      local dn = nil
-      if PLDR.GetMassDriverName ~= nil then dn = PLDR.GetMassDriverName(i) end
-      if dn == "sdc" then goto continue2 end
-      if PLDR.MassHasPops(i) then
-        table.insert(roots, "mass"..tostring(i)..":/")
-      end
-      ::continue2::
-    end
+  local ok, present = pcall(System.listMassIndices, 9)
+  if not ok or type(present) ~= "table" then
+    return roots
   end
 
-  if #roots == 0 then
-    local alias_dn = nil
-    if PLDR.GetMassAliasDriverName ~= nil then
-      alias_dn = PLDR.GetMassAliasDriverName()
-    end
-    if alias_dn ~= nil and alias_dn ~= "" and alias_dn ~= "sdc" then
-      if PLDR.MassHasPopsAlias ~= nil and PLDR.MassHasPopsAlias() then
-        return {"mass:/"}
+  for i = 1, #present do
+    local idx = tonumber(present[i])
+    if idx ~= nil then
+      local is_mx4sio = (PLDR.MX4SIO ~= nil and PLDR.MX4SIO.MASSINDX ~= nil and PLDR.MX4SIO.MASSINDX == idx)
+      if not is_mx4sio then
+        local pops_path = "mass"..tostring(idx)..":/POPS/"
+        local dir = System.listDirectory(pops_path)
+        if dir ~= nil or OpenProbe(pops_path) then
+          table.insert(roots, "mass"..tostring(idx)..":/")
+        end
       end
     end
   end
 
   return roots
+end
+
+function PLDR.GetUsbMassRoots(max_index)
+  return PLDR.GetUsbRootsFromPresentMass()
 end
 
 function PLDR.GetActiveUsbRoots(max_index)
@@ -1604,13 +1573,11 @@ function PLDR.RefreshUsbGames(max_index)
   PLDR.GAMEART = {}
   PLDR.GAMEPATH = nil
 
-  local roots = PLDR.GetUsbMassRoots(max_index or 9)
+  local roots = PLDR.GetUsbRootsFromPresentMass()
   PLDR.USB.ROOTS = roots
 
-  -- Merge listing from each root's POPS folder.
   for _, root in ipairs(roots) do
-    local pops = root.."POPS/"
-    PLDR.GetPS1GameListsUSB(pops, root)
+    PLDR.GetPS1GameListsUSB(root.."POPS/", root)
   end
 
   if #PLDR.GAMES > 0 then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1577,7 +1577,6 @@ end
           end
           return
         end
-        UI.UpdateUsbDelayedRefresh()
         local ammount = #PLDR.GAMES
         if UI.CURSCENE == UI.SCENES.GMMCE and not hide_ui then
           local slots = PLDR.GetMMCESlots()
@@ -2551,7 +2550,6 @@ function UI.OnSceneEnter(previous_scene, current_scene)
         UI.Notif_queue.add("No USB device found")
       end
     end
-    UI.ScheduleUsbDelayedRefresh(30)
   end
 end
 function UI.OnSceneExit(previous_scene, next_scene)
@@ -2559,9 +2557,6 @@ function UI.OnSceneExit(previous_scene, next_scene)
     if UI.CoverCache ~= nil and UI.CoverCache.Clear ~= nil then
       UI.CoverCache:Clear()
     end
-  end
-  if UI.IsUsbScene(previous_scene) and previous_scene ~= next_scene then
-    UI.ClearUsbDelayedRefresh()
   end
 end
 UI.RecalcLayout()

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1053,6 +1053,41 @@ static int lua_getMassDriverName(lua_State *L)
 	return 1;
 }
 
+static int lua_listMassIndices(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc > 1) {
+		return luaL_error(L, "Argument error: System.listMassIndices([max_index]) takes zero or one argument.");
+	}
+
+	int max_index = 9;
+	if (argc == 1 && !lua_isnil(L, 1)) {
+		max_index = luaL_checkinteger(L, 1);
+	}
+	if (max_index < 0) {
+		max_index = 0;
+	}
+	if (max_index > 9) {
+		max_index = 9;
+	}
+
+	lua_newtable(L);
+	int out_idx = 1;
+	for (int i = 0; i <= max_index; ++i) {
+		char mass_path[16];
+		snprintf(mass_path, sizeof(mass_path), "mass%d:/", i);
+
+		int dd = fileXioDopen(mass_path);
+		if (dd >= 0) {
+			fileXioDclose(dd);
+			lua_pushinteger(L, i);
+			lua_rawseti(L, -2, out_idx++);
+		}
+	}
+
+	return 1;
+}
+
 static int lua_mx4sio_init(lua_State *L)
 {
 	const char *hint = NULL;
@@ -1118,6 +1153,7 @@ static const luaL_Reg System_functions[] = {
 	{"embedReadText",      lua_embedReadText},
 	{"embedReadBytes",    lua_embedReadBytes},
 	{"getMassDriverName",        lua_getMassDriverName},
+	{"listMassIndices",          lua_listMassIndices},
 	{"initMX4SIO",             lua_mx4sio_init},
 	{"ensureMx4sioInit",      lua_ensure_mx4sio_init},
 	{"bdmList",                lua_bdm_list},


### PR DESCRIPTION
### Motivation
- Make USB enumeration deterministic and not dependent on driver-name IOCTL timing so the USB page reliably shows games when devices are present.
- Provide a minimal, authoritative C helper to cheaply detect which mass indices are present and let Lua probe only those indices for POPS content.

### Description
- Add `System.listMassIndices([max_index])` in `src/luasystem.cpp` which clamps `max_index` to `0..9`, attempts `fileXioDopen` on each `massN:/`, and returns a Lua array of present indices without side effects. 
- Register the new function in the `System` Lua API table so scripts can call `System.listMassIndices`. 
- Introduce `PLDR.GetUsbRootsFromPresentMass()` in `bin/POPSLDR/system.lua` that calls `System.listMassIndices(9)`, skips the known `MX4SIO.MASSINDX` index, probes `mass{i}:/POPS/` (via `System.listDirectory` or `OpenProbe`) and returns only roots that contain `POPS/`. 
- Make `PLDR.GetUsbMassRoots()` delegate to the new deterministic function and update `PLDR.RefreshUsbGames()` to reset `PLDR.GAMES` once and aggregate games only from the returned roots, and remove the previous alias/fallback probing path in this code path. 
- Change UI behavior in `bin/POPSLDR/ui.lua` so USB refresh runs on entering the USB page (scene entry) and remove the delayed/tick-based refresh calls while rendering/transitions continue.

### Testing
- Ran `rg -n "listMassIndices" src/luasystem.cpp bin/POPSLDR/system.lua` and confirmed the new symbol is present (succeeded). 
- Ran `rg -n "RunPOPStarterGame" bin/POPSLDR/system.lua src/luasystem.cpp bin/POPSLDR/ui.lua` to verify no changes to `RunPOPStarterGame` (succeeded). 
- Inspected diffs with `git diff` and repository status with `git status --short` to verify the intended files were modified and committed (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0bc4fe3188321b8c17e95fbfb075d)