### PR TITLE
Implement MX4SIO main-menu entry with bounded init retry

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -832,6 +832,39 @@ function PLDR.BuildUsbGameListMulti()
   return nil
 end
 
+function PLDR.InitMX4SIOPopsRoot()
+  local roots = {
+    "mx4sio:/POPS/",
+    "mx4sio0:/POPS/"
+  }
+
+  if type(System) == "table" and type(System.ensureBDMFatFs) == "function" then
+    pcall(System.ensureBDMFatFs)
+  end
+
+  PLDR.MX4SIO.READY = false
+  PLDR.MX4SIO.ROOT = nil
+
+  for i = 1, #roots do
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
+
+    local path = roots[i]
+    local dir = System.listDirectory(path)
+    if dir ~= nil then
+      PLDR.MX4SIO.READY = true
+      PLDR.MX4SIO.ROOT = string.match(path, "^(mx4sio%d*:/)") or "mx4sio:/"
+      return path
+    end
+  end
+
+  return nil
+end
+
 local function EncodeHddGameEntry(partition, relpath)
   if partition == nil or relpath == nil then
     return nil

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1642,10 +1642,18 @@ end
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            if type(System) == "table" and type(System.ensureBDMFatFs) == "function" then
-              System.ensureBDMFatFs()
+            local mx4sio_root = nil
+            if type(PLDR) == "table" and type(PLDR.InitMX4SIOPopsRoot) == "function" then
+              mx4sio_root = PLDR.InitMX4SIOPopsRoot()
             end
-            UI.Notif_queue.add("Not Implemented Yet")
+            if mx4sio_root == nil then
+              UI.Notif_queue.add("No MX4SIO device found (POPS/ missing)")
+            else
+              PLDR.CleanupGameList()
+              PLDR.GetPS1GameLists(mx4sio_root, true)
+              UI.setDeviceLock(DEVLOCK.MX4SIO)
+              UI.SceneChange(UI.SCENES.GMX4SIO)
+            end
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- Enable real MX4SIO entry from the main menu by replacing the previous "Not Implemented" placeholder with a lightweight, deterministic init/probe flow. 
- Address the common MX4SIO first-init failure by retrying initialization in a bounded, non-blocking way while preventing any USB mass initialization side-effects. 

### Description
- Added `PLDR.InitMX4SIOPopsRoot()` in `bin/POPSLDR/system.lua` which runs BDM/FatFs prereqs and performs up to two lightweight attempts to initialize MX4SIO and probe `mx4sio:/POPS/` then `mx4sio0:/POPS/`, storing `PLDR.MX4SIO.READY` and `PLDR.MX4SIO.ROOT` on success. 
- The helper re-runs `_G.ensureMx4sioInit` and `System.initMX4SIO` per attempt and explicitly avoids calling USB mass init helpers. 
- Replaced the main-menu MX4SIO placeholder in `bin/POPSLDR/ui.lua` so the menu now calls `PLDR.InitMX4SIOPopsRoot()`, shows a single notification `No MX4SIO device found (POPS/ missing)` on failure, and on success loads the PS1 game list from the resolved MX4SIO POPS path, sets the device lock to `MX4SIO`, and transitions to the MX4SIO game scene. 
- Changes are localized to Lua only (`system.lua` and `ui.lua`) and avoid heavy device scanning or new debug output. 

### Testing
- Ran `rg -n "MX4SIO|mx4sio|initMX4SIO|ensureMx4sio|bdmList|devctl|ioctl|mass\d*:" bin/POPSLDR/*.lua` to verify code references and locations (succeeded). 
- Attempted syntax checks with `luac -p` for `bin/POPSLDR/ui.lua` and `bin/POPSLDR/system.lua` but `luac` is not installed in the environment so checks were skipped. 
- Produced and inspected the `git diff` for the two modified files and committed the change; `git show --stat --oneline HEAD` confirms the commit `Implement MX4SIO menu entry with bounded init retry` containing the two-file change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a25b697f68832192ef3402f1ea6640)