### PR TITLE
Adjust transition and boot pacing with longer inclusive totals

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -776,8 +776,8 @@ end
         end
 
         local show_credits = show_boot_credits == true
-        local FADE_IN_MS = 1500
-        local FADE_OUT_MS = 1200
+        local FADE_IN_MS = 1600
+        local FADE_OUT_MS = 1400
 
         local function Clamp01(value)
           if value < 0 then return 0 end
@@ -863,8 +863,8 @@ end
 
         -- Start boot sound once; fixed boot totals must not be lengthened by audio duration.
         TryBootSound()
-        local SPLASH_TOTAL_MS = 3000
-        local CREDITS_TOTAL_MS = 4000
+        local SPLASH_TOTAL_MS = 5500
+        local CREDITS_TOTAL_MS = 6500
         local splash_hold_ms = SPLASH_TOTAL_MS - (FADE_IN_MS + FADE_OUT_MS)
         if splash_hold_ms < 0 then splash_hold_ms = 0 end
         local credits_hold_ms = CREDITS_TOTAL_MS - (FADE_IN_MS + FADE_OUT_MS)
@@ -1066,8 +1066,8 @@ end
       elapsed = 0,
       last_time = nil,
       max_step = 33,
-      duration_out = 1200,
-      duration_in = 1500,
+      duration_out = 1400,
+      duration_in = 1600,
       Queue = function (target)
         if target == nil then return end
         if UI.Transition.active and UI.Transition.phase == "out" then


### PR DESCRIPTION
### Motivation
- Runtime fades and boot intro/credits felt too fast and did not hold long enough under the existing inclusive-total constraint. 
- The intent is to slow fades to a premium pace while increasing inclusive TOTAL windows so fades remain included but holds are meaningfully longer. 

### Description
- Set runtime transition defaults in `UI.Transition` to `duration_in = 1600` and `duration_out = 1400` while preserving existing easing and phase logic. 
- In `UI.WelcomeDraw.Play()` updated boot fade constants to `FADE_IN_MS = 1600` and `FADE_OUT_MS = 1400`. 
- Increased inclusive boot totals to `SPLASH_TOTAL_MS = 5500` and `CREDITS_TOTAL_MS = 6500`, and kept hold computation as `total - (FADE_IN_MS + FADE_OUT_MS)` with a floor at zero. 
- Preserved the exact boot chain (`StepFade` / `StepHold` sequence), retained `TryBootSound()` behavior, and did not add any audio-based extension of splash/credits durations; only `bin/POPSLDR/ui.lua` was modified. 

### Testing
- Ran `rg` searches to verify the numeric replacements for `FADE_IN_MS`, `FADE_OUT_MS`, `SPLASH_TOTAL_MS`, `CREDITS_TOTAL_MS`, `duration_in`, and `duration_out`, and the searches returned the updated occurrences as expected (success). 
- Inspected the diff with `git diff -- bin/POPSLDR/ui.lua` to confirm the change is limited to the intended numeric timing updates in `bin/POPSLDR/ui.lua` (success). 
- Committed the single-file change and created the PR metadata via the automated `make_pr` invocation (commit/PR creation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a209702af08321b862605472fba5c8)