### PR TITLE
Fix embedded PNG backgrounds and port checkpoint splash layout

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -63,6 +63,7 @@ IMG = setmetatable({}, {
       local ok, blob = pcall(System.getEmbeddedAsset, source)
       if ok and blob ~= nil then
         img = Graphics.loadImageEmbedded(blob, string.len(blob))
+        if img == 0 then img = nil end
       end
     end
 

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -14,7 +14,6 @@ local IMG_REGISTRATIONS = {
   "SMB.png",
   "MMCE.png",
   "MX4SIO.png",
-  "HDD.png",
   "APAHDD.png",
   "BDHDD.png",
   "BG.png",

--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -7,38 +7,45 @@
 --]]
 
 LOG("Registering images")
---- Add your images to this table, just write the name of the file.
---- FILES MUST HAVE EXTENSION. filename is parsed to create the access key: USB.PNG will be accesed by typing `IMG["USB"]`
+--- Add your images to this table, just write the file name.
+--- Access key is generated from basename without extension (e.g. USB.png -> IMG["USB"]).
 local IMG_REGISTRATIONS = {
-  {"USB", "USB.png"},
-  {"SMB", "SMB.png"},
-  {"MMCE", "MMCE.png"},
-  {"MX4SIO", "MX4SIO.png"},
-  {"HDD", "HDD.png"},
-  {"APAHDD", "APAHDD.png"},
-  {"BDHDD", "BDHDD.png"},
-  {"BKG", "BKG.png"},
-  {"BGM", "BGM.png"},
-  {"DISC", "DISC.png"},
-  {"SPLASH1", "splash_bg.png"},
-  {"SPLASH2", "splash_logo.png"},
-  {"SPLASH3", "splash_appname.png"},
-  {"SPLASH4", "splash_credits.png"},
-  {"select", "select.png"},
-  {"start", "start.png"},
-  {"triangle", "triangle.png"},
-  {"circle", "circle.png"},
-  {"cross", "cross.png"},
-  {"R2", "R2.png"},
-  {"square", "square.png"},
+  "USB.png",
+  "SMB.png",
+  "MMCE.png",
+  "MX4SIO.png",
+  "HDD.png",
+  "APAHDD.png",
+  "BDHDD.png",
+  "BG.png",
+  "BKG.png",
+  "BGM.png",
+  "DISC.png",
+  "splash_bg.png",
+  "splash_logo.png",
+  "splash_appname.png",
+  "splash_credits.png",
+  "select.png",
+  "start.png",
+  "triangle.png",
+  "circle.png",
+  "cross.png",
+  "R2.png",
+  "square.png",
 }
 
 local IMG_SOURCES = {}
 for x = 1, #IMG_REGISTRATIONS do
-  local name = IMG_REGISTRATIONS[x][1]
-  local path = IMG_REGISTRATIONS[x][2]
-  IMG_SOURCES[name] = path
+  local file = IMG_REGISTRATIONS[x]
+  local name = string.match(file, "^(.*)%.[^%.]+$") or file
+  IMG_SOURCES[name] = file
 end
+
+-- legacy splash aliases
+IMG_SOURCES["SPLASH1"] = "splash_bg.png"
+IMG_SOURCES["SPLASH2"] = "splash_logo.png"
+IMG_SOURCES["SPLASH3"] = "splash_appname.png"
+IMG_SOURCES["SPLASH4"] = "splash_credits.png"
 
 local IMG_FAILED = {}
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -731,23 +731,50 @@ end
           local tint = Color.new(128, 128, 128, alpha)
           Graphics.drawScaleImage(img, x, y, draw_w, draw_h, tint)
         end
-        local function DrawSplashText(alpha)
-          -- Requested: black text because splash image is white.
-          local y0 = UI.SCR.Y_MID + 120
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0,       8, UI.SCR.X, 16, "Coded by El_isra",      Color.new(0, 0, 0, alpha))
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 18,  8, UI.SCR.X, 16, "Graphics by Berion",   Color.new(0, 0, 0, alpha))
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 36,  8, UI.SCR.X, 16, "israpps.github.io",    Color.new(0, 0, 0, alpha))
+        local function DrawSplashFit(img, x, y, draw_w, draw_h, alpha)
+          if img == nil then return end
+          local img_w = Graphics.getImageWidth(img)
+          local img_h = Graphics.getImageHeight(img)
+          if img_w == nil or img_h == nil or img_w <= 0 or img_h <= 0 then return end
+          local scale = math.min(draw_w / img_w, draw_h / img_h)
+          local fit_w = Round(img_w * scale)
+          local fit_h = Round(img_h * scale)
+          local fit_x = Round(x + ((draw_w - fit_w) / 2))
+          local fit_y = Round(y + ((draw_h - fit_h) / 2))
+          local tint = Color.new(128, 128, 128, alpha or 128)
+          Graphics.drawScaleImage(img, fit_x, fit_y, fit_w, fit_h, tint)
         end
