### PR TITLE
Finalize embedded-only Lua module boot flow

### DIFF
--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,13 +1,3 @@
-local function ensure_dir(path)
-  if path == nil or path == "" then return "./" end
-  if string.sub(path, -1) ~= "/" then
-    return path.."/"
-  end
-  return path
-end
-
-local BASE_DIR = ensure_dir(APP_DIR or System.currentDirectory())
-package.path = BASE_DIR.."?.lua;"..BASE_DIR.."?/init.lua;"..BASE_DIR.."POPSLDR/?.lua;./?.lua;./POPSLDR/?.lua;mass:/POPSLDR/?.lua;mc0:/POPSLDR/?.lua;mc1:/POPSLDR/?.lua"
 function LOG(...)
   print_uart(...)
 end

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -253,11 +253,12 @@ int test_error(lua_State * L) {
 }
 
 const char * runScript(const char* script, bool isStringBuffer )
-{	
+{
+    (void)isStringBuffer;
     DPRINTF("Creating luaVM... \n");
 
-  	L = luaL_newstate();
-	if (!L) {
+    L = luaL_newstate();
+    if (!L) {
         char *errMsg = (char*)malloc(512);
         if (errMsg != NULL) {
             snprintf(errMsg, 512, "%s", kLuaErrorCreateState);
@@ -266,75 +267,60 @@ const char * runScript(const char* script, bool isStringBuffer )
         return kLuaErrorCreateState;
     }
     lua_atpanic(L, test_error);
-	
-	  // Init Standard libraries
-	  luaL_openlibs(L);
-      InstallEmbeddedLuaSearcher(L);
-      DisableLuaFilesystemScriptLoaders(L);
+
+    // Init Standard libraries
+    luaL_openlibs(L);
+    InstallEmbeddedLuaSearcher(L);
+    DisableLuaFilesystemScriptLoaders(L);
 
     DPRINTF("Loading libs... ");
 
-	  // init graphics
+    // init graphics
     luaGraphics_init(L);
     luaControls_init(L);
-	luaScreen_init(L);
+    luaScreen_init(L);
     luaTimer_init(L);
     luaSystem_init(L);
     luaSound_init(L);
     luaRender_init(L);
-	luaHDD_init(L);
-    	
-    DPRINTF("done !\n");
-     
-	int s = 0;
+    luaHDD_init(L);
 
-	if(!isStringBuffer){
-        DPRINTF("Loading embedded script key: `%s'\n", script);
-        size_t embedded_size = 0;
-        const uint8_t *embedded_script = FindEmbeddedLua(script, &embedded_size);
-        if (embedded_script == NULL) {
-            char *errMsg = (char*)malloc(512);
-            if (errMsg != NULL) {
-                snprintf(errMsg, 512, "FATAL: embedded Lua script missing: %s\n", script);
-                DPRINTF("%s", errMsg);
-            }
-            lua_close(L);
-            return (errMsg != NULL) ? errMsg : kLuaErrorOutOfMemory;
+    DPRINTF("done !\n");
+
+    int s = 0;
+
+    DPRINTF("Loading embedded script key: `%s'\n", script);
+    size_t embedded_size = 0;
+    const uint8_t *embedded_script = FindEmbeddedLua(script, &embedded_size);
+    if (embedded_script == NULL) {
+        char *errMsg = (char*)malloc(512);
+        if (errMsg != NULL) {
+            snprintf(errMsg, 512, "FATAL: embedded Lua script missing: %s\n", script);
+            DPRINTF("%s", errMsg);
         }
-        s = luaL_loadbuffer(L, (const char *)embedded_script, embedded_size, script);
-        if (s == 0) {
-            s = lua_pcall(L, 0, LUA_MULTRET, 0);
-        }
-	} else {
-            const char *boot_script_key = "boot.lua";
-            size_t boot_script_size = 0;
-            const uint8_t *boot_script_data = FindEmbeddedLua(boot_script_key, &boot_script_size);
-            if (boot_script_data == NULL) {
-                s = LUA_ERRFILE;
-                lua_pushfstring(L, "FATAL: embedded Lua script missing: %s", boot_script_key);
-            } else {
-                s = luaL_loadbuffer(L, (const char *)boot_script_data, boot_script_size, boot_script_key);
-                if (s == 0) {
-                    s = lua_pcall(L, 0, LUA_MULTRET, 0);
-                }
-            }
-        }
+        lua_close(L);
+        return (errMsg != NULL) ? errMsg : kLuaErrorOutOfMemory;
     }
 
-	if (s == 0) {
-		lua_close(L);
-		return NULL;
-	}
+    s = luaL_loadbuffer(L, (const char *)embedded_script, embedded_size, script);
+    if (s == 0) {
+        s = lua_pcall(L, 0, LUA_MULTRET, 0);
+    }
 
-	const char *lua_error = lua_tostring(L, -1);
-	const char *safe_error = (lua_error != NULL) ? lua_error : "(unknown lua error)";
-	char *errMsg = (char*)malloc(512);
-	if (errMsg != NULL) {
-		snprintf(errMsg, 512, "%s\n", safe_error);
-	}
+    if (s == 0) {
+        lua_close(L);
+        return NULL;
+    }
+
+    const char *lua_err_str = lua_tostring(L, -1);
+    const char *safe_error = (lua_err_str != NULL) ? lua_err_str : "(unknown lua error)";
+    char *errMsg = (char*)malloc(512);
+    if (errMsg != NULL) {
+        snprintf(errMsg, 512, "%s\n", safe_error);
+    }
     DPRINTF("%s\n", safe_error);
-	lua_pop(L, 1); // remove error message
-	lua_close(L);
-	
-	return (errMsg != NULL) ? errMsg : kLuaErrorOutOfMemory;
+    lua_pop(L, 1); // remove error message
+    lua_close(L);
+
+    return (errMsg != NULL) ? errMsg : kLuaErrorOutOfMemory;
 }

--- a/src/luaplayer.cpp
+++ b/src/luaplayer.cpp
@@ -116,7 +116,9 @@ static void InstallEmbeddedLuaSearcher(lua_State *L)
     lua_getglobal(L, "package");
     if (!lua_istable(L, -1)) {
         lua_pop(L, 1);
-        return;
+        lua_newtable(L);
+        lua_setglobal(L, "package");
+        lua_getglobal(L, "package");
     }
 
     lua_getfield(L, -1, "loaders");
@@ -125,11 +127,11 @@ static void InstallEmbeddedLuaSearcher(lua_State *L)
         lua_getfield(L, -1, "searchers");
     }
     if (!lua_istable(L, -1)) {
-        lua_pop(L, 2);
-        return;
+        lua_pop(L, 1);
+        lua_newtable(L);
     }
 
-    lua_rawgeti(L, -1, 1); // preload loader
+    lua_rawgeti(L, -1, 1);
     lua_pushcfunction(L, lua_embedded_searcher);
     lua_rawseti(L, -3, 2);
     lua_rawseti(L, -2, 1);
@@ -161,23 +163,11 @@ static void DisableLuaFilesystemScriptLoaders(lua_State *L)
         lua_getglobal(L, "package");
     }
 
-    lua_getfield(L, -1, "path");
-    if (!lua_isstring(L, -1)) {
-        lua_pop(L, 1);
-        lua_pushliteral(L, "");
-        lua_setfield(L, -2, "path");
-    } else {
-        lua_pop(L, 1);
-    }
+    lua_pushliteral(L, "");
+    lua_setfield(L, -2, "path");
 
-    lua_getfield(L, -1, "cpath");
-    if (!lua_isstring(L, -1)) {
-        lua_pop(L, 1);
-        lua_pushliteral(L, "");
-        lua_setfield(L, -2, "cpath");
-    } else {
-        lua_pop(L, 1);
-    }
+    lua_pushliteral(L, "");
+    lua_setfield(L, -2, "cpath");
 
     lua_pop(L, 1);
 }
@@ -324,19 +314,6 @@ const char * runScript(const char* script, bool isStringBuffer )
                 lua_pushfstring(L, "FATAL: embedded Lua script missing: %s", boot_script_key);
             } else {
                 s = luaL_loadbuffer(L, (const char *)boot_script_data, boot_script_size, boot_script_key);
-                if (s == 0) {
-                    s = lua_pcall(L, 0, LUA_MULTRET, 0);
-                }
-            }
-        if (s == 0) {
-            const char *boot_entry = "system.lua";
-            size_t boot_entry_size = 0;
-            const uint8_t *boot_entry_data = FindEmbeddedLua(boot_entry, &boot_entry_size);
-            if (boot_entry_data == NULL) {
-                s = LUA_ERRFILE;
-                lua_pushfstring(L, "FATAL: embedded Lua script missing: %s", boot_entry);
-            } else {
-                s = luaL_loadbuffer(L, (const char *)boot_entry_data, boot_entry_size, boot_entry);
                 if (s == 0) {
                     s = lua_pcall(L, 0, LUA_MULTRET, 0);
                 }


### PR DESCRIPTION
### Motivation

- Create a deterministic embedded-only `require()` implementation so Lua module loading is stable without filesystem loaders and `boot.lua` remains the single Lua entrypoint. 
- Preserve all runtime filesystem access for non-Lua assets while preventing any Lua script loads from the external filesystem.

### Description

- Hardened Lua package invariants in `DisableLuaFilesystemScriptLoaders` by ensuring a `package` table exists and unconditionally setting `package.path = ""` and `package.cpath = ""`, while removing `dofile` and `loadfile` and leaving standard libs intact in `src/luaplayer.cpp`.
- Implemented an embedded-only searcher in `InstallEmbeddedLuaSearcher` that ensures `package` exists, installs the embedded loader at loader/searcher index 2 (preserving slot 1), and clears loader entries from index 3 onward, resolving `module/name.lua` then `module/name/init.lua` via `FindEmbeddedLua()` and loading with `luaL_loadbuffer()`.
- Enforced single-entry ownership in `runScript()` by removing the branch that directly executed `system.lua`, so only the provided script (`boot.lua`) is executed by the VM.
- Removed filesystem Lua path manipulation from `etc/boot.lua` so startup relies on `require("system")` in embedded modules only.

### Testing

- Verified diffs and presence of changes with `git diff` and `rg` to confirm the `InstallEmbeddedLuaSearcher`, `DisableLuaFilesystemScriptLoaders`, `runScript()` and `etc/boot.lua` edits were applied successfully. 
- Attempted a dry-run build with `make -n`, which failed due to missing external build environment files (`/samples/Makefile.eeglobal`), so a full compile/test was not possible in this environment. 
- Committed the changes (`Finalize embedded-only Lua module boot flow`) after local verification of the source edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bb16c17083219b4c1ee1bcca1e17)