### PR TITLE
Fix embedded Lua searcher: Lua-only assets + correct module mapping

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -80,4 +80,4 @@ Font.ftSetCharSize(SFONT, 600, 600)
 BOOT_PROF.stamp("UI assets init (fonts)")
 function STOP() LOG("PROGRAM STOP") Screen.clear(Color.new(255,0,0)) Screen.flip() while true do end end
 
-require("system")
+-- system.lua is launched explicitly by the native boot sequence.

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -32,13 +32,9 @@ extern unsigned int size_asset_pops_profiles_lua;
 
 static const embedded_asset_t g_embedded_lua_assets[] = {
     {"system.lua", asset_system_lua, size_asset_system_lua},
-    {"POPSLDR/system.lua", asset_system_lua, size_asset_system_lua},
     {"ui.lua", asset_ui_lua, size_asset_ui_lua},
-    {"POPSLDR/ui.lua", asset_ui_lua, size_asset_ui_lua},
     {"images.lua", asset_images_lua, size_asset_images_lua},
-    {"POPSLDR/images.lua", asset_images_lua, size_asset_images_lua},
-    {"pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua},
-    {"POPSLDR/pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua}
+    {"pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua}
 };
 
 static const uint8_t* FindEmbeddedLua(const char *key, size_t *out_size)

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <debug.h>
+#include <stdint.h>
 
 #include "include/luaplayer.h"
 #include "include/graphics.h"
@@ -31,42 +32,78 @@ extern unsigned int size_asset_pops_profiles_lua;
 
 static const embedded_asset_t g_embedded_lua_assets[] = {
     {"system.lua", asset_system_lua, size_asset_system_lua},
+    {"POPSLDR/system.lua", asset_system_lua, size_asset_system_lua},
     {"ui.lua", asset_ui_lua, size_asset_ui_lua},
+    {"POPSLDR/ui.lua", asset_ui_lua, size_asset_ui_lua},
     {"images.lua", asset_images_lua, size_asset_images_lua},
-    {"pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua}
+    {"POPSLDR/images.lua", asset_images_lua, size_asset_images_lua},
+    {"pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua},
+    {"POPSLDR/pops_profiles.lua", asset_pops_profiles_lua, size_asset_pops_profiles_lua}
 };
 
-static const embedded_asset_t* FindEmbeddedLuaAsset(const char *name)
+static const uint8_t* FindEmbeddedLua(const char *key, size_t *out_size)
 {
-    if (name == NULL) {
+    if (out_size != NULL) {
+        *out_size = 0;
+    }
+    if (key == NULL) {
         return NULL;
     }
     for (size_t i = 0; i < sizeof(g_embedded_lua_assets) / sizeof(g_embedded_lua_assets[0]); ++i) {
-        if (strcmp(name, g_embedded_lua_assets[i].name) == 0) {
-            return &g_embedded_lua_assets[i];
+        if (strcmp(key, g_embedded_lua_assets[i].name) == 0) {
+            if (out_size != NULL) {
+                *out_size = (size_t)g_embedded_lua_assets[i].size;
+            }
+            return (const uint8_t *)g_embedded_lua_assets[i].data;
         }
     }
     return NULL;
 }
 
+static int BuildEmbeddedLuaModuleKey(const char *module_name, char *out_key, size_t out_key_size, int map_dots)
+{
+    if (module_name == NULL || out_key == NULL || out_key_size == 0) {
+        return 0;
+    }
+    size_t idx = 0;
+    while (module_name[idx] != '\0' && idx < out_key_size - 5) {
+        char c = module_name[idx];
+        out_key[idx] = (map_dots && c == '.') ? '/' : c;
+        idx++;
+    }
+    if (module_name[idx] != '\0') {
+        return 0;
+    }
+    out_key[idx++] = '.';
+    out_key[idx++] = 'l';
+    out_key[idx++] = 'u';
+    out_key[idx++] = 'a';
+    out_key[idx] = '\0';
+    return 1;
+}
+
 static int lua_embedded_searcher(lua_State *L)
 {
     const char *module_name = luaL_checkstring(L, 1);
-    char embedded_name[128];
-    size_t i = 0;
-    for (; module_name[i] != '\0' && i < sizeof(embedded_name) - 5; ++i) {
-        embedded_name[i] = (module_name[i] == '.') ? '/' : module_name[i];
-    }
-    embedded_name[i] = '\0';
-    strcat(embedded_name, ".lua");
+    char module_key[128];
+    size_t module_size = 0;
+    const uint8_t *module_data = NULL;
 
-    const embedded_asset_t *asset = FindEmbeddedLuaAsset(embedded_name);
-    if (asset == NULL) {
+    if (BuildEmbeddedLuaModuleKey(module_name, module_key, sizeof(module_key), 1)) {
+        module_data = FindEmbeddedLua(module_key, &module_size);
+    }
+
+    if (module_data == NULL && strchr(module_name, '.') == NULL &&
+        BuildEmbeddedLuaModuleKey(module_name, module_key, sizeof(module_key), 0)) {
+        module_data = FindEmbeddedLua(module_key, &module_size);
+    }
+
+    if (module_data == NULL) {
         lua_pushfstring(L, "\n\tno embedded Lua module '%s'", module_name);
         return 1;
     }
 
-    int load_ret = luaL_loadbuffer(L, (const char *)asset->data, asset->size, embedded_name);
+    int load_ret = luaL_loadbuffer(L, (const char *)module_data, module_size, module_key);
     if (load_ret != 0) {
         lua_pushfstring(L, "\n\terror loading embedded module '%s': %s", module_name, lua_tostring(L, -1));
         return 1;
@@ -83,7 +120,7 @@ static void InstallEmbeddedLuaSearcher(lua_State *L)
         return;
     }
 
-    int n = (int)lua_objlen(L, -1);
+    int n = (int)lua_rawlen(L, -1);
     for (int i = n + 1; i > 1; --i) {
         lua_rawgeti(L, -1, i - 1);
         lua_rawseti(L, -2, i);
@@ -91,7 +128,7 @@ static void InstallEmbeddedLuaSearcher(lua_State *L)
     lua_pushcfunction(L, lua_embedded_searcher);
     lua_rawseti(L, -2, 1);
 
-    int n_after = (int)lua_objlen(L, -1);
+    int n_after = (int)lua_rawlen(L, -1);
     for (int i = 2; i <= n_after; ++i) {
         lua_pushnil(L);
         lua_rawseti(L, -2, i);
@@ -201,20 +238,38 @@ const char * runScript(const char* script, bool isStringBuffer )
 
 	if(!isStringBuffer){
         DPRINTF("Loading embedded script key: `%s'\n", script);
-        const embedded_asset_t *asset = FindEmbeddedLuaAsset(script);
-        if (asset == NULL) {
+        size_t embedded_size = 0;
+        const uint8_t *embedded_script = FindEmbeddedLua(script, &embedded_size);
+        if (embedded_script == NULL) {
             sprintf((char*)errMsg, "FATAL: embedded Lua script missing: %s\n", script);
             DPRINTF("%s", errMsg);
             lua_close(L);
             return errMsg;
         }
-        s = luaL_loadbuffer(L, (const char *)asset->data, asset->size, script);
+        s = luaL_loadbuffer(L, (const char *)embedded_script, embedded_size, script);
+        if (s == 0) {
+            s = lua_pcall(L, 0, LUA_MULTRET, 0);
+        }
 	} else {
-        s = luaL_loadbuffer(L, script, strlen(script), NULL);
+        s = luaL_loadbuffer(L, script, strlen(script), "boot.lua");
+        if (s == 0) {
+            s = lua_pcall(L, 0, LUA_MULTRET, 0);
+        }
+        if (s == 0) {
+            const char *boot_entry = "system.lua";
+            size_t boot_entry_size = 0;
+            const uint8_t *boot_entry_data = FindEmbeddedLua(boot_entry, &boot_entry_size);
+            if (boot_entry_data == NULL) {
+                s = LUA_ERRFILE;
+                lua_pushfstring(L, "FATAL: embedded Lua script missing: %s", boot_entry);
+            } else {
+                s = luaL_loadbuffer(L, (const char *)boot_entry_data, boot_entry_size, boot_entry);
+                if (s == 0) {
+                    s = lua_pcall(L, 0, LUA_MULTRET, 0);
+                }
+            }
+        }
     }
-
-		
-	if (s == 0) s = lua_pcall(L, 0, LUA_MULTRET, 0);
 
 	if (s) {
 		sprintf((char*)errMsg, "%s\n", lua_tostring(L, -1));


### PR DESCRIPTION
### Motivation
- The embedded module searcher could feed non-Lua bytes (PNG/TM2/etc) into `luaL_loadbuffer`, producing syntax errors at boot; the change makes module lookup deterministic and restricts embedded lookups to Lua-only assets while keeping image embedding unchanged.

### Description
- Add a Lua-only embedded table and lookup API `FindEmbeddedLua(const char *key, size_t *out_size)` and register additional keys (including `POPSLDR/...` variants) in `src/luaplayer.cpp` so only `.lua` assets are returned to the Lua loader.
- Implement deterministic module→path mapping with `BuildEmbeddedLuaModuleKey` so dotted names map to `foo/bar.lua` and plain names also try `name.lua`, and the searcher never tries non-Lua extensions.
- Ensure correct length APIs and loading: switch to `lua_rawlen` for package loader table sizing and always pass the exact embedded byte length from `FindEmbeddedLua` into `luaL_loadbuffer`.
- Make boot explicit: `runScript(..., true)` now loads the embedded `system.lua` directly from the Lua-only table and `require("system")` was removed from `etc/boot.lua` to avoid ambiguous resolution through the generic asset table.

### Testing
- Extracted the Lua-only embedded keys from `src/luaplayer.cpp` and verified the list is: `system.lua`, `POPSLDR/system.lua`, `ui.lua`, `POPSLDR/ui.lua`, `images.lua`, `POPSLDR/images.lua`, `pops_profiles.lua`, `POPSLDR/pops_profiles.lua`.
- Confirmed by code inspection that the searcher only appends `.lua` via the module key builder and only calls `FindEmbeddedLua` (no `.png` or other extensions are attempted).
- Ran repository checks (`rg` searches and a small Python extractor) to validate the new symbols and keys were present and updated as expected, and created the commit `Fix embedded Lua searcher: Lua-only assets + correct module mapping`.
- Attempted `make -n` but a full build/run verification could not be completed in this environment due to a missing local dependency (`/samples/Makefile.eeglobal`), so runtime boot-to-main-menu verification was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14f824f8c8321b9162735bfd8b302)