-        local function DrawSplashLayered(alpha)
+        local function DrawSplash(alpha)
           local splash_alpha = alpha or 128
-          local splash1 = IMG.SPLASH1
-          local splash2 = IMG.SPLASH2
-          local splash3 = IMG.SPLASH3
-          local splash4 = IMG.SPLASH4
-          if splash1 ~= nil then DrawSplashCover(splash1, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash2 ~= nil then DrawSplashCover(splash2, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash3 ~= nil then DrawSplashCover(splash3, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash4 ~= nil then DrawSplashCover(splash4, UI.SCR.X, UI.SCR.Y, splash_alpha) end
+          local splash_bg = IMG.splash_bg or IMG.SPLASH1
+          local splash_logo = IMG.splash_logo or IMG.SPLASH2
+          local splash_appname = IMG.splash_appname or IMG.SPLASH3
+          local splash_credits = IMG.splash_credits or IMG.SPLASH4
+
+          if splash_bg ~= nil then
+            DrawSplashCover(splash_bg, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          end
+
+          local appname_x = 32
+          local appname_y = 42
+          local appname_w = UI.SCR.X - 64
+          local appname_h = 92
+          local logo_x = 72
+          local logo_y = 118
+          local logo_w = UI.SCR.X - 144
+          local logo_h = 280
+          local credits_x = 64
+          local credits_y = UI.SCR.Y - 120
+          local credits_w = UI.SCR.X - 128
+          local credits_h = 72
+
+          DrawSplashFit(splash_appname, appname_x, appname_y, appname_w, appname_h, splash_alpha)
+          DrawSplashFit(splash_logo, logo_x, logo_y, logo_w, logo_h, splash_alpha)
+          DrawSplashFit(splash_credits, credits_x, credits_y, credits_w, credits_h, splash_alpha)
+
+          if splash_bg == nil and splash_logo == nil and splash_appname == nil and splash_credits == nil and IMG.PSL ~= nil then
+            DrawSplashCover(IMG.PSL, UI.SCR.X, UI.SCR.Y, splash_alpha)
+          end
         end
 
         local fade_in_frames = 120
@@ -788,22 +815,19 @@ end
         for i = 1, fade_in_frames do
           local alpha = Round(128 * (i / fade_in_frames))
           DrawBackground()
-          DrawSplashLayered(alpha)
-          DrawSplashText(alpha)
+          DrawSplash(alpha)
           Screen.flip() -- we dont use UI.flip here because we dont want notifications on the welcome screen
         end
         for _ = 1, boot_hold_frames do
           DrawBackground()
-          DrawSplashLayered(128)
-          DrawSplashText(128)
+          DrawSplash(128)
           Screen.flip()
         end
         if show_credits and fade_mid_frames > 0 then
           for i = 1, fade_mid_frames do
             local alpha = Round(128 * (1 - (i / fade_mid_frames)))
             DrawTargetScene(UI.SCENES.CREDITS)
-            DrawSplashLayered(alpha)
-            DrawSplashText(alpha)
+            DrawSplash(alpha)
             Screen.flip()
           end
         end

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1277,7 +1277,6 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 	d.size = size;
 	d.cur = 0;
 	//png_set_error_fn(png_ptr, &error_parameters, pngtest_error, pngtest_warning);
-	DPRINTF("%s: Info: %p %d \n",__func__, d.buf, d.size);
 	png_set_read_fn(png_ptr, (png_voidp)&d, (png_rw_ptr)PNG_read_data);
 
 	//png_init_io(png_ptr, hwc_credits_png);
@@ -1289,16 +1288,9 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
 	png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type,&interlace_type, NULL, NULL);
 
-	png_set_strip_16(png_ptr);
-
-	if (color_type == PNG_COLOR_TYPE_PALETTE)
-		png_set_expand(png_ptr);
-
-	if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
-		png_set_expand(png_ptr);
-
-	if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS))
-		png_set_tRNS_to_alpha(png_ptr);
+	if (bit_depth == 16) png_set_strip_16(png_ptr);
+	if (color_type == PNG_COLOR_TYPE_GRAY || bit_depth < 4) png_set_expand(png_ptr);
+	if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) png_set_tRNS_to_alpha(png_ptr);
 
 	png_set_filler(png_ptr, 0xff, PNG_FILLER_AFTER);
 
