### PR TITLE
Add deferred BDMA mode save/apply flow in Profiles

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -31,6 +31,8 @@ local IMG_REGISTRATIONS = {
   {"cross", "cross.png"},
   {"R2", "R2.png"},
   {"square", "square.png"},
+  {"left", "left.png"},
+  {"right", "right.png"},
 }
 
 local IMG_SOURCES = {}

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -71,6 +71,7 @@ function JoinPath(base, rel)
 end
 
 local APP_DIR_LOCAL = NormalizeDirPath(APP_DIR or BOOT_PATH_RAW)
+APP_DIR_NORM = APP_DIR_LOCAL
 local SELECTOR_MODE = "basename"
 
 local function ResolveAsset(rel)
@@ -268,39 +269,25 @@ if UI.DEVLOCK ~= nil then
 end
 require("images")
 
-local POPSTARTER_PACK_ROOT = "mc0:/POPSTARTER"
-local POPSTARTER_UI_FILES = {
+PLDR.POPSTARTER_DIR = "mc0:/POPSTARTER"
+PLDR.SETTINGS_PATH = "mc0:/POPSTARTER/.pldrs"
+PLDR.BDMA_MODE_KEY = "FAT32"
+PLDR.SELECTED_PROFILE = tonumber(PLDR.DEFAULT_PROFILE) or 1
+
+local POPSTARTER_PACK_ROOT = PLDR.POPSTARTER_DIR
+local BDMA_COPY_FILES = {
+  "usbd.irx",
+  "usbhdfsd.irx",
   "icon.sys",
   "list.icn",
+  "copy.icn",
   "del.icn"
 }
-local BDMA_MODE_KEYS = {
-  USBEXFAT = "usbexfat",
-  MMCE = "fat32",
-  MX4SIO = "mx4sio"
+local BDMA_SUFFIX = {
+  USBEXFAT = ".usbexfat",
+  MX4SIO = ".mx4sio",
+  MMCE = ".mmce"
 }
-
-local function ExternalCandidatesFor(name, mode_key)
-  local suffix = string.lower(mode_key or "")
-  local candidates = {}
-  if suffix ~= "" then
-    candidates[#candidates + 1] = JoinPath(APP_DIR_LOCAL, name.."."..suffix)
-    candidates[#candidates + 1] = JoinPath(APP_DIR_LOCAL, "POPSLDR/"..name.."."..suffix)
-    candidates[#candidates + 1] = JoinPath(APP_DIR_LOCAL, "POPSTARTER/"..string.upper(suffix).."/"..name)
-  end
-  return candidates
-end
-
-local function ResolveExternalBdmaSource(name, mode_key)
-  local candidates = ExternalCandidatesFor(name, mode_key)
-  for i = 1, #candidates do
-    local source = candidates[i]
-    if doesFileExist(source) then
-      return source
-    end
-  end
-  return nil
-end
 
 local function ReadWholeFile(path)
   local fd = System.openFile(path, FREAD)
@@ -363,6 +350,99 @@ local function EnsureDirectory(path)
   return ok
 end
 
+function PLDR.EnsurePopstarterDir()
+  return EnsureDirectory(PLDR.POPSTARTER_DIR)
+end
+
+local function EncodeSettings()
+  local lines = {
+    "PROFILE="..tostring(tonumber(PLDR.SELECTED_PROFILE) or 1),
+    "POPSTARTER_PATH="..tostring(PLDR.POPSTARTER_PATH or ""),
+    "BDMA_MODE="..tostring(PLDR.BDMA_MODE_KEY or "FAT32")
+  }
+  return table.concat(lines, "\n").."\n"
+end
+
+function PLDR.SaveSettingsAtomic()
+  PLDR.EnsurePopstarterDir()
+  local data = EncodeSettings()
+  local ok = WriteAtomic(PLDR.SETTINGS_PATH, data)
+  if not ok and UI ~= nil and UI.Notif_queue ~= nil then
+    UI.Notif_queue.add("Failed to save settings")
+  end
+  return ok
+end
+
+function PLDR.LoadSettingsNonFatal()
+  local defaults_profile = tonumber(PLDR.DEFAULT_PROFILE) or 1
+  PLDR.SELECTED_PROFILE = defaults_profile
+  PLDR.BDMA_MODE_KEY = "FAT32"
+  if PLDR.PROFILES ~= nil and PLDR.PROFILES[defaults_profile] ~= nil then
+    PLDR.POPSTARTER_PATH = PLDR.PROFILES[defaults_profile].ELF
+  end
+  if not doesFileExist(PLDR.SETTINGS_PATH) then
+    return false
+  end
+  local data = ReadWholeFile(PLDR.SETTINGS_PATH)
+  if data == nil then
+    return false
+  end
+  local profile = tonumber(string.match(data, "\nPROFILE=([^\n]+)")) or tonumber(string.match(data, "^PROFILE=([^\n]+)"))
+  local popstarter_path = string.match(data, "\nPOPSTARTER_PATH=([^\n]*)") or string.match(data, "^POPSTARTER_PATH=([^\n]*)")
+  local bdma_mode = string.match(data, "\nBDMA_MODE=([^\n]+)") or string.match(data, "^BDMA_MODE=([^\n]+)")
+  if profile ~= nil and PLDR.PROFILES ~= nil and PLDR.PROFILES[profile] ~= nil then
+    PLDR.SELECTED_PROFILE = profile
+    PLDR.POPSTARTER_PATH = PLDR.PROFILES[profile].ELF
+  end
+  if popstarter_path ~= nil and popstarter_path ~= "" then
+    PLDR.POPSTARTER_PATH = popstarter_path
+  end
+  if bdma_mode == "FAT32" or bdma_mode == "USBEXFAT" or bdma_mode == "MX4SIO" or bdma_mode == "MMCE" then
+    PLDR.BDMA_MODE_KEY = bdma_mode
+  end
+  return true
+end
+
+function PLDR.ApplyBdmaMode(mode_key)
+  local selected = mode_key or "FAT32"
+  PLDR.EnsurePopstarterDir()
+  if selected == "FAT32" then
+    pcall(System.removeFile, POPSTARTER_PACK_ROOT.."/usbd.irx")
+    pcall(System.removeFile, POPSTARTER_PACK_ROOT.."/usbhdfsd.irx")
+    return true
+  end
+
+  local suffix = BDMA_SUFFIX[selected]
+  if suffix == nil then
+    if UI ~= nil and UI.Notif_queue ~= nil then
+      UI.Notif_queue.add("Unknown BDMA mode: "..tostring(selected))
+    end
+    return false
+  end
+
+  local had_failure = false
+  for i = 1, #BDMA_COPY_FILES do
+    local name = BDMA_COPY_FILES[i]
+    local source = APP_DIR_NORM..name..suffix
+    local dest = POPSTARTER_PACK_ROOT.."/"..name
+    if not doesFileExist(source) then
+      had_failure = true
+      if UI ~= nil and UI.Notif_queue ~= nil then
+        UI.Notif_queue.add("Missing BDMA source: "..source)
+      end
+    else
+      local ok = CopyExternalAtomic(source, dest)
+      if not ok then
+        had_failure = true
+        if UI ~= nil and UI.Notif_queue ~= nil then
+          UI.Notif_queue.add("Failed BDMA copy: "..source)
+        end
+      end
+    end
+  end
+  return not had_failure
+end
+
 local function RemoveDirectoryRecursive(path)
   local normalized = NormalizeDirPath(path)
   if not doesFolderExist(normalized) then
@@ -412,56 +492,7 @@ local function ResolvePackUiSource(name)
 end
 
 function PLDR.ApplyPopstarterPack(pack_key)
-  local mode_key = BDMA_MODE_KEYS[pack_key]
-  if mode_key == nil then
-    UI.Notif_queue.add("Unknown POPSTARTER pack: "..tostring(pack_key))
-    return false
-  end
-  if not EnsureDirectory(POPSTARTER_PACK_ROOT) then
-    UI.Notif_queue.add("Failed to create "..POPSTARTER_PACK_ROOT)
-    return false
-  end
-
-  local had_failure = false
-  local bdma_files = {"usbd.irx", "usbhdfsd.irx"}
-  for i = 1, #bdma_files do
-    local name = bdma_files[i]
-    local source = ResolveExternalBdmaSource(name, mode_key)
-    local dest = POPSTARTER_PACK_ROOT.."/"..name
-    if source == nil then
-      UI.Notif_queue.add("BDMA module missing: "..name)
-      had_failure = true
-    else
-      local ok = CopyExternalAtomic(source, dest)
-      if not ok then
-        UI.Notif_queue.add("BDMA module missing: "..name)
-        had_failure = true
-      end
-    end
-  end
-
-  for i = 1, #POPSTARTER_UI_FILES do
-    local name = POPSTARTER_UI_FILES[i]
-    local dest = POPSTARTER_PACK_ROOT.."/"..name
-    local source = ResolvePackUiSource(name)
-    if doesFileExist(source) then
-      local ok = CopyExternalAtomic(source, dest)
-      if not ok then
-        UI.Notif_queue.add("Missing pack file: "..name)
-        had_failure = true
-      end
-    else
-      UI.Notif_queue.add("Missing pack file: "..name)
-      had_failure = true
-    end
-  end
-
-  if had_failure then
-    UI.Notif_queue.add("Applied "..pack_key.." pack with missing files")
-    return false
-  end
-  UI.Notif_queue.add("Installed "..pack_key.." pack to "..POPSTARTER_PACK_ROOT)
-  return true
+  return PLDR.ApplyBdmaMode(pack_key)
 end
 
 function PLDR.ResetPopstarterPack()
@@ -1433,6 +1464,8 @@ function Touch(FILE)
     return false
   end
 end
+
+PLDR.LoadSettingsNonFatal()
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.MMAIN

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -367,6 +367,13 @@ function PLDR.EnsurePopstarterDir()
   return EnsureDirectory(PLDR.POPSTARTER_DIR)
 end
 
+function PLDR.AppDirPath(rel)
+  if rel == nil or rel == "" then
+    return APP_DIR_LOCAL
+  end
+  return JoinPath(APP_DIR_LOCAL, rel)
+end
+
 local function EncodeSettings()
   local lines = {
     "PROFILE="..tostring(tonumber(PLDR.SELECTED_PROFILE) or 1),
@@ -436,7 +443,7 @@ function PLDR.ApplyBdmaMode(mode_key)
   local had_failure = false
   for i = 1, #BDMA_COPY_FILES do
     local name = BDMA_COPY_FILES[i]
-    local source = APP_DIR_NORM..name..suffix
+    local source = PLDR.AppDirPath(name..suffix)
     local dest = POPSTARTER_PACK_ROOT.."/"..name
     if not doesFileExist(source) then
       had_failure = true

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -378,7 +378,7 @@ local function EncodeSettings()
   local lines = {
     "PROFILE="..tostring(tonumber(PLDR.SELECTED_PROFILE) or 1),
     "POPSTARTER_PATH="..tostring(PLDR.POPSTARTER_PATH or ""),
-    "BDMA_MODE="..tostring(PLDR.BDMA_MODE_KEY or "FAT32")
+    "BDMA="..tostring(PLDR.BDMA_MODE_KEY or "FAT32")
   }
   return table.concat(lines, "\n").."\n"
 end
@@ -409,7 +409,7 @@ function PLDR.LoadSettingsNonFatal()
   end
   local profile = tonumber(string.match(data, "\nPROFILE=([^\n]+)")) or tonumber(string.match(data, "^PROFILE=([^\n]+)"))
   local popstarter_path = string.match(data, "\nPOPSTARTER_PATH=([^\n]*)") or string.match(data, "^POPSTARTER_PATH=([^\n]*)")
-  local bdma_mode = string.match(data, "\nBDMA_MODE=([^\n]+)") or string.match(data, "^BDMA_MODE=([^\n]+)")
+  local bdma_mode = string.match(data, "\nBDMA=([^\n]+)") or string.match(data, "^BDMA=([^\n]+)") or string.match(data, "\nBDMA_MODE=([^\n]+)") or string.match(data, "^BDMA_MODE=([^\n]+)")
   if profile ~= nil and PLDR.PROFILES ~= nil and PLDR.PROFILES[profile] ~= nil then
     PLDR.SELECTED_PROFILE = profile
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[profile].ELF
@@ -419,6 +419,86 @@ function PLDR.LoadSettingsNonFatal()
   end
   if bdma_mode == "FAT32" or bdma_mode == "USBEXFAT" or bdma_mode == "MX4SIO" or bdma_mode == "MMCE" then
     PLDR.BDMA_MODE_KEY = bdma_mode
+  end
+  return true
+end
+
+function PLDR.ParseMassIndexFromPath(path)
+  local source = NormalizeDirPath(path or APP_DIR_NORM)
+  local index = string.match(source, "^mass(%d+):/")
+  if index ~= nil then
+    return tonumber(index)
+  end
+  if string.match(source, "^mass:/") then
+    return 0
+  end
+  return nil
+end
+
+function PLDR.GetMassDriverName(index)
+  if index == nil then return nil end
+  if type(System) == "table" then
+    if type(System.getMassDriverName) == "function" then
+      local ok, driver = pcall(System.getMassDriverName, index)
+      if ok and type(driver) == "string" and driver ~= "" then
+        return string.lower(driver)
+      end
+    end
+    if type(System.getMassDriver) == "function" then
+      local ok, driver = pcall(System.getMassDriver, index)
+      if ok and type(driver) == "string" and driver ~= "" then
+        return string.lower(driver)
+      end
+    end
+  end
+  return nil
+end
+
+function PLDR.EnsureBackendForAppDir()
+  local path = APP_DIR_NORM
+  if path == nil then return false end
+  if string.match(path, "^host:/") then
+    return true
+  end
+  if string.match(path, "^mmce%d*:/") then
+    if type(System) == "table" and type(System.initMMCE) == "function" then
+      local ok = pcall(System.initMMCE)
+      return ok
+    end
+    return true
+  end
+  if string.match(path, "^mx4sio%d*:/") then
+    if type(_G.ensureMx4sioInit) == "function" then
+      local ok = pcall(_G.ensureMx4sioInit)
+      if ok then return true end
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      local ok = pcall(System.initMX4SIO)
+      return ok
+    end
+    return true
+  end
+  if string.match(path, "^mass%d*:/") then
+    local idx = PLDR.ParseMassIndexFromPath(path)
+    local driver = PLDR.GetMassDriverName(idx)
+    if driver ~= nil then
+      if string.find(driver, "sdc", 1, true) ~= nil then
+        if type(_G.ensureMx4sioInit) == "function" then
+          local ok = pcall(_G.ensureMx4sioInit)
+          if ok then return true end
+        end
+        if type(System) == "table" and type(System.initMX4SIO) == "function" then
+          local ok = pcall(System.initMX4SIO)
+          if ok then return true end
+        end
+      elseif string.find(driver, "usb", 1, true) ~= nil then
+        if type(System) == "table" and type(System.initUSB) == "function" then
+          local ok = pcall(System.initUSB)
+          if ok then return true end
+        end
+      end
+    end
+    return true
   end
   return true
 end
@@ -440,23 +520,29 @@ function PLDR.ApplyBdmaMode(mode_key)
     return false
   end
 
+  if not PLDR.EnsureBackendForAppDir() then
+    if UI ~= nil and UI.Notif_queue ~= nil then
+      UI.Notif_queue.add("BDMA source backend not ready:\n"..APP_DIR_NORM)
+    end
+    return false
+  end
+
   local had_failure = false
+  local missing_notified = false
   for i = 1, #BDMA_COPY_FILES do
     local name = BDMA_COPY_FILES[i]
     local source = PLDR.AppDirPath(name..suffix)
     local dest = POPSTARTER_PACK_ROOT.."/"..name
     if not doesFileExist(source) then
       had_failure = true
-      if UI ~= nil and UI.Notif_queue ~= nil then
-        UI.Notif_queue.add("Missing BDMA source: "..source)
+      if not missing_notified and UI ~= nil and UI.Notif_queue ~= nil then
+        UI.Notif_queue.add("Missing BDMA source:\n"..source)
+        missing_notified = true
       end
     else
       local ok = CopyExternalAtomic(source, dest)
       if not ok then
         had_failure = true
-        if UI ~= nil and UI.Notif_queue ~= nil then
-          UI.Notif_queue.add("Failed BDMA copy: "..source)
-        end
       end
     end
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -231,6 +231,19 @@ if MMCE_SLOT0_READY ~= nil and MMCE_SLOT0_READY >= 0 then
   end
 end
 
+
+function CLAMP(a, MIN, MAX)
+  if a < MIN then return MIN end
+  if a > MAX then return MAX end
+  return a
+end
+
+function CYCLE_CLAMP(a, MIN, MAX)
+  if a < MIN then return MAX end
+  if a > MAX then return MIN end
+  return a
+end
+
 require("pops_profiles")
 local ok_ui, ui_or_err = pcall(require, "ui")
 if not ok_ui then
@@ -554,18 +567,6 @@ function PLDR.SetMMCESlot(index)
   return PLDR.MMCE.PREFIX
 end
 
-
-function CLAMP(a, MIN, MAX)
-  if a < MIN then return MIN end
-  if a > MAX then return MAX end
-  return a
-end
-
-function CYCLE_CLAMP(a, MIN, MAX)
-  if a < MIN then return MAX end
-  if a > MAX then return MIN end
-  return a
-end
 
 function Font.ftPrintMultiLineAligned(font, x, y, spacing, width, height, text, color)
   local internal_y = y

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -320,6 +320,27 @@ UI = {
       MIN_ACTION_MS = 220;
       DEBUG_INPUT_LOG = false;
     };
+    BdmaModes = {
+      { key = "FAT32", label = "FAT32-USB (None)" },
+      { key = "USBEXFAT", label = "exFAT-USB" },
+      { key = "MX4SIO", label = "MX4SIO" },
+      { key = "MMCE", label = "MMCE" }
+    };
+    BdmaModeIndex = 1;
+    BdmaDirty = false;
+    ProfileDirty = false;
+    ShowSavingOverlay = function ()
+      UI.Modal.active = true
+      UI.Modal.title = "Saving..."
+      UI.Modal.body = "Applying profile and BDMA settings"
+      UI.Modal.options = {"", ""}
+      UI.Modal.confirm_action = nil
+      UI.Modal.cancel_action = nil
+      UI.Modal.triangle_action = nil
+      UI.Modal.ignore_until_release = false
+      UI.flip()
+      UI.Modal.Close()
+    end;
     --- Notifications queue handler
     Notif_queue = {
       display = function ()
@@ -1319,35 +1340,86 @@ end
         Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 30, 8, UI.SCR.X, 16, "Profile "..UI.ProfileQuery.curopt, UI.CCOL.GREY)
         Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 140, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].DESC, UI.CCOL.GREY)
         Font.ftPrint(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 220, 8, UI.SCR.X, 16, PLDR.PROFILES[UI.ProfileQuery.curopt].ELF, Color.new(128,128,128, 110))
+
+        local mode = UI.BdmaModes[UI.BdmaModeIndex]
+        local mode_y = layout.TITLE_Y + 92
+        local left_icon = IMG.left
+        local right_icon = IMG.right
+        Font.ftPrint(BFONT, UI.SCR.X_MID - 180, mode_y, 0, 200, 16, "BDMA Mode", UI.CCOL.GREY)
+        if left_icon ~= nil then
+          Graphics.drawImage(left_icon, UI.SCR.X_MID - 36, mode_y - 2, UI.CCOL.GREY)
+        end
+        Font.ftPrint(BFONT, UI.SCR.X_MID, mode_y, 8, UI.SCR.X, 16, mode.label, UI.CCOL.GREY)
+        if right_icon ~= nil then
+          Graphics.drawImage(right_icon, UI.SCR.X_MID + 18, mode_y - 2, UI.CCOL.GREY)
+        end
+
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
-        if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
-        if UI.Pad.Events.NAV_DOWN then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt) end
-        if UI.Pad.Events.NAV_UP then UI.ProfileQuery.curopt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt) end
-        if UI.Pad.Events.BACK then UI.SceneChange(UI.SCENES.MMAIN) end
+
+        local function queue_exit(target_scene)
+          if UI.ProfileDirty or UI.BdmaDirty then
+            UI.ShowSavingOverlay()
+            PLDR.EnsurePopstarterDir()
+            PLDR.SELECTED_PROFILE = UI.ProfileQuery.curopt
+            PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
+            PLDR.BDMA_MODE_KEY = UI.BdmaModes[UI.BdmaModeIndex].key
+            PLDR.SaveSettingsAtomic()
+            PLDR.ApplyBdmaMode(PLDR.BDMA_MODE_KEY)
+            UI.ProfileDirty = false
+            UI.BdmaDirty = false
+          end
+          UI.SceneChange(target_scene)
+        end
+
+        if UI.Pad.Events.EXIT then queue_exit(UI.SCENES.CREDITS) end
+        if UI.Pad.Events.NAV_DOWN then
+          local next_opt = CLAMP(UI.ProfileQuery.curopt+1, 1, profcnt)
+          if next_opt ~= UI.ProfileQuery.curopt then
+            UI.ProfileQuery.curopt = next_opt
+            UI.ProfileDirty = true
+          end
+        end
+        if UI.Pad.Events.NAV_UP then
+          local next_opt = CLAMP(UI.ProfileQuery.curopt-1, 1, profcnt)
+          if next_opt ~= UI.ProfileQuery.curopt then
+            UI.ProfileQuery.curopt = next_opt
+            UI.ProfileDirty = true
+          end
+        end
+        if UI.Pad.Events.NAV_RIGHT then
+          UI.BdmaModeIndex = UI.BdmaModeIndex + 1
+          if UI.BdmaModeIndex > #UI.BdmaModes then UI.BdmaModeIndex = 1 end
+          UI.BdmaDirty = true
+        end
+        if UI.Pad.Events.NAV_LEFT then
+          UI.BdmaModeIndex = UI.BdmaModeIndex - 1
+          if UI.BdmaModeIndex < 1 then UI.BdmaModeIndex = #UI.BdmaModes end
+          UI.BdmaDirty = true
+        end
+        if UI.Pad.Events.BACK then queue_exit(UI.SCENES.MMAIN) end
         if UI.Pad.Events.START then
           local default_profile = tonumber(PLDR.DEFAULT_PROFILE) or 1
-          UI.ProfileQuery.curopt = CLAMP(default_profile, 1, profcnt)
-          local profile = PLDR.PROFILES[UI.ProfileQuery.curopt]
-          if profile ~= nil then
-            PLDR.POPSTARTER_PATH = profile.ELF
+          local next_default = CLAMP(default_profile, 1, profcnt)
+          if next_default ~= UI.ProfileQuery.curopt then
+            UI.ProfileQuery.curopt = next_default
+            UI.ProfileDirty = true
+          end
+          if UI.BdmaModeIndex ~= 1 then
+            UI.BdmaModeIndex = 1
+            UI.BdmaDirty = true
           end
           UI.Notif_queue.add("Profile defaults restored")
         end
         if UI.Pad.Events.CONFIRM then
-          if not doesFileExist(PLDR.PROFILES[UI.ProfileQuery.curopt].ELF) then
-            UI.Notif_queue.add("POPStarter ELF missing")
-          else
-            PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
-            UI.SceneChange(UI.SCENES.MMAIN)
-          end
+          queue_exit(UI.SCENES.MMAIN)
         end
         local labels, order = UI.Footer.ResolveLegend({
           order = UI.Footer.order_with_start_r2,
           order_id = "start_r2",
           circle = UI.Footer.labels.circle_other,
           cross = UI.Footer.labels.cross_select,
-          square = "Cover Art",
+          square = "BDMA Mode",
           start = UI.Footer.labels.start_reset
         })
         UI.Footer.Draw(labels, order)
@@ -1856,6 +1928,17 @@ function UI.OnSceneExit(previous_scene, next_scene)
   end
 end
 UI.RecalcLayout()
+do
+  local mode_key = PLDR.BDMA_MODE_KEY or "FAT32"
+  for i = 1, #UI.BdmaModes do
+    if UI.BdmaModes[i].key == mode_key then
+      UI.BdmaModeIndex = i
+      break
+    end
+  end
+  local selected_profile = tonumber(PLDR.SELECTED_PROFILE) or tonumber(PLDR.DEFAULT_PROFILE) or 1
+  UI.ProfileQuery.curopt = CLAMP(selected_profile, 1, #PLDR.PROFILES)
+end
 function Input_GetEvent()
   UI.Pad.Listen()
   if UI.Transition ~= nil and UI.Transition.active then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -329,17 +329,11 @@ UI = {
     BdmaModeIndex = 1;
     BdmaDirty = false;
     ProfileDirty = false;
+    SavingActive = false;
     ShowSavingOverlay = function ()
-      UI.Modal.active = true
-      UI.Modal.title = "Saving..."
-      UI.Modal.body = "Applying profile and BDMA settings"
-      UI.Modal.options = {"", ""}
-      UI.Modal.confirm_action = nil
-      UI.Modal.cancel_action = nil
-      UI.Modal.triangle_action = nil
-      UI.Modal.ignore_until_release = false
+      UI.SavingActive = true
       UI.flip()
-      UI.Modal.Close()
+      UI.SavingActive = false
     end;
     --- Notifications queue handler
     Notif_queue = {
@@ -496,6 +490,10 @@ UI = {
     flip = function (notif)
       UI.Notif_queue.display()
       UI.Modal.Draw()
+      if UI.SavingActive then
+        Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, 140))
+        Font.ftPrint(BFONT, UI.SCR.X_MID, UI.SCR.Y_MID - 8, 8, UI.SCR.X, 16, "Saving...", UI.CCOL.YELLOW)
+      end
       if UI.Transition ~= nil then
         local alpha = UI.Transition.Update()
         if alpha > 0 then


### PR DESCRIPTION
### Motivation

- Provide a BDMA mode selector on the Profiles page that cycles LEFT/RIGHT and does not perform file I/O on every change.  
- Persist POPSTARTER settings under `mc0:/POPSTARTER` (non-fatal on boot) and apply BDMA pack changes deterministically from files next to POPSLOADER.ELF.  
- Ensure BDMA pack changes are applied only when leaving the Profiles page, and show a blocking "Saving..." overlay (render one frame) during file operations so the UI does not appear frozen.

### Description

- Added persistent settings and helpers in `bin/POPSLDR/system.lua`: `PLDR.POPSTARTER_DIR`, `PLDR.SETTINGS_PATH`, `PLDR.EnsurePopstarterDir()`, `PLDR.LoadSettingsNonFatal()` and `PLDR.SaveSettingsAtomic()` which use an atomic temp-then-rename write.  
- Implemented `PLDR.ApplyBdmaMode(mode_key)` in `system.lua` to perform deterministic BDMA pack operations using `APP_DIR_NORM` sources and `mc0:/POPSTARTER/` destinations; FAT32 deletes only `usbd.irx` and `usbhdfsd.irx`, other modes copy the full set of files (`usbd.irx`, `usbhdfsd.irx`, `icon.sys`, `list.icn`, `copy.icn`, `del.icn`) with atomic writes and non-fatal missing-file notifications.  
- Updated `bin/POPSLDR/ui.lua` ProfileQuery UI to add BDMA selector state (`UI.BdmaModes`, `UI.BdmaModeIndex`, `UI.BdmaDirty`), render `left.png`/`right.png` icons next to the BDMA label, and handle NAV_LEFT/NAV_RIGHT to cycle and mark dirty without performing I/O.  
- Deferred save + BDMA apply on page exit only: on BACK/EXIT/CONFIRM the code shows a blocking "Saving..." overlay, flips a frame, then calls `PLDR.SaveSettingsAtomic()` and `PLDR.ApplyBdmaMode(...)`, clears dirty flags and transitions away.  
- Added `left.png` / `right.png` registrations in `bin/POPSLDR/images.lua` so the selector icons are available.

### Testing

- Inspected and validated the code changes via repository file/diff inspection commands (`git show --stat --oneline HEAD`, `git show -- bin/POPSLDR/ui.lua bin/POPSLDR/system.lua`) and grepped the codebase to confirm presence and placement of the new APIs and UI hooks; these inspections succeeded.  
- Performed targeted source checks with `rg`/`sed`/`nl` to confirm functions `PLDR.LoadSettingsNonFatal`, `PLDR.SaveSettingsAtomic`, `PLDR.ApplyBdmaMode`, and ProfileQuery UI changes are present and wired to page-exit flows; these checks succeeded.  
- Attempted a Lua syntax sanity check with `luac -p` but the tool is not available in this environment (command not found), so no bytecode parse was run; recommend running `luac -p` or equivalent on the target environment before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2454e5ab08321b5479697e1899641)