### PR TITLE
Add libpng interlace handling to embedded PNG decode path

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -71,6 +71,13 @@ static GSTEXTURE* decode_png_stream(png_structp png_ptr, png_infop info_ptr, boo
 	int row, i, k = 0, j, bit_depth, color_type, interlace_type;
 
 	png_read_info(png_ptr, info_ptr);
+	/* Enable proper handling for interlaced PNGs.
+	   Required before png_read_update_info/png_read_image.
+	   No performance impact for non-interlaced images. */
+	if (png_get_interlace_type(png_ptr, info_ptr) != PNG_INTERLACE_NONE)
+	{
+		png_set_interlace_handling(png_ptr);
+	}
 	png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, &interlace_type, NULL, NULL);
 
 	if (bit_depth == 16) png_set_strip_16(png_ptr);


### PR DESCRIPTION
### Motivation
- libpng emits a runtime warning for interlaced images because interlace handling must be enabled before `png_read_update_info`/`png_read_image`, so a minimal change is required to decode embedded interlaced PNGs deterministically without affecting non-interlaced performance or texture behavior.

### Description
- Inserted a conditional interlace-handling block in `decode_png_stream(...)` immediately after `png_read_info(...)` that calls `png_set_interlace_handling(png_ptr)` only when `png_get_interlace_type(...) != PNG_INTERLACE_NONE`, and left the call before `png_read_update_info(...)` and any `png_read_image(...)` usage; the change is limited to `src/graphics.cpp` with no other refactors or behavioral changes.

### Testing
- Verified locations with `rg -n "decode_png_stream|png_read_info|png_read_update_info|png_read_image" src/graphics.cpp` and confirmed the interlace call sits between `png_read_info` and `png_read_update_info` (succeeded). 
- Inspected the file diff with `git diff -- src/graphics.cpp` and reviewed the insertion is the only substantive change in `src/graphics.cpp` (succeeded). 
- Displayed the modified region with `nl -ba src/graphics.cpp | sed -n '64,92p'` to confirm formatting and exact placement (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ed354c8483218a840cd690fd9b17)