@@ -1309,6 +1301,7 @@ GSTEXTURE* loadEmbeddedPNG(uint8_t * data, size_t size, bool delayed)
 
         tex->VramClut = 0;
         tex->Clut = NULL;
+	tex->ClutStorageMode = GS_CLUT_STORAGE_CSM1;
 
 	if(png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_RGB_ALPHA)
 	{

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -563,12 +563,22 @@ static int lua_getloaddata(lua_State *L){
 static int lua_load_embedded_png(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 2) return luaL_error(L, "wrong number of arguments");
-    lua_gc(L, LUA_GCCOLLECT, 0);
-	uint8_t* ptr = (uint8_t *)luaL_checkstring(L, 1);
-	size_t siz = luaL_checkinteger(L, 2);
-	GSTEXTURE* image = NULL;
-	image = loadEmbeddedPNG(ptr, siz, true);
-	lua_pushinteger(L, (uint32_t)(image));
+	size_t blob_len = 0;
+	const char *blob = luaL_checklstring(L, 1, &blob_len);
+
+	// Respect caller-supplied length, but clamp to real string length to avoid overruns.
+	size_t siz = (size_t)luaL_checkinteger(L, 2);
+	if (siz > blob_len) siz = blob_len;
+
+	lua_gc(L, LUA_GCCOLLECT, 0);
+	GSTEXTURE *image = loadEmbeddedPNG((uint8_t*)blob, siz, true);
+
+	if (image == NULL) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_pushinteger(L, (uint32_t)image);
 	return 1;
 }
 //Register our Graphics Functions


### PR DESCRIPTION
### Motivation
- Background images embedded in the binary were decoding differently from file-loaded PNGs, breaking splash/BG rendering and CLUT-backed images.  
- The boot splash layout in the current tree was rendered as fullscreen layers instead of the checkpoint's fit/position layout, causing misaligned logo/appname/credits.  
- Make a minimal, targeted port of the checkpoint behavior so embedded backgrounds render and the splash aligns correctly without changing timing math or reintroducing filesystem loading.

### Description
- Adjusted PNG transforms in `loadEmbeddedPNG` so the embedded path uses the same libpng setup as the file loader (`if (bit_depth == 16) png_set_strip_16...`, `png_set_expand` rules, `png_set_tRNS_to_alpha`, `png_set_filler`), removed the noisy `DPRINTF` info line, and set `tex->ClutStorageMode = GS_CLUT_STORAGE_CSM1` for embedded textures in `src/graphics.cpp`.  
- Kept the rest of the embedded decode/upload flow unchanged so behavior is consistent with the existing `loadpng(FILE*)` path.  
- Reworked image registration in `bin/POPSLDR/images.lua` to register by filename-derived keys (basename without extension), added `BG.png` alongside `BKG.png`/`BGM.png`, and added legacy aliases `SPLASH1..4` -> `splash_bg.png`, `splash_logo.png`, `splash_appname.png`, `splash_credits.png` to preserve backward compatibility.  
- Replaced layered fullscreen splash rendering with checkpoint-style fit composition in `bin/POPSLDR/ui.lua` by adding `DrawSplashFit` and `DrawSplash` (using `IMG.splash_*` keys with legacy fallback) and switching the welcome-sequence draw calls to `DrawSplash(alpha)` while preserving all timing/hold/fade calculations.

### Testing
- Verified diffs with `git diff -- src/graphics.cpp bin/POPSLDR/images.lua bin/POPSLDR/ui.lua` to confirm the intended changes were applied.  
- Confirmed changes were committed in a single commit with the requested message via `git status`/commit output.  
- Attempted Lua syntax checks with `luac -p bin/POPSLDR/images.lua && luac -p bin/POPSLDR/ui.lua` but the environment lacks `luac`, so byte-compile checks could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d33865f883219bed92f195a4e8b3)