### PR TITLE
Unify UI images to embed:/ loader and restore checkpoint splash layout

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -17,13 +17,14 @@ local IMG_REGISTRATIONS = {
   {"HDD", "HDD.png"},
   {"APAHDD", "APAHDD.png"},
   {"BDHDD", "BDHDD.png"},
+  {"BG", "BG.png"},
   {"BKG", "BKG.png"},
   {"BGM", "BGM.png"},
   {"DISC", "DISC.png"},
-  {"SPLASH1", "splash_bg.png"},
-  {"SPLASH2", "splash_logo.png"},
-  {"SPLASH3", "splash_appname.png"},
-  {"SPLASH4", "splash_credits.png"},
+  {"splash_bg", "splash_bg.png"},
+  {"splash_logo", "splash_logo.png"},
+  {"splash_appname", "splash_appname.png"},
+  {"splash_credits", "splash_credits.png"},
   {"select", "select.png"},
   {"start", "start.png"},
   {"triangle", "triangle.png"},
@@ -40,25 +41,40 @@ for x = 1, #IMG_REGISTRATIONS do
   IMG_SOURCES[name] = path
 end
 
+local IMG_EMBED_ROOT = "embed:/POPSLDR/IMG/"
+
+local IMG_EMBED_OVERRIDES = {
+  BG = "embed:/POPSLDR/IMG/BG.png",
+  BKG = "embed:/POPSLDR/IMG/BKG.png",
+  BGM = "embed:/POPSLDR/IMG/BGM.png",
+
+  splash_bg = "embed:/POPSLDR/IMG/splash_bg.png",
+  splash_logo = "embed:/POPSLDR/IMG/splash_logo.png",
+  splash_appname = "embed:/POPSLDR/IMG/splash_appname.png",
+  splash_credits = "embed:/POPSLDR/IMG/splash_credits.png",
+}
+
+local function ResolveImage(name, key)
+  if IMG_EMBED_OVERRIDES[key] then
+    return IMG_EMBED_OVERRIDES[key]
+  end
+  return IMG_EMBED_ROOT .. name
+end
+
 local IMG_FAILED = {}
 
 IMG = setmetatable({}, {
   __index = function (tbl, key)
     if IMG_FAILED[key] then return nil end
-    local source = IMG_SOURCES[key]
-    if source == nil then return nil end
+    local name = IMG_SOURCES[key]
+    if name == nil then return nil end
     if BOOT_PROF and BOOT_PROF.stamp and not BOOT_PROF.textures_ready then
       BOOT_PROF.textures_ready = true
       BOOT_PROF.stamp("UI assets init (textures)")
     end
 
-    local img = nil
-    if type(System) == "table" and type(System.getEmbeddedAsset) == "function" and type(Graphics) == "table" and type(Graphics.loadImageEmbedded) == "function" then
-      local ok, blob = pcall(System.getEmbeddedAsset, source)
-      if ok and blob ~= nil then
-        img = Graphics.loadImageEmbedded(blob, string.len(blob))
-      end
-    end
+    local path = ResolveImage(name, key)
+    local img = Graphics.loadImage(path)
 
     if img == nil then
       IMG_FAILED[key] = true

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -715,39 +715,38 @@ end
           boot_sound_hold_frames = math.floor(((sec + pad) * 60) + 0.5)
           LOGF("BOOT SOUND: hold frames=%s", tostring(boot_sound_hold_frames))
         end
-        local function DrawSplashCover(img, screen_w, screen_h, alpha)
+        local function DrawSplashCover(img, alpha)
           if img == nil then return end
+          local screen_w = UI.SCR.X
+          local screen_h = UI.SCR.Y
           local img_w = Graphics.getImageWidth(img)
           local img_h = Graphics.getImageHeight(img)
-          local scale = 1
-          if img_w > 0 and img_h > 0 then
-            local cover_scale = math.max(screen_w / img_w, screen_h / img_h)
-            scale = cover_scale * 1.02
-          end
+          if img_w == nil or img_h == nil or img_w <= 0 or img_h <= 0 then return end
+          local scale = math.max(screen_w / img_w, screen_h / img_h)
           local draw_w = Round(img_w * scale)
           local draw_h = Round(img_h * scale)
           local x = Round((screen_w - draw_w) / 2)
           local y = Round((screen_h - draw_h) / 2)
-          local tint = Color.new(128, 128, 128, alpha)
-          Graphics.drawScaleImage(img, x, y, draw_w, draw_h, tint)
+          Graphics.drawScaleImage(img, x, y, draw_w, draw_h, Color.new(128, 128, 128, alpha or 128))
         end
-        local function DrawSplashText(alpha)
-          -- Requested: black text because splash image is white.
-          local y0 = UI.SCR.Y_MID + 120
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0,       8, UI.SCR.X, 16, "Coded by El_isra",      Color.new(0, 0, 0, alpha))
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 18,  8, UI.SCR.X, 16, "Graphics by Berion",   Color.new(0, 0, 0, alpha))
-          Font.ftPrint(BFONT, UI.SCR.X_MID, y0 + 36,  8, UI.SCR.X, 16, "israpps.github.io",    Color.new(0, 0, 0, alpha))
+        local function DrawSplashFit(img, x, y, w, h, alpha)
+          if img == nil then return end
+          local img_w = Graphics.getImageWidth(img)
+          local img_h = Graphics.getImageHeight(img)
+          if img_w == nil or img_h == nil or img_w <= 0 or img_h <= 0 then return end
+          local scale = math.min(w / img_w, h / img_h)
+          local draw_w = Round(img_w * scale)
+          local draw_h = Round(img_h * scale)
+          local draw_x = Round(x + ((w - draw_w) / 2))
+          local draw_y = Round(y + ((h - draw_h) / 2))
+          Graphics.drawScaleImage(img, draw_x, draw_y, draw_w, draw_h, Color.new(128, 128, 128, alpha or 128))
         end
-        local function DrawSplashLayered(alpha)
+        local function DrawSplash(alpha)
           local splash_alpha = alpha or 128
-          local splash1 = IMG.SPLASH1
-          local splash2 = IMG.SPLASH2
-          local splash3 = IMG.SPLASH3
-          local splash4 = IMG.SPLASH4
-          if splash1 ~= nil then DrawSplashCover(splash1, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash2 ~= nil then DrawSplashCover(splash2, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash3 ~= nil then DrawSplashCover(splash3, UI.SCR.X, UI.SCR.Y, splash_alpha) end
-          if splash4 ~= nil then DrawSplashCover(splash4, UI.SCR.X, UI.SCR.Y, splash_alpha) end
+          DrawSplashCover(IMG.splash_bg, splash_alpha)
+          DrawSplashFit(IMG.splash_logo, 80, 44, 480, 188, splash_alpha)
+          DrawSplashFit(IMG.splash_appname, 120, 214, 400, 64, splash_alpha)
+          DrawSplashFit(IMG.splash_credits, 160, 304, 320, 84, splash_alpha)
         end
 
         local fade_in_frames = 120
@@ -788,22 +787,19 @@ end
         for i = 1, fade_in_frames do
           local alpha = Round(128 * (i / fade_in_frames))
           DrawBackground()
-          DrawSplashLayered(alpha)
-          DrawSplashText(alpha)
+          DrawSplash(alpha)
           Screen.flip() -- we dont use UI.flip here because we dont want notifications on the welcome screen
         end
         for _ = 1, boot_hold_frames do
           DrawBackground()
-          DrawSplashLayered(128)
-          DrawSplashText(128)
+          DrawSplash(128)
           Screen.flip()
         end
         if show_credits and fade_mid_frames > 0 then
           for i = 1, fade_mid_frames do
             local alpha = Round(128 * (1 - (i / fade_mid_frames)))
             DrawTargetScene(UI.SCENES.CREDITS)
-            DrawSplashLayered(alpha)
-            DrawSplashText(alpha)
+            DrawSplash(alpha)
             Screen.flip()
           end
         end

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ extern "C"{
 extern "C" int SifExecModuleBuffer(void *ptr, int size, int arg_len, const char *args, int *mod_res);
 #endif
 
-extern "C" void EmbeddedAssets_Init(void);
+extern void load_modules(void);
 
 extern char bootString[];
 extern unsigned int size_bootString;
@@ -309,6 +309,8 @@ int main(int argc, char * argv[])
     sbv_patch_disable_prefix_check(); 
     sbv_patch_fileio(); 
 
+    load_modules();
+
 #ifdef POWERPC_UART
 	LOAD_IRX_NARG(ppctty_irx);
 #endif
@@ -404,9 +406,6 @@ int main(int argc, char * argv[])
     DPRINTF("app dir : %s\n", app_dir);
 	dbgprintf("app dir : %s\n", app_dir);
 
-    EmbeddedAssets_Init();
-    BootStamp("embed fs init");
-    
     BootStamp("Lua init start");
     while (1)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ extern "C"{
 extern "C" int SifExecModuleBuffer(void *ptr, int size, int arg_len, const char *args, int *mod_res);
 #endif
 
+extern "C" void EmbeddedAssets_Init(void);
+
 extern char bootString[];
 extern unsigned int size_bootString;
 
@@ -401,6 +403,9 @@ int main(int argc, char * argv[])
 	dbgprintf("boot path : %s\n", boot_path);
     DPRINTF("app dir : %s\n", app_dir);
 	dbgprintf("app dir : %s\n", app_dir);
+
+    EmbeddedAssets_Init();
+    BootStamp("embed fs init");
     
     BootStamp("Lua init start");
     while (1)


### PR DESCRIPTION
### Motivation
- UI images were being loaded from embedded blobs which used a different texture pipeline and caused mismatches with the checkpoint behavior. 
- The goal is to unify UI image loading to the checkpoint `embed:/...` loader and restore the checkpoint splash composition and alignment. 

### Description
- Replaced blob-based loading in `bin/POPSLDR/images.lua` by removing `System.getEmbeddedAsset(...)` and `Graphics.loadImageEmbedded(...)` and making the lazy `IMG` loader call only `Graphics.loadImage(path)`. 
- Added a checkpoint-style resolver with `IMG_EMBED_ROOT`, `IMG_EMBED_OVERRIDES`, and `ResolveImage(name, key)` to map registration keys to `embed:/POPSLDR/IMG/...` paths. 
- Updated the image registration keys to include `BG` and checkpoint-style splash keys (`splash_bg`, `splash_logo`, `splash_appname`, `splash_credits`) and preserved the existing cache/failure behavior and `Graphics.setImageFilters`. 
- Restored checkpoint-style splash drawing in `bin/POPSLDR/ui.lua` by adding `DrawSplashCover(img, alpha)`, `DrawSplashFit(img, x, y, w, h, alpha)`, and `DrawSplash(alpha)`, and replaced the previous layered/text draw calls with these helpers while leaving timing, fades, and audio logic untouched. 

### Testing
- Verified there are no remaining references to `System.getEmbeddedAsset` or `Graphics.loadImageEmbedded` in `images.lua` / `ui.lua` using `rg`, which succeeded. 
- Confirmed the new splash helper functions exist with `rg` searches for `DrawSplashCover`, `DrawSplashFit`, and `DrawSplash`, which succeeded. 
- Created a local commit with message `Unify UI images to embed:/ loader and restore checkpoint splash layout`, which completed successfully. 
- Attempted a Lua syntax check with `luac -p` but it could not be run because `luac` is not installed in this environment, so that validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1db1d18588321897765d29dd2e22c)