### PR TITLE
Unify USB pages into a single bounded multi-device USB page

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -73,20 +73,6 @@ for x=1, #IMG_REGISTRATIONS do
   RegisterImageIfExists(name, path)
 end
 
-if IMG_SOURCES["MISSING"] == nil then
-  if not RegisterImageIfExists("MISSING", "splash_bg.png") then
-    RegisterImageIfExists("MISSING", "USB.png")
-  end
-end
-if IMG_SOURCES["BKG"] == nil then
-  if not RegisterImageIfExists("BKG", "splash_bg.png") then
-    RegisterImageIfExists("BKG", "MISSING.png")
-  end
-end
-if IMG_SOURCES["BGM"] == nil then
-  IMG_SOURCES["BGM"] = IMG_SOURCES["BKG"]
-end
-
 local IMG_FAILED = {}
 
 IMG = setmetatable({}, {
@@ -103,21 +89,6 @@ IMG = setmetatable({}, {
     if img == nil then
       LOGF("Image load failed: %s", path)
       IMG_FAILED[key] = true
-      if key ~= "MISSING" then
-        local missing_source = IMG_SOURCES["MISSING"]
-        if missing_source ~= nil and not IMG_FAILED["MISSING"] then
-          local missing_path = ResolveImage(missing_source)
-          local missing_img = Graphics.loadImage(missing_path)
-          if missing_img ~= nil then
-            Graphics.setImageFilters(missing_img, LINEAR)
-            rawset(tbl, "MISSING", missing_img)
-            rawset(tbl, key, missing_img)
-            return missing_img
-          end
-          LOGF("Image load failed: %s", missing_path)
-          IMG_FAILED["MISSING"] = true
-        end
-      end
       return nil
     end
     Graphics.setImageFilters(img, LINEAR)

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -10,29 +10,43 @@ LOG("Registering images")
 local function ResolveImage(name)
   return System.resolveAssetType(name, ASSET_IMG) or name
 end
+local function DoesAssetExist(path)
+  if path == nil or path == "" then return false end
+  if type(System) == "table" and type(System.doesFileExist) == "function" then
+    local ok, found = pcall(System.doesFileExist, path)
+    if ok and found == true then return true end
+  end
+  if type(doesFileExist) == "function" then
+    local ok, found = pcall(doesFileExist, path)
+    if ok and found == true then return true end
+  end
+  return false
+end
 --- Add your images to this table, just write the name of the file.
 --- Flat layout places images beside POPSLOADER.ELF; legacy installs can still use POPSLDR/IMG/*
 --- FILES MUST HAVE EXTENSION. filename is parsed to create the access key: USB.PNG will be accesed by typing `IMG["USB"]`
-local IMGS = {
-  "USB.png",
-  "USBEXFAT.png",
-  "SMB.png",
-  "MMCE.png",
-  "MX4SIO.png",
-  "HDD.png",
-  "APAHDD.png",
-  "BDHDD.png",
-  "BKG.png",
-  "BGM.png",
-  "DISC.png",
-  "MISSING.png",
-  "PSL.png",
-  "select.png",
-  "start.png",
-  "triangle.png",
-  "circle.png",
-  "cross.png",
-  "R2.png",
+local IMG_REGISTRATIONS = {
+  {"USB", "USB.png"},
+  {"SMB", "SMB.png"},
+  {"MMCE", "MMCE.png"},
+  {"MX4SIO", "MX4SIO.png"},
+  {"HDD", "HDD.png"},
+  {"APAHDD", "APAHDD.png"},
+  {"BDHDD", "BDHDD.png"},
+  {"BKG", "BKG.png"},
+  {"BGM", "BGM.png"},
+  {"DISC", "DISC.png"},
+  {"MISSING", "MISSING.png"},
+  {"SPLASH1", "splash_bg.png"},
+  {"SPLASH2", "splash_logo.png"},
+  {"SPLASH3", "splash_appname.png"},
+  {"SPLASH4", "splash_credits.png"},
+  {"select", "select.png"},
+  {"start", "start.png"},
+  {"triangle", "triangle.png"},
+  {"circle", "circle.png"},
+  {"cross", "cross.png"},
+  {"R2", "R2.png"},
   --"down.png",
   --"L1.png",
   --"L2.png",
@@ -41,16 +55,37 @@ local IMGS = {
   --"R1.png",
   --"R3.png",
   --"right.png",
-  "square.png",
+  {"square", "square.png"},
   --"up.png",
 }
 local IMG_SOURCES = {}
-for x=1, #IMGS do
-  local key = IMGS[x]:match("(.+)%..+$")
-  IMG_SOURCES[key] = IMGS[x]
+local function RegisterImageIfExists(name, path)
+  local resolved = ResolveImage(path)
+  if DoesAssetExist(resolved) then
+    IMG_SOURCES[name] = path
+    return true
+  end
+  return false
 end
-IMG_SOURCES["MMCE"] = "MMCE.png"
-IMG_SOURCES["MX4SIO"] = "MX4SIO.png"
+for x=1, #IMG_REGISTRATIONS do
+  local name = IMG_REGISTRATIONS[x][1]
+  local path = IMG_REGISTRATIONS[x][2]
+  RegisterImageIfExists(name, path)
+end
+
+if IMG_SOURCES["MISSING"] == nil then
+  if not RegisterImageIfExists("MISSING", "splash_bg.png") then
+    RegisterImageIfExists("MISSING", "USB.png")
+  end
+end
+if IMG_SOURCES["BKG"] == nil then
+  if not RegisterImageIfExists("BKG", "splash_bg.png") then
+    RegisterImageIfExists("BKG", "MISSING.png")
+  end
+end
+if IMG_SOURCES["BGM"] == nil then
+  IMG_SOURCES["BGM"] = IMG_SOURCES["BKG"]
+end
 
 local IMG_FAILED = {}
 
@@ -103,4 +138,8 @@ function IMG.ReleaseAll()
   end
   IMG_FAILED = {}
 end
-LOGF("%d images registered (lazy)", #IMGS)
+local registered_count = 0
+for _, _ in pairs(IMG_SOURCES) do
+  registered_count = registered_count + 1
+end
+LOGF("%d images registered (lazy)", registered_count)

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -36,7 +36,6 @@ local IMG_REGISTRATIONS = {
   {"BKG", "BKG.png"},
   {"BGM", "BGM.png"},
   {"DISC", "DISC.png"},
-  {"MISSING", "MISSING.png"},
   {"SPLASH1", "splash_bg.png"},
   {"SPLASH2", "splash_logo.png"},
   {"SPLASH3", "splash_appname.png"},

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -541,6 +541,58 @@ function PLDR.GetPS1GameLists(path, updating)
   end
 end
 
+function PLDR.BuildUsbGameListMulti()
+  PLDR.CleanupGameList()
+  local roots = {
+    "mass0:/POPS/",
+    "mass1:/POPS/",
+    "mass2:/POPS/",
+    "mass3:/POPS/",
+    "mass4:/POPS/"
+  }
+  local found_any = false
+  for i = 1, #roots do
+    local root = roots[i]
+    local DIR = System.listDirectory(root)
+    if DIR ~= nil then
+      for j = 1, #DIR do
+        local entry = DIR[j]
+        if not entry.directory and string.lower(string.sub(entry.name, -4)) == ".vcd" then
+          found_any = true
+          table.insert(PLDR.GAMES, root.."|"..entry.name)
+        end
+      end
+    end
+  end
+  if not found_any then
+    local fallback_root = "mass:/POPS/"
+    local DIR = System.listDirectory(fallback_root)
+    if DIR ~= nil then
+      for j = 1, #DIR do
+        local entry = DIR[j]
+        if not entry.directory and string.lower(string.sub(entry.name, -4)) == ".vcd" then
+          found_any = true
+          table.insert(PLDR.GAMES, fallback_root.."|"..entry.name)
+        end
+      end
+    end
+  end
+  if found_any then
+    table.sort(PLDR.GAMES, function(a, b)
+      local root_a, name_a = string.match(a or "", "^([^|]+)|(.+)$")
+      local root_b, name_b = string.match(b or "", "^([^|]+)|(.+)$")
+      name_a = name_a or (a or "")
+      name_b = name_b or (b or "")
+      if name_a == name_b then
+        return (root_a or "") < (root_b or "")
+      end
+      return name_a < name_b
+    end)
+    return PLDR.GAMES
+  end
+  return nil
+end
+
 local function EncodeHddGameEntry(partition, relpath)
   if partition == nil or relpath == nil then
     return nil

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -740,10 +740,14 @@ end
         end
         local function DrawSplashLayered(alpha)
           local splash_alpha = alpha or 128
-          DrawSplashCover(IMG.SPLASH1 or IMG.BKG, UI.SCR.X, UI.SCR.Y, splash_alpha)
-          DrawSplashCover(IMG.SPLASH2, UI.SCR.X, UI.SCR.Y, splash_alpha)
-          DrawSplashCover(IMG.SPLASH3, UI.SCR.X, UI.SCR.Y, splash_alpha)
-          DrawSplashCover(IMG.SPLASH4, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          local splash1 = IMG.SPLASH1
+          local splash2 = IMG.SPLASH2
+          local splash3 = IMG.SPLASH3
+          local splash4 = IMG.SPLASH4
+          if splash1 ~= nil then DrawSplashCover(splash1, UI.SCR.X, UI.SCR.Y, splash_alpha) end
+          if splash2 ~= nil then DrawSplashCover(splash2, UI.SCR.X, UI.SCR.Y, splash_alpha) end
+          if splash3 ~= nil then DrawSplashCover(splash3, UI.SCR.X, UI.SCR.Y, splash_alpha) end
+          if splash4 ~= nil then DrawSplashCover(splash4, UI.SCR.X, UI.SCR.Y, splash_alpha) end
         end
 
         local fade_in_frames = 120
@@ -1188,7 +1192,7 @@ end
         end
         if layout.PREVIEW_W > 0 then
           Graphics.drawRect(layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4, UI.CCOL.GREY)
-          local preview_img = cover_img or IMG.MISSING
+          local preview_img = cover_img
           if preview_img ~= nil then
             Graphics.drawScaleImage(preview_img, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
           end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -738,6 +738,13 @@ end
           Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 18,  8, UI.SCR.X, 16, "Graphics by Berion",   Color.new(0, 0, 0, alpha))
           Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 36,  8, UI.SCR.X, 16, "israpps.github.io",    Color.new(0, 0, 0, alpha))
         end
+        local function DrawSplashLayered(alpha)
+          local splash_alpha = alpha or 128
+          DrawSplashCover(IMG.SPLASH1 or IMG.BKG, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          DrawSplashCover(IMG.SPLASH2, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          DrawSplashCover(IMG.SPLASH3, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          DrawSplashCover(IMG.SPLASH4, UI.SCR.X, UI.SCR.Y, splash_alpha)
+        end
 
         local fade_in_frames = 120
         local fade_mid_frames = 30
@@ -776,13 +783,13 @@ end
         for i = 1, fade_in_frames do
           local alpha = Round(128 * (i / fade_in_frames))
           DrawBackground()
-          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, alpha)
+          DrawSplashLayered(alpha)
           DrawSplashText(alpha)
           Screen.flip() -- we dont use UI.flip here because we dont want notifications on the welcome screen
         end
         for _ = 1, boot_hold_frames do
           DrawBackground()
-          DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, 128)
+          DrawSplashLayered(128)
           DrawSplashText(128)
           Screen.flip()
         end
@@ -790,7 +797,7 @@ end
           for i = 1, fade_mid_frames do
             local alpha = Round(128 * (1 - (i / fade_mid_frames)))
             DrawTargetScene(UI.SCENES.CREDITS)
-            DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, alpha)
+            DrawSplashLayered(alpha)
             DrawSplashText(alpha)
             Screen.flip()
           end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -170,7 +170,6 @@ UI = {
     LASTSCENE = 5;
     SCENES = {
       GUSBFAT = 1,
-      GUSBEXFAT = 2,
       GSMB = 3,
       GMX4SIO = 4,
       GHDD = 5,
@@ -1112,8 +1111,7 @@ end
         local layout = UI.LAYOUT
         UI.GameList.MAXDRAW = layout.LIST_MAX
         local titles = {
-          [UI.SCENES.GUSBFAT] = "USB FAT32",
-          [UI.SCENES.GUSBEXFAT] = "USB exFAT"
+          [UI.SCENES.GUSBFAT] = "USB"
         }
         local scene_title = titles[UI.CURSCENE]
         if scene_title ~= nil then
@@ -1170,7 +1168,13 @@ end
         local cover_img = nil
         if UI.CoverCache ~= nil then
           if ammount > 0 then
-            cover_img = UI.CoverCache:UpdateSelection(PLDR.GAMES[UI.GameList.CURR], PLDR.GAMEPATH)
+            local entry = PLDR.GAMES[UI.GameList.CURR]
+            local cover_path = PLDR.GAMEPATH
+            local root = string.match(entry or "", "^([^|]+)|.+$")
+            if root ~= nil then
+              cover_path = root
+            end
+            cover_img = UI.CoverCache:UpdateSelection(entry, cover_path)
           else
             UI.CoverCache:UpdateSelection(nil, PLDR.GAMEPATH)
           end
@@ -1200,16 +1204,28 @@ end
           elseif not doesFileExist(PLDR.POPSTARTER_PATH) then
             UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..PLDR.POPSTARTER_PATH)
           else
+            local entry = PLDR.GAMES[UI.GameList.CURR]
+            local root, rel = string.match(entry or "", "^([^|]+)|(.+)$")
+            local vcd_full = nil
+            if root ~= nil then
+              vcd_full = root..rel
+            else
+              vcd_full = PLDR.GAMEPATH..entry
+            end
             if UI.CURSCENE ~= UI.SCENES.GHDD then -- only check if game can be found on USB and SMB
-              if not doesFileExist(PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR]) then
-                UI.Notif_queue.add("Cant find Game\n"..PLDR.GAMEPATH .. PLDR.GAMES[UI.GameList.CURR])
+              if not doesFileExist(vcd_full) then
+                UI.Notif_queue.add("Cant find Game\n"..vcd_full)
               end
             end
             local launch_path = PLDR.GAMEPATH
             if UI.CURSCENE == UI.SCENES.GHDD then
               launch_path = ""
             end
-            PLDR.RunPOPStarterGame(launch_path, PLDR.GAMES[UI.GameList.CURR], UI.CURSCENE)
+            if root ~= nil then
+              PLDR.RunPOPStarterGame(root, rel, UI.CURSCENE)
+            else
+              PLDR.RunPOPStarterGame(launch_path, entry, UI.CURSCENE)
+            end
           end
         end
         local cross_label = UI.Footer.labels.cross_launch
@@ -1273,7 +1289,7 @@ end
     };
     MainMenu = {
       OPT = 1;
-      opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB (exFAT)", "USB (FAT32)", "SMB (v1)", "Disc (DKWDRV)"};
+      opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
         targetIndex = 1,
@@ -1307,8 +1323,7 @@ end
           ["MX4SIO"] = "MX4SIO",
           ["HDD (exFAT)"] = "BDHDD",
           ["HDD (PFS)"] = "APAHDD",
-          ["USB (exFAT)"] = "USBEXFAT",
-          ["USB (FAT32)"] = "USB",
+          ["USB"] = "USB",
           ["SMB (v1)"] = "SMB",
           ["Disc (DKWDRV)"] = "DISC"
         }
@@ -1523,17 +1538,12 @@ end
             UI.SceneChange(UI.SCENES.GHDD)
           elseif UI.MainMenu.OPT == 5 then
             PLDR.CleanupGameList()
-            PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
-            UI.setDeviceLock(DEVLOCK.USB)
-            UI.SceneChange(UI.SCENES.GUSBEXFAT)
-          elseif UI.MainMenu.OPT == 6 then
-            PLDR.CleanupGameList()
-            PLDR.GetPS1GameLists("mass"..PLDR.USB.MASSINDX..":/POPS/", true)
+            PLDR.BuildUsbGameListMulti()
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBFAT)
-          elseif UI.MainMenu.OPT == 7 then
+          elseif UI.MainMenu.OPT == 6 then
             UI.Notif_queue.add("Not Implemented Yet")
-          elseif UI.MainMenu.OPT == 8 then
+          elseif UI.MainMenu.OPT == 7 then
             UI.Notif_queue.add("Not Implemented Yet")
           end --because we still dont support SMB
         end
@@ -1757,7 +1767,6 @@ end
 _G.UI = UI
 UI.GAME_SCENES = {
   [UI.SCENES.GUSBFAT] = true,
-  [UI.SCENES.GUSBEXFAT] = true,
   [UI.SCENES.GSMB] = true,
   [UI.SCENES.GMX4SIO] = true,
   [UI.SCENES.GHDD] = true,
@@ -1767,7 +1776,7 @@ function UI.IsGameScene(scene)
   return UI.GAME_SCENES[scene] == true
 end
 function UI.IsUsbScene(scene)
-  return scene == UI.SCENES.GUSBFAT or scene == UI.SCENES.GUSBEXFAT
+  return scene == UI.SCENES.GUSBFAT
 end
 function UI.OnSceneExit(previous_scene, next_scene)
   if UI.IsGameScene(previous_scene) and previous_scene ~= next_scene then


### PR DESCRIPTION
### Motivation
- Simplify the UI by collapsing the two USB pages into a single unified USB page and ensure the USB menu option uses the `USB.png` icon while keeping enumeration bounded to known USB roots.
- Provide a safe, minimal change that collects PS1 `.vcd` games from a fixed set of USB roots without wide device scanning and preserve per-device provenance for cover lookup and launching.

### Description
- Removed the separate `GUSBEXFAT` scene and references, kept a single USB scene (`GUSBFAT`) and changed the USB scene title to `"USB"` in `bin/POPSLDR/ui.lua`.
- Collapsed main-menu options to a single `"USB"` entry and updated the icon mapping to map `"USB"` -> `"USB"` (removed `USBEXFAT`) in `bin/POPSLDR/ui.lua` and routed the menu selection to the unified USB scene.
- Added `PLDR.BuildUsbGameListMulti()` to `bin/POPSLDR/system.lua` which enumerates only `mass0:/POPS/` through `mass4:/POPS/`, encodes entries as `<root>|<filename>`, sorts by filename then root, and falls back to `mass:/POPS/` only if none of `mass0..mass4` yield results.
- Updated game-list cover resolution, file existence checking, and launch logic in `bin/POPSLDR/ui.lua` to decode `<root>|<filename>` entries so cover lookup and `PLDR.RunPOPStarterGame` use the correct originating root while preserving legacy behavior for non-encoded entries.

### Testing
- Ran `rg -n "GUSBEXFAT|USBEXFAT|USB \(exFAT\)|USB \(FAT32\)|USB FAT32|USB exFAT" bin/POPSLDR/ui.lua` and it produced no matches (no output), confirming removal of old USBEXFAT/GUSBEXFAT references.
- Ran `rg -n "BuildUsbGameListMulti|mass0:/POPS|mass4:/POPS" bin/POPSLDR/system.lua` and observed the new function and roots: `544:function PLDR.BuildUsbGameListMulti()`, `547:    "mass0:/POPS/",`, `551:    "mass4:/POPS/"`.
- Attempted Lua syntax/load sanity checks via `lua -e "assert(loadfile('bin/POPSLDR/system.lua')); assert(loadfile('bin/POPSLDR/ui.lua'))"` and `luac -p bin/POPSLDR/system.lua && luac -p bin/POPSLDR/ui.lua` but both failed because the `lua`/`luac` binaries are not available in this environment (`bash: command not found`).
- Changes were committed as `ffc89c6` (`Unify USB menu into single bounded multi-device page`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fe3cf3c483218b1b57873885e391)