### PR TITLE
ci: package release as POPSLOADER.zip with split root folders

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -58,43 +58,42 @@ jobs:
         run: |
           make clean elfloader all
 
-      - name: Create flat allowlisted release package
+      - name: Create release package (PS1_POPSLOADER + POPS)
         shell: sh
         run: |
           set -eu
 
-          rm -rf dist APP_POPSLOADER.zip
-          mkdir -p dist
+          rm -rf dist_root POPSLOADER.zip
+          mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
 
           required_files="
-          bin/POPSLOADER.ELF:POPSLOADER.ELF
-          bin/POPSLDR/POPSTARTER.ELF:POPSTARTER.ELF
-          bin/POPSLDR/APPINFO.PBT:APPINFO.PBT
-          bin/POPSLDR/PATCH_5.BIN:PATCH_5.BIN
-          bin/POPSLDR/IGR_BG.tm2:IGR_BG.tm2
-          bin/POPSLDR/IGR_NO.tm2:IGR_NO.tm2
-          bin/POPSLDR/IGR_YES.tm2:IGR_YES.tm2
-          bin/POPSLDR/boot.adp:boot.adp
-          bin/POPSLDR/title.cfg:title.cfg
-          bin/POPSLDR/icon.sys:icon.sys
-          bin/POPSLDR/list.icn:list.icn
-          bin/POPSLDR/copy.icn:copy.icn
-          bin/POPSLDR/del.icn:del.icn
-          bin/POPSLDR/icon.sys.mmce:icon.sys.mmce
-          bin/POPSLDR/icon.sys.mx4sio:icon.sys.mx4sio
-          bin/POPSLDR/icon.sys.usbexfat:icon.sys.usbexfat
-          bin/POPSLDR/list.icn.mmce:list.icn.mmce
-          bin/POPSLDR/list.icn.mx4sio:list.icn.mx4sio
-          bin/POPSLDR/list.icn.usbexfat:list.icn.usbexfat
-          bin/POPSLDR/del.icn.mmce:del.icn.mmce
-          bin/POPSLDR/del.icn.mx4sio:del.icn.mx4sio
-          bin/POPSLDR/del.icn.usbexfat:del.icn.usbexfat
-          bin/POPSLDR/usbd.irx.mmce:usbd.irx.mmce
-          bin/POPSLDR/usbd.irx.mx4sio:usbd.irx.mx4sio
-          bin/POPSLDR/usbd.irx.usbexfat:usbd.irx.usbexfat
-          bin/POPSLDR/usbhdfsd.irx.mmce:usbhdfsd.irx.mmce
-          bin/POPSLDR/usbhdfsd.irx.mx4sio:usbhdfsd.irx.mx4sio
-          bin/POPSLDR/usbhdfsd.irx.usbexfat:usbhdfsd.irx.usbexfat
+          bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
+          bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
+          bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
+          bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
+          bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
+          bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
+          bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
+          bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
+          bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
+          bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
+          bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
+          bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
+          bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
+          bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
+          bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
+          bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
+          bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
+          bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
+          bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
+          bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
+          bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
+          bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
+          bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+          bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+          bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
+          bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
+          bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
           "
 
           echo "$required_files" | while IFS=':' read -r src dst; do
@@ -105,72 +104,79 @@ jobs:
               echo "ERROR: required release file missing: $src"
               exit 1
             fi
-            cp -f "$src" "dist/$dst"
+            cp -f "$src" "dist_root/$dst"
           done
 
-          cd dist
+          cd dist_root
           if command -v zip >/dev/null 2>&1; then
-            zip -9 ../APP_POPSLOADER.zip ./* >/dev/null
+            find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
           elif command -v 7z >/dev/null 2>&1; then
-            7z a -tzip ../APP_POPSLOADER.zip ./* >/dev/null
+            7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
           else
-            echo "ERROR: neither zip nor 7z is available to create APP_POPSLOADER.zip"
+            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
             exit 1
           fi
           cd - >/dev/null
 
           echo "== Package contents =="
-          unzip -Z1 APP_POPSLOADER.zip
+          unzip -Z1 POPSLOADER.zip
 
-      - name: Verify flat allowlisted package contents
+      - name: Verify release package contents
         shell: sh
         run: |
           set -eu
 
-          file_paths="$(unzip -Z1 APP_POPSLOADER.zip | sed '/^$/d')"
+          file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
 
-          if printf '%s\n' "$file_paths" | grep -q '/'; then
-            echo "ERROR: archive must be flat (no directory entries or nested paths)"
+          top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
+          if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
+PS1_POPSLOADER" ]; then
+            echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
+            printf '%s\n' "$top_dirs"
+            exit 1
+          fi
+
+          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
+            echo "ERROR: archive must not contain files at zip root"
             printf '%s\n' "$file_paths"
             exit 1
           fi
 
           file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
 
-          if [ "$file_count" -ne 28 ]; then
-            echo "ERROR: package must contain exactly 28 files, found $file_count"
+          if [ "$file_count" -ne 27 ]; then
+            echo "ERROR: package must contain exactly 27 files, found $file_count"
             printf '%s\n' "$file_paths"
             exit 1
           fi
 
-          expected="APPINFO.PBT
-          IGR_BG.tm2
-          IGR_NO.tm2
-          IGR_YES.tm2
-          PATCH_5.BIN
-          POPSLOADER.ELF
-          POPSTARTER.ELF
-          boot.adp
-          copy.icn
-          del.icn
-          del.icn.mmce
-          del.icn.mx4sio
-          del.icn.usbexfat
-          icon.sys
-          icon.sys.mmce
-          icon.sys.mx4sio
-          icon.sys.usbexfat
-          list.icn
-          list.icn.mmce
-          list.icn.mx4sio
-          list.icn.usbexfat
-          title.cfg
-          usbd.irx.mmce
-          usbd.irx.mx4sio
-          usbd.irx.usbexfat
-          usbhdfsd.irx.mmce
-          usbhdfsd.irx.mx4sio
-          usbhdfsd.irx.usbexfat"
+          expected="POPS/IGR_BG.tm2
+          POPS/IGR_NO.tm2
+          POPS/IGR_YES.tm2
+          PS1_POPSLOADER/APPINFO.PBT
+          PS1_POPSLOADER/POPSLOADER.ELF
+          PS1_POPSLOADER/POPSTARTER.ELF
+          PS1_POPSLOADER/boot.adp
+          PS1_POPSLOADER/copy.icn
+          PS1_POPSLOADER/del.icn
+          PS1_POPSLOADER/del.icn.mmce
+          PS1_POPSLOADER/del.icn.mx4sio
+          PS1_POPSLOADER/del.icn.usbexfat
+          PS1_POPSLOADER/icon.sys
+          PS1_POPSLOADER/icon.sys.mmce
+          PS1_POPSLOADER/icon.sys.mx4sio
+          PS1_POPSLOADER/icon.sys.usbexfat
+          PS1_POPSLOADER/list.icn
+          PS1_POPSLOADER/list.icn.mmce
+          PS1_POPSLOADER/list.icn.mx4sio
+          PS1_POPSLOADER/list.icn.usbexfat
+          PS1_POPSLOADER/title.cfg
+          PS1_POPSLOADER/usbd.irx.mmce
+          PS1_POPSLOADER/usbd.irx.mx4sio
+          PS1_POPSLOADER/usbd.irx.usbexfat
+          PS1_POPSLOADER/usbhdfsd.irx.mmce
+          PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+          PS1_POPSLOADER/usbhdfsd.irx.usbexfat"
 
           actual_names="$(printf '%s\n' "$file_paths" | sort)"
           expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
@@ -184,7 +190,7 @@ jobs:
             exit 1
           fi
 
-          if printf '%s\n' "$file_paths" | grep -Eiq '(^IMG/)|(^POPSLDR/)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
+          if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
             echo "ERROR: forbidden file patterns detected in package"
             printf '%s\n' "$file_paths"
             exit 1
@@ -194,7 +200,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: POPSLoader
-          path: APP_POPSLOADER.zip
+          name: POPSLOADER
+          path: POPSLOADER.zip
           if-no-files-found: error
           compression-level: 0

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,6 +1,6 @@
 name: CI
 
-"on":
+on:
   push:
     branches:
       - "*"
@@ -23,7 +23,7 @@ jobs:
         shell: sh
         run: |
           set -eu
-          apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
+          apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip python3
 
       - name: Workaround permission issue
         shell: sh
@@ -67,7 +67,7 @@ jobs:
           set -eu
           make clean elfloader all
 
-      - name: Create release package (PS1_POPSLOADER + POPS)
+      - name: Create release package (PS1_POPSLOADER + POPS) — no PATCH5.bin
         shell: sh
         run: |
           set -eu
@@ -75,135 +75,148 @@ jobs:
           rm -rf dist_root POPSLOADER.zip
           mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
 
-          cat > /tmp/required_files.txt <<'EOF'
-bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
-bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
-bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
-bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
-bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
-bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
-bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
-bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
-bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
-bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
-bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
-bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
-bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
-bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
-bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
-bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
-bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
-bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
-bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
-bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
-bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
-bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
-bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
-bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
-bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
-bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
-EOF
+          req() { [ -f "$1" ] || { echo "ERROR: required release file missing: $1" >&2; exit 1; }; }
 
-          while IFS=':' read -r src dst; do
-            [ -n "$src" ] || continue
-            if [ ! -f "$src" ]; then
-              echo "ERROR: required release file missing: $src" >&2
-              exit 1
-            fi
-            cp -f "$src" "dist_root/$dst"
-          done < /tmp/required_files.txt
+          req bin/POPSLOADER.ELF
+          req bin/POPSLDR/POPSTARTER.ELF
+          req bin/POPSLDR/APPINFO.PBT
+          req bin/POPSLDR/boot.adp
+          req bin/POPSLDR/title.cfg
+          req bin/POPSLDR/icon.sys
+          req bin/POPSLDR/list.icn
+          req bin/POPSLDR/copy.icn
+          req bin/POPSLDR/del.icn
+          req bin/POPSLDR/icon.sys.mmce
+          req bin/POPSLDR/icon.sys.mx4sio
+          req bin/POPSLDR/icon.sys.usbexfat
+          req bin/POPSLDR/list.icn.mmce
+          req bin/POPSLDR/list.icn.mx4sio
+          req bin/POPSLDR/list.icn.usbexfat
+          req bin/POPSLDR/del.icn.mmce
+          req bin/POPSLDR/del.icn.mx4sio
+          req bin/POPSLDR/del.icn.usbexfat
+          req bin/POPSLDR/usbd.irx.mmce
+          req bin/POPSLDR/usbd.irx.mx4sio
+          req bin/POPSLDR/usbd.irx.usbexfat
+          req bin/POPSLDR/usbhdfsd.irx.mmce
+          req bin/POPSLDR/usbhdfsd.irx.mx4sio
+          req bin/POPSLDR/usbhdfsd.irx.usbexfat
+          req bin/POPSLDR/IGR_BG.tm2
+          req bin/POPSLDR/IGR_NO.tm2
+          req bin/POPSLDR/IGR_YES.tm2
+
+          cp -f bin/POPSLOADER.ELF dist_root/PS1_POPSLOADER/POPSLOADER.ELF
+          cp -f bin/POPSLDR/POPSTARTER.ELF dist_root/PS1_POPSLOADER/POPSTARTER.ELF
+          cp -f bin/POPSLDR/APPINFO.PBT dist_root/PS1_POPSLOADER/APPINFO.PBT
+          cp -f bin/POPSLDR/boot.adp dist_root/PS1_POPSLOADER/boot.adp
+          cp -f bin/POPSLDR/title.cfg dist_root/PS1_POPSLOADER/title.cfg
+          cp -f bin/POPSLDR/icon.sys dist_root/PS1_POPSLOADER/icon.sys
+          cp -f bin/POPSLDR/list.icn dist_root/PS1_POPSLOADER/list.icn
+          cp -f bin/POPSLDR/copy.icn dist_root/PS1_POPSLOADER/copy.icn
+          cp -f bin/POPSLDR/del.icn dist_root/PS1_POPSLOADER/del.icn
+          cp -f bin/POPSLDR/icon.sys.mmce dist_root/PS1_POPSLOADER/icon.sys.mmce
+          cp -f bin/POPSLDR/icon.sys.mx4sio dist_root/PS1_POPSLOADER/icon.sys.mx4sio
+          cp -f bin/POPSLDR/icon.sys.usbexfat dist_root/PS1_POPSLOADER/icon.sys.usbexfat
+          cp -f bin/POPSLDR/list.icn.mmce dist_root/PS1_POPSLOADER/list.icn.mmce
+          cp -f bin/POPSLDR/list.icn.mx4sio dist_root/PS1_POPSLOADER/list.icn.mx4sio
+          cp -f bin/POPSLDR/list.icn.usbexfat dist_root/PS1_POPSLOADER/list.icn.usbexfat
+          cp -f bin/POPSLDR/del.icn.mmce dist_root/PS1_POPSLOADER/del.icn.mmce
+          cp -f bin/POPSLDR/del.icn.mx4sio dist_root/PS1_POPSLOADER/del.icn.mx4sio
+          cp -f bin/POPSLDR/del.icn.usbexfat dist_root/PS1_POPSLOADER/del.icn.usbexfat
+          cp -f bin/POPSLDR/usbd.irx.mmce dist_root/PS1_POPSLOADER/usbd.irx.mmce
+          cp -f bin/POPSLDR/usbd.irx.mx4sio dist_root/PS1_POPSLOADER/usbd.irx.mx4sio
+          cp -f bin/POPSLDR/usbd.irx.usbexfat dist_root/PS1_POPSLOADER/usbd.irx.usbexfat
+          cp -f bin/POPSLDR/usbhdfsd.irx.mmce dist_root/PS1_POPSLOADER/usbhdfsd.irx.mmce
+          cp -f bin/POPSLDR/usbhdfsd.irx.mx4sio dist_root/PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+          cp -f bin/POPSLDR/usbhdfsd.irx.usbexfat dist_root/PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+
+          cp -f bin/POPSLDR/IGR_BG.tm2 dist_root/POPS/IGR_BG.tm2
+          cp -f bin/POPSLDR/IGR_NO.tm2 dist_root/POPS/IGR_NO.tm2
+          cp -f bin/POPSLDR/IGR_YES.tm2 dist_root/POPS/IGR_YES.tm2
 
           cd dist_root
-          if command -v zip >/dev/null 2>&1; then
-            find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
-          elif command -v 7z >/dev/null 2>&1; then
-            7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
-          else
-            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip" >&2
-            exit 1
-          fi
+          find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
           cd - >/dev/null
 
           echo "== Package contents =="
-          unzip -Z1 POPSLOADER.zip | sed '/^$/d'
+          unzip -Z1 POPSLOADER.zip
 
-      - name: Verify release package contents
+      - name: Verify release package contents (python)
         shell: sh
         run: |
           set -eu
+          python3 - <<'PY'
+          import sys, zipfile
 
-          file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
+          zpath = "POPSLOADER.zip"
+          expected = {
+              "POPS/IGR_BG.tm2",
+              "POPS/IGR_NO.tm2",
+              "POPS/IGR_YES.tm2",
+              "PS1_POPSLOADER/APPINFO.PBT",
+              "PS1_POPSLOADER/POPSLOADER.ELF",
+              "PS1_POPSLOADER/POPSTARTER.ELF",
+              "PS1_POPSLOADER/boot.adp",
+              "PS1_POPSLOADER/copy.icn",
+              "PS1_POPSLOADER/del.icn",
+              "PS1_POPSLOADER/del.icn.mmce",
+              "PS1_POPSLOADER/del.icn.mx4sio",
+              "PS1_POPSLOADER/del.icn.usbexfat",
+              "PS1_POPSLOADER/icon.sys",
+              "PS1_POPSLOADER/icon.sys.mmce",
+              "PS1_POPSLOADER/icon.sys.mx4sio",
+              "PS1_POPSLOADER/icon.sys.usbexfat",
+              "PS1_POPSLOADER/list.icn",
+              "PS1_POPSLOADER/list.icn.mmce",
+              "PS1_POPSLOADER/list.icn.mx4sio",
+              "PS1_POPSLOADER/list.icn.usbexfat",
+              "PS1_POPSLOADER/title.cfg",
+              "PS1_POPSLOADER/usbd.irx.mmce",
+              "PS1_POPSLOADER/usbd.irx.mx4sio",
+              "PS1_POPSLOADER/usbd.irx.usbexfat",
+              "PS1_POPSLOADER/usbhdfsd.irx.mmce",
+              "PS1_POPSLOADER/usbhdfsd.irx.mx4sio",
+              "PS1_POPSLOADER/usbhdfsd.irx.usbexfat",
+          }
 
-          top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
-          top_count="$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')"
-          if [ "$top_count" -ne 2 ]; then
-            echo "ERROR: archive root must contain exactly 2 directories (POPS/ and PS1_POPSLOADER/)" >&2
-            printf '%s\n' "$top_dirs"
-            exit 1
-          fi
-          echo "$top_dirs" | grep -qx "POPS" || { echo "ERROR: missing POPS/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
-          echo "$top_dirs" | grep -qx "PS1_POPSLOADER" || { echo "ERROR: missing PS1_POPSLOADER/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
+          with zipfile.ZipFile(zpath, "r") as z:
+              names = [n for n in z.namelist() if n and not n.endswith("/")]
+          actual = set(names)
 
-          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {found=1} END {exit (found?0:1)}'; then
-            echo "ERROR: archive must not contain files at zip root" >&2
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+          # Root dirs
+          top = sorted({n.split("/", 1)[0] for n in names if "/" in n})
+          if top != ["POPS", "PS1_POPSLOADER"]:
+              print("ERROR: zip root must contain exactly POPS/ and PS1_POPSLOADER/")
+              print("Top dirs:", top)
+              sys.exit(1)
 
-          file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
-          if [ "$file_count" -ne 27 ]; then
-            echo "ERROR: package must contain exactly 27 files, found $file_count" >&2
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+          # No root files
+          root_files = [n for n in names if "/" not in n]
+          if root_files:
+              print("ERROR: zip must not contain files at root:", root_files)
+              sys.exit(1)
 
-          cat > /tmp/expected_files.txt <<'EOF'
-POPS/IGR_BG.tm2
-POPS/IGR_NO.tm2
-POPS/IGR_YES.tm2
-PS1_POPSLOADER/APPINFO.PBT
-PS1_POPSLOADER/POPSLOADER.ELF
-PS1_POPSLOADER/POPSTARTER.ELF
-PS1_POPSLOADER/boot.adp
-PS1_POPSLOADER/copy.icn
-PS1_POPSLOADER/del.icn
-PS1_POPSLOADER/del.icn.mmce
-PS1_POPSLOADER/del.icn.mx4sio
-PS1_POPSLOADER/del.icn.usbexfat
-PS1_POPSLOADER/icon.sys
-PS1_POPSLOADER/icon.sys.mmce
-PS1_POPSLOADER/icon.sys.mx4sio
-PS1_POPSLOADER/icon.sys.usbexfat
-PS1_POPSLOADER/list.icn
-PS1_POPSLOADER/list.icn.mmce
-PS1_POPSLOADER/list.icn.mx4sio
-PS1_POPSLOADER/list.icn.usbexfat
-PS1_POPSLOADER/title.cfg
-PS1_POPSLOADER/usbd.irx.mmce
-PS1_POPSLOADER/usbd.irx.mx4sio
-PS1_POPSLOADER/usbd.irx.usbexfat
-PS1_POPSLOADER/usbhdfsd.irx.mmce
-PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-PS1_POPSLOADER/usbhdfsd.irx.usbexfat
-EOF
+          # Exact set
+          if actual != expected:
+              missing = sorted(expected - actual)
+              extra = sorted(actual - expected)
+              print("ERROR: package file set mismatch")
+              if missing:
+                  print("Missing:")
+                  print("\n".join(missing))
+              if extra:
+                  print("Extra:")
+                  print("\n".join(extra))
+              sys.exit(1)
 
-          actual_names="$(printf '%s\n' "$file_paths" | sort)"
-          expected_names="$(sort /tmp/expected_files.txt)"
-          if [ "$actual_names" != "$expected_names" ]; then
-            echo "ERROR: package file set mismatch" >&2
-            echo "Expected:" >&2
-            printf '%s\n' "$expected_names"
-            echo "Actual:" >&2
-            printf '%s\n' "$actual_names"
-            exit 1
-          fi
+          # Forbidden patterns / PATCH5.bin
+          forbidden = [n for n in names if n.lower().endswith("patch5.bin") or "patch_5.bin" in n.lower()]
+          if forbidden:
+              print("ERROR: forbidden PATCH5.bin found:", forbidden)
+              sys.exit(1)
 
-          if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
-            echo "ERROR: forbidden file patterns detected in package" >&2
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+          print("OK: POPSLOADER.zip contents verified")
+          PY
 
       - name: Upload artifact (no release)
         if: success()

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -6,26 +6,29 @@ on:
       - "*"
     tags:
       - "v*"
-  pull_request:
-  workflow_dispatch:
+  pull_request: {}
+  workflow_dispatch: {}
   repository_dispatch:
-    types: [run_build]
+    types:
+      - run_build
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: "ps2dev/ps2dev:latest"
+      image: ps2dev/ps2dev:latest
 
     steps:
       - name: Install dependencies
         shell: sh
         run: |
+          set -eu
           apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
 
       - name: Workaround permission issue
         shell: sh
         run: |
+          set -eu
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout
@@ -61,6 +64,7 @@ jobs:
       - name: Compile project
         shell: sh
         run: |
+          set -eu
           make clean elfloader all
 
       - name: Create release package (PS1_POPSLOADER + POPS)
@@ -71,46 +75,44 @@ jobs:
           rm -rf dist_root POPSLOADER.zip
           mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
 
-          required_files="
-          bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
-          bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
-          bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
-          bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
-          bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
-          bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
-          bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
-          bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
-          bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
-          bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
-          bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
-          bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
-          bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
-          bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
-          bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
-          bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
-          bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
-          bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
-          bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
-          bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
-          bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
-          bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
-          bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-          bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
-          bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
-          bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
-          bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
-          "
+          cat > /tmp/required_files.txt <<'EOF'
+bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
+bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
+bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
+bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
+bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
+bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
+bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
+bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
+bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
+bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
+bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
+bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
+bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
+bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
+bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
+bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
+bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
+bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
+bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
+bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
+bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
+bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
+bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
+bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
+bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
+EOF
 
-          echo "$required_files" | while IFS=':' read -r src dst; do
-            src="$(echo "$src" | xargs)"
-            dst="$(echo "$dst" | xargs)"
+          while IFS=':' read -r src dst; do
             [ -n "$src" ] || continue
             if [ ! -f "$src" ]; then
-              echo "ERROR: required release file missing: $src"
+              echo "ERROR: required release file missing: $src" >&2
               exit 1
             fi
             cp -f "$src" "dist_root/$dst"
-          done
+          done < /tmp/required_files.txt
 
           cd dist_root
           if command -v zip >/dev/null 2>&1; then
@@ -118,13 +120,13 @@ jobs:
           elif command -v 7z >/dev/null 2>&1; then
             7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
           else
-            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
+            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip" >&2
             exit 1
           fi
           cd - >/dev/null
 
           echo "== Package contents =="
-          unzip -Z1 POPSLOADER.zip
+          unzip -Z1 POPSLOADER.zip | sed '/^$/d'
 
       - name: Verify release package contents
         shell: sh
@@ -133,28 +135,35 @@ jobs:
 
           file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
 
+          # Root must contain exactly POPS/ and PS1_POPSLOADER/
           top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
-          if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
-PS1_POPSLOADER" ]; then
-            echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
+          top_count="$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')"
+          if [ "$top_count" -ne 2 ]; then
+            echo "ERROR: archive root must contain exactly 2 directories (POPS/ and PS1_POPSLOADER/)" >&2
             printf '%s\n' "$top_dirs"
             exit 1
           fi
+          echo "$top_dirs" | grep -qx "POPS" || { echo "ERROR: missing POPS/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
+          echo "$top_dirs" | grep -qx "PS1_POPSLOADER" || { echo "ERROR: missing PS1_POPSLOADER/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
 
-          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
-            echo "ERROR: archive must not contain files at zip root"
+          # No files at zip root
+          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {found=1} END {exit (found?0:1)}'; then
+            echo "ERROR: archive must not contain files at zip root" >&2
             printf '%s\n' "$file_paths"
             exit 1
           fi
 
+          # Exact file count
           file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
           if [ "$file_count" -ne 27 ]; then
-            echo "ERROR: package must contain exactly 27 files, found $file_count"
+            echo "ERROR: package must contain exactly 27 files, found $file_count" >&2
             printf '%s\n' "$file_paths"
             exit 1
           fi
 
-          expected="POPS/IGR_BG.tm2
+          # Exact file set
+          cat > /tmp/expected_files.txt <<'EOF'
+POPS/IGR_BG.tm2
 POPS/IGR_NO.tm2
 POPS/IGR_YES.tm2
 PS1_POPSLOADER/APPINFO.PBT
@@ -180,21 +189,24 @@ PS1_POPSLOADER/usbd.irx.mx4sio
 PS1_POPSLOADER/usbd.irx.usbexfat
 PS1_POPSLOADER/usbhdfsd.irx.mmce
 PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-PS1_POPSLOADER/usbhdfsd.irx.usbexfat"
+PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+EOF
 
           actual_names="$(printf '%s\n' "$file_paths" | sort)"
-          expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
+          expected_names="$(sort /tmp/expected_files.txt)"
+
           if [ "$actual_names" != "$expected_names" ]; then
-            echo "ERROR: package file set mismatch"
-            echo "Expected:"
+            echo "ERROR: package file set mismatch" >&2
+            echo "Expected:" >&2
             printf '%s\n' "$expected_names"
-            echo "Actual:"
+            echo "Actual:" >&2
             printf '%s\n' "$actual_names"
             exit 1
           fi
 
+          # Forbidden patterns (incl PATCH5.bin)
           if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
-            echo "ERROR: forbidden file patterns detected in package"
+            echo "ERROR: forbidden file patterns detected in package" >&2
             printf '%s\n' "$file_paths"
             exit 1
           fi

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,163 +1,160 @@
 name: CI
 
 on:
-push:
-branches:
-- '*'
-tags:
-- v*
-pull_request:
-workflow_dispatch:
-repository_dispatch:
-types: [run_build]
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [run_build]
 
 jobs:
-build:
-runs-on: ubuntu-latest
-container: ps2dev/ps2dev:latest
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: "ps2dev/ps2dev:latest"
 
-```
-steps:
-  - name: Install dependencies
-    run: |
-      apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
+    steps:
+      - name: Install dependencies
+        shell: sh
+        run: |
+          apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
 
-  - name: Workaround permission issue
-    run: |
-      git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Workaround permission issue
+        shell: sh
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-  - name: Checkout
-    uses: actions/checkout@v4
-    with:
-      fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  - name: Generate build info
-    shell: sh
-    run: |
-      set -eu
-      COMMIT_SHORT="$(echo "$GITHUB_SHA" | cut -c1-7)"
-      BUILD_UTC="$(date -u '+%Y-%m-%d %H:%MZ')"
-      printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
-      cat bin/POPSLDR/BUILD_INFO.txt
+      - name: Generate build info
+        shell: sh
+        run: |
+          set -eu
+          COMMIT_SHORT="$(echo "$GITHUB_SHA" | cut -c1-7)"
+          BUILD_UTC="$(date -u '+%Y-%m-%d %H:%MZ')"
+          printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
+          cat bin/POPSLDR/BUILD_INFO.txt
 
-  - name: Validate etc/boot.lua (syntax/newline)
-    shell: bash
-    run: |
-      set -eu
-      BOOT_LUA="etc/boot.lua"
-      [ -f "$BOOT_LUA" ] || { echo "ERROR: $BOOT_LUA not found" >&2; exit 1; }
-      LAST_BYTE_HEX="$(tail -c 1 "$BOOT_LUA" | od -An -tx1 | tr -d '[:space:]')"
-      [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: $BOOT_LUA must end with newline (0x0A)" >&2; exit 1; }
-      if command -v luac >/dev/null 2>&1; then
-        luac -p "$BOOT_LUA"
-      elif command -v lua >/dev/null 2>&1; then
-        lua -e "assert(loadfile('$BOOT_LUA'))"
-      else
-        echo "NOTE: luac/lua not found; skipped Lua syntax validation"
-      fi
+      - name: Validate etc/boot.lua (syntax/newline)
+        shell: bash
+        run: |
+          set -eu
+          BOOT_LUA="etc/boot.lua"
+          [ -f "$BOOT_LUA" ] || { echo "ERROR: $BOOT_LUA not found" >&2; exit 1; }
+          LAST_BYTE_HEX="$(tail -c 1 "$BOOT_LUA" | od -An -tx1 | tr -d '[:space:]')"
+          [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: $BOOT_LUA must end with newline (0x0A)" >&2; exit 1; }
+          if command -v luac >/dev/null 2>&1; then
+            luac -p "$BOOT_LUA"
+          elif command -v lua >/dev/null 2>&1; then
+            lua -e "assert(loadfile('$BOOT_LUA'))"
+          else
+            echo "NOTE: luac/lua not found; skipped Lua syntax validation"
+          fi
 
-  - name: Compile project
-    run: |
-      make clean elfloader all
+      - name: Compile project
+        shell: sh
+        run: |
+          make clean elfloader all
 
-  - name: Create release package (PS1_POPSLOADER + POPS)
-    shell: sh
-    run: |
-      set -eu
+      - name: Create release package (PS1_POPSLOADER + POPS)
+        shell: sh
+        run: |
+          set -eu
 
-      rm -rf dist_root POPSLOADER.zip
-      mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
+          rm -rf dist_root POPSLOADER.zip
+          mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
 
-      required_files="
-      bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
-      bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
-      bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
-      bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
-      bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
-      bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
-      bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
-      bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
-      bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
-      bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
-      bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
-      bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
-      bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
-      bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
-      bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
-      bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
-      bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
-      bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
-      bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
-      bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
-      bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
-      bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
-      bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-      bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
-      bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
-      bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
-      bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
-      "
+          required_files="
+          bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
+          bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
+          bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
+          bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
+          bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
+          bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
+          bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
+          bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
+          bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
+          bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
+          bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
+          bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
+          bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
+          bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
+          bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
+          bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
+          bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
+          bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
+          bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
+          bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
+          bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
+          bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
+          bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+          bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+          bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
+          bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
+          bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
+          "
 
-      echo "$required_files" | while IFS=':' read -r src dst; do
-        src="$(echo "$src" | xargs)"
-        dst="$(echo "$dst" | xargs)"
-        [ -n "$src" ] || continue
-        if [ ! -f "$src" ]; then
-          echo "ERROR: required release file missing: $src"
-          exit 1
-        fi
-        cp -f "$src" "dist_root/$dst"
-      done
+          echo "$required_files" | while IFS=':' read -r src dst; do
+            src="$(echo "$src" | xargs)"
+            dst="$(echo "$dst" | xargs)"
+            [ -n "$src" ] || continue
+            if [ ! -f "$src" ]; then
+              echo "ERROR: required release file missing: $src"
+              exit 1
+            fi
+            cp -f "$src" "dist_root/$dst"
+          done
 
-      cd dist_root
-      if command -v zip >/dev/null 2>&1; then
-        find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
-      elif command -v 7z >/dev/null 2>&1; then
-        7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
-      else
-        echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
-        exit 1
-      fi
-      cd - >/dev/null
+          cd dist_root
+          if command -v zip >/dev/null 2>&1; then
+            find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
+          elif command -v 7z >/dev/null 2>&1; then
+            7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
+          else
+            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
+            exit 1
+          fi
+          cd - >/dev/null
 
-      echo "== Package contents =="
-      unzip -Z1 POPSLOADER.zip
+          echo "== Package contents =="
+          unzip -Z1 POPSLOADER.zip
 
-  - name: Verify release package contents
-    shell: sh
-    run: |
-      set -eu
+      - name: Verify release package contents
+        shell: sh
+        run: |
+          set -eu
 
-      file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
+          file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
 
-      top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
-      if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
-```
-
+          top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
+          if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
 PS1_POPSLOADER" ]; then
-echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
-printf '%s\n' "$top_dirs"
-exit 1
-fi
+            echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
+            printf '%s\n' "$top_dirs"
+            exit 1
+          fi
 
-```
-      if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
-        echo "ERROR: archive must not contain files at zip root"
-        printf '%s\n' "$file_paths"
-        exit 1
-      fi
+          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
+            echo "ERROR: archive must not contain files at zip root"
+            printf '%s\n' "$file_paths"
+            exit 1
+          fi
 
-      file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
+          file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
+          if [ "$file_count" -ne 27 ]; then
+            echo "ERROR: package must contain exactly 27 files, found $file_count"
+            printf '%s\n' "$file_paths"
+            exit 1
+          fi
 
-      if [ "$file_count" -ne 27 ]; then
-        echo "ERROR: package must contain exactly 27 files, found $file_count"
-        printf '%s\n' "$file_paths"
-        exit 1
-      fi
-
-      expected="POPS/IGR_BG.tm2
-```
-
+          expected="POPS/IGR_BG.tm2
 POPS/IGR_NO.tm2
 POPS/IGR_YES.tm2
 PS1_POPSLOADER/APPINFO.PBT
@@ -185,31 +182,28 @@ PS1_POPSLOADER/usbhdfsd.irx.mmce
 PS1_POPSLOADER/usbhdfsd.irx.mx4sio
 PS1_POPSLOADER/usbhdfsd.irx.usbexfat"
 
-```
-      actual_names="$(printf '%s\n' "$file_paths" | sort)"
-      expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
+          actual_names="$(printf '%s\n' "$file_paths" | sort)"
+          expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
+          if [ "$actual_names" != "$expected_names" ]; then
+            echo "ERROR: package file set mismatch"
+            echo "Expected:"
+            printf '%s\n' "$expected_names"
+            echo "Actual:"
+            printf '%s\n' "$actual_names"
+            exit 1
+          fi
 
-      if [ "$actual_names" != "$expected_names" ]; then
-        echo "ERROR: package file set mismatch"
-        echo "Expected:"
-        printf '%s\n' "$expected_names"
-        echo "Actual:"
-        printf '%s\n' "$actual_names"
-        exit 1
-      fi
+          if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
+            echo "ERROR: forbidden file patterns detected in package"
+            printf '%s\n' "$file_paths"
+            exit 1
+          fi
 
-      if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
-        echo "ERROR: forbidden file patterns detected in package"
-        printf '%s\n' "$file_paths"
-        exit 1
-      fi
-
-  - name: Upload artifact (no release)
-    if: success()
-    uses: actions/upload-artifact@v4
-    with:
-      name: POPSLOADER
-      path: POPSLOADER.zip
-      if-no-files-found: error
-      compression-level: 0
-```
+      - name: Upload artifact (no release)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: POPSLOADER
+          path: POPSLOADER.zip
+          if-no-files-found: error
+          compression-level: 0

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,206 +1,215 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - v*
-  pull_request:
-  workflow_dispatch:
-  repository_dispatch:
-    types: [run_build]
+push:
+branches:
+- '*'
+tags:
+- v*
+pull_request:
+workflow_dispatch:
+repository_dispatch:
+types: [run_build]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container: ps2dev/ps2dev:latest
-    steps:
-      - name: Install dependencies
-        run: |
-          apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
+build:
+runs-on: ubuntu-latest
+container: ps2dev/ps2dev:latest
 
-      - name: Workaround permission issue
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+```
+steps:
+  - name: Install dependencies
+    run: |
+      apk add --no-cache build-base git bash p7zip findutils coreutils zip unzip
 
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
+  - name: Workaround permission issue
+    run: |
+      git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Generate build info
-        shell: sh
-        run: |
-          set -eu
-          COMMIT_SHORT="$(echo "$GITHUB_SHA" | cut -c1-7)"
-          BUILD_UTC="$(date -u '+%Y-%m-%d %H:%MZ')"
-          printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
-          cat bin/POPSLDR/BUILD_INFO.txt
+  - name: Checkout
+    uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
 
-      - name: Validate etc/boot.lua (syntax/newline)
-        shell: bash
-        run: |
-          set -eu
-          BOOT_LUA="etc/boot.lua"
-          [ -f "$BOOT_LUA" ] || { echo "ERROR: $BOOT_LUA not found" >&2; exit 1; }
-          LAST_BYTE_HEX="$(tail -c 1 "$BOOT_LUA" | od -An -tx1 | tr -d '[:space:]')"
-          [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: $BOOT_LUA must end with newline (0x0A)" >&2; exit 1; }
-          if command -v luac >/dev/null 2>&1; then
-            luac -p "$BOOT_LUA"
-          elif command -v lua >/dev/null 2>&1; then
-            lua -e "assert(loadfile('$BOOT_LUA'))"
-          else
-            echo "NOTE: luac/lua not found; skipped Lua syntax validation"
-          fi
+  - name: Generate build info
+    shell: sh
+    run: |
+      set -eu
+      COMMIT_SHORT="$(echo "$GITHUB_SHA" | cut -c1-7)"
+      BUILD_UTC="$(date -u '+%Y-%m-%d %H:%MZ')"
+      printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
+      cat bin/POPSLDR/BUILD_INFO.txt
 
-      - name: Compile project
-        run: |
-          make clean elfloader all
+  - name: Validate etc/boot.lua (syntax/newline)
+    shell: bash
+    run: |
+      set -eu
+      BOOT_LUA="etc/boot.lua"
+      [ -f "$BOOT_LUA" ] || { echo "ERROR: $BOOT_LUA not found" >&2; exit 1; }
+      LAST_BYTE_HEX="$(tail -c 1 "$BOOT_LUA" | od -An -tx1 | tr -d '[:space:]')"
+      [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: $BOOT_LUA must end with newline (0x0A)" >&2; exit 1; }
+      if command -v luac >/dev/null 2>&1; then
+        luac -p "$BOOT_LUA"
+      elif command -v lua >/dev/null 2>&1; then
+        lua -e "assert(loadfile('$BOOT_LUA'))"
+      else
+        echo "NOTE: luac/lua not found; skipped Lua syntax validation"
+      fi
 
-      - name: Create release package (PS1_POPSLOADER + POPS)
-        shell: sh
-        run: |
-          set -eu
+  - name: Compile project
+    run: |
+      make clean elfloader all
 
-          rm -rf dist_root POPSLOADER.zip
-          mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
+  - name: Create release package (PS1_POPSLOADER + POPS)
+    shell: sh
+    run: |
+      set -eu
 
-          required_files="
-          bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
-          bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
-          bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
-          bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
-          bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
-          bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
-          bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
-          bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
-          bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
-          bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
-          bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
-          bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
-          bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
-          bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
-          bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
-          bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
-          bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
-          bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
-          bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
-          bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
-          bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
-          bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
-          bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-          bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
-          bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
-          bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
-          bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
-          "
+      rm -rf dist_root POPSLOADER.zip
+      mkdir -p dist_root/PS1_POPSLOADER dist_root/POPS
 
-          echo "$required_files" | while IFS=':' read -r src dst; do
-            src="$(echo "$src" | xargs)"
-            dst="$(echo "$dst" | xargs)"
-            [ -n "$src" ] || continue
-            if [ ! -f "$src" ]; then
-              echo "ERROR: required release file missing: $src"
-              exit 1
-            fi
-            cp -f "$src" "dist_root/$dst"
-          done
+      required_files="
+      bin/POPSLOADER.ELF:PS1_POPSLOADER/POPSLOADER.ELF
+      bin/POPSLDR/POPSTARTER.ELF:PS1_POPSLOADER/POPSTARTER.ELF
+      bin/POPSLDR/APPINFO.PBT:PS1_POPSLOADER/APPINFO.PBT
+      bin/POPSLDR/boot.adp:PS1_POPSLOADER/boot.adp
+      bin/POPSLDR/title.cfg:PS1_POPSLOADER/title.cfg
+      bin/POPSLDR/icon.sys:PS1_POPSLOADER/icon.sys
+      bin/POPSLDR/list.icn:PS1_POPSLOADER/list.icn
+      bin/POPSLDR/copy.icn:PS1_POPSLOADER/copy.icn
+      bin/POPSLDR/del.icn:PS1_POPSLOADER/del.icn
+      bin/POPSLDR/icon.sys.mmce:PS1_POPSLOADER/icon.sys.mmce
+      bin/POPSLDR/icon.sys.mx4sio:PS1_POPSLOADER/icon.sys.mx4sio
+      bin/POPSLDR/icon.sys.usbexfat:PS1_POPSLOADER/icon.sys.usbexfat
+      bin/POPSLDR/list.icn.mmce:PS1_POPSLOADER/list.icn.mmce
+      bin/POPSLDR/list.icn.mx4sio:PS1_POPSLOADER/list.icn.mx4sio
+      bin/POPSLDR/list.icn.usbexfat:PS1_POPSLOADER/list.icn.usbexfat
+      bin/POPSLDR/del.icn.mmce:PS1_POPSLOADER/del.icn.mmce
+      bin/POPSLDR/del.icn.mx4sio:PS1_POPSLOADER/del.icn.mx4sio
+      bin/POPSLDR/del.icn.usbexfat:PS1_POPSLOADER/del.icn.usbexfat
+      bin/POPSLDR/usbd.irx.mmce:PS1_POPSLOADER/usbd.irx.mmce
+      bin/POPSLDR/usbd.irx.mx4sio:PS1_POPSLOADER/usbd.irx.mx4sio
+      bin/POPSLDR/usbd.irx.usbexfat:PS1_POPSLOADER/usbd.irx.usbexfat
+      bin/POPSLDR/usbhdfsd.irx.mmce:PS1_POPSLOADER/usbhdfsd.irx.mmce
+      bin/POPSLDR/usbhdfsd.irx.mx4sio:PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+      bin/POPSLDR/usbhdfsd.irx.usbexfat:PS1_POPSLOADER/usbhdfsd.irx.usbexfat
+      bin/POPSLDR/IGR_BG.tm2:POPS/IGR_BG.tm2
+      bin/POPSLDR/IGR_NO.tm2:POPS/IGR_NO.tm2
+      bin/POPSLDR/IGR_YES.tm2:POPS/IGR_YES.tm2
+      "
 
-          cd dist_root
-          if command -v zip >/dev/null 2>&1; then
-            find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
-          elif command -v 7z >/dev/null 2>&1; then
-            7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
-          else
-            echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
-            exit 1
-          fi
-          cd - >/dev/null
+      echo "$required_files" | while IFS=':' read -r src dst; do
+        src="$(echo "$src" | xargs)"
+        dst="$(echo "$dst" | xargs)"
+        [ -n "$src" ] || continue
+        if [ ! -f "$src" ]; then
+          echo "ERROR: required release file missing: $src"
+          exit 1
+        fi
+        cp -f "$src" "dist_root/$dst"
+      done
 
-          echo "== Package contents =="
-          unzip -Z1 POPSLOADER.zip
+      cd dist_root
+      if command -v zip >/dev/null 2>&1; then
+        find PS1_POPSLOADER POPS -type f | LC_ALL=C sort | zip -X -9 ../POPSLOADER.zip -@ >/dev/null
+      elif command -v 7z >/dev/null 2>&1; then
+        7z a -tzip ../POPSLOADER.zip ./PS1_POPSLOADER/* ./POPS/* >/dev/null
+      else
+        echo "ERROR: neither zip nor 7z is available to create POPSLOADER.zip"
+        exit 1
+      fi
+      cd - >/dev/null
 
-      - name: Verify release package contents
-        shell: sh
-        run: |
-          set -eu
+      echo "== Package contents =="
+      unzip -Z1 POPSLOADER.zip
 
-          file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
+  - name: Verify release package contents
+    shell: sh
+    run: |
+      set -eu
 
-          top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
-          if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
+      file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
+
+      top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
+      if [ "$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')" -ne 2 ] || [ "$(printf '%s\n' "$top_dirs")" != "POPS
+```
+
 PS1_POPSLOADER" ]; then
-            echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
-            printf '%s\n' "$top_dirs"
-            exit 1
-          fi
+echo "ERROR: archive root must contain exactly POPS/ and PS1_POPSLOADER/"
+printf '%s\n' "$top_dirs"
+exit 1
+fi
 
-          if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
-            echo "ERROR: archive must not contain files at zip root"
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+```
+      if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {exit 0} END {exit 1}'; then
+        echo "ERROR: archive must not contain files at zip root"
+        printf '%s\n' "$file_paths"
+        exit 1
+      fi
 
-          file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
+      file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
 
-          if [ "$file_count" -ne 27 ]; then
-            echo "ERROR: package must contain exactly 27 files, found $file_count"
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+      if [ "$file_count" -ne 27 ]; then
+        echo "ERROR: package must contain exactly 27 files, found $file_count"
+        printf '%s\n' "$file_paths"
+        exit 1
+      fi
 
-          expected="POPS/IGR_BG.tm2
-          POPS/IGR_NO.tm2
-          POPS/IGR_YES.tm2
-          PS1_POPSLOADER/APPINFO.PBT
-          PS1_POPSLOADER/POPSLOADER.ELF
-          PS1_POPSLOADER/POPSTARTER.ELF
-          PS1_POPSLOADER/boot.adp
-          PS1_POPSLOADER/copy.icn
-          PS1_POPSLOADER/del.icn
-          PS1_POPSLOADER/del.icn.mmce
-          PS1_POPSLOADER/del.icn.mx4sio
-          PS1_POPSLOADER/del.icn.usbexfat
-          PS1_POPSLOADER/icon.sys
-          PS1_POPSLOADER/icon.sys.mmce
-          PS1_POPSLOADER/icon.sys.mx4sio
-          PS1_POPSLOADER/icon.sys.usbexfat
-          PS1_POPSLOADER/list.icn
-          PS1_POPSLOADER/list.icn.mmce
-          PS1_POPSLOADER/list.icn.mx4sio
-          PS1_POPSLOADER/list.icn.usbexfat
-          PS1_POPSLOADER/title.cfg
-          PS1_POPSLOADER/usbd.irx.mmce
-          PS1_POPSLOADER/usbd.irx.mx4sio
-          PS1_POPSLOADER/usbd.irx.usbexfat
-          PS1_POPSLOADER/usbhdfsd.irx.mmce
-          PS1_POPSLOADER/usbhdfsd.irx.mx4sio
-          PS1_POPSLOADER/usbhdfsd.irx.usbexfat"
+      expected="POPS/IGR_BG.tm2
+```
 
-          actual_names="$(printf '%s\n' "$file_paths" | sort)"
-          expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
+POPS/IGR_NO.tm2
+POPS/IGR_YES.tm2
+PS1_POPSLOADER/APPINFO.PBT
+PS1_POPSLOADER/POPSLOADER.ELF
+PS1_POPSLOADER/POPSTARTER.ELF
+PS1_POPSLOADER/boot.adp
+PS1_POPSLOADER/copy.icn
+PS1_POPSLOADER/del.icn
+PS1_POPSLOADER/del.icn.mmce
+PS1_POPSLOADER/del.icn.mx4sio
+PS1_POPSLOADER/del.icn.usbexfat
+PS1_POPSLOADER/icon.sys
+PS1_POPSLOADER/icon.sys.mmce
+PS1_POPSLOADER/icon.sys.mx4sio
+PS1_POPSLOADER/icon.sys.usbexfat
+PS1_POPSLOADER/list.icn
+PS1_POPSLOADER/list.icn.mmce
+PS1_POPSLOADER/list.icn.mx4sio
+PS1_POPSLOADER/list.icn.usbexfat
+PS1_POPSLOADER/title.cfg
+PS1_POPSLOADER/usbd.irx.mmce
+PS1_POPSLOADER/usbd.irx.mx4sio
+PS1_POPSLOADER/usbd.irx.usbexfat
+PS1_POPSLOADER/usbhdfsd.irx.mmce
+PS1_POPSLOADER/usbhdfsd.irx.mx4sio
+PS1_POPSLOADER/usbhdfsd.irx.usbexfat"
 
-          if [ "$actual_names" != "$expected_names" ]; then
-            echo "ERROR: package file set mismatch"
-            echo "Expected:"
-            printf '%s\n' "$expected_names"
-            echo "Actual:"
-            printf '%s\n' "$actual_names"
-            exit 1
-          fi
+```
+      actual_names="$(printf '%s\n' "$file_paths" | sort)"
+      expected_names="$(printf '%s\n' "$expected" | awk 'NF > 0' | sort)"
 
-          if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
-            echo "ERROR: forbidden file patterns detected in package"
-            printf '%s\n' "$file_paths"
-            exit 1
-          fi
+      if [ "$actual_names" != "$expected_names" ]; then
+        echo "ERROR: package file set mismatch"
+        echo "Expected:"
+        printf '%s\n' "$expected_names"
+        echo "Actual:"
+        printf '%s\n' "$actual_names"
+        exit 1
+      fi
 
-      - name: Upload artifact (no release)
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: POPSLOADER
-          path: POPSLOADER.zip
-          if-no-files-found: error
-          compression-level: 0
+      if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
+        echo "ERROR: forbidden file patterns detected in package"
+        printf '%s\n' "$file_paths"
+        exit 1
+      fi
+
+  - name: Upload artifact (no release)
+    if: success()
+    uses: actions/upload-artifact@v4
+    with:
+      name: POPSLOADER
+      path: POPSLOADER.zip
+      if-no-files-found: error
+      compression-level: 0
+```

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,13 +1,13 @@
 name: CI
 
-on:
+"on":
   push:
     branches:
       - "*"
     tags:
       - "v*"
-  pull_request: {}
-  workflow_dispatch: {}
+  pull_request:
+  workflow_dispatch:
   repository_dispatch:
     types:
       - run_build
@@ -135,7 +135,6 @@ EOF
 
           file_paths="$(unzip -Z1 POPSLOADER.zip | sed '/^$/d')"
 
-          # Root must contain exactly POPS/ and PS1_POPSLOADER/
           top_dirs="$(printf '%s\n' "$file_paths" | awk -F'/' 'NF > 1 {print $1}' | sort -u)"
           top_count="$(printf '%s\n' "$top_dirs" | wc -l | tr -d ' ')"
           if [ "$top_count" -ne 2 ]; then
@@ -146,14 +145,12 @@ EOF
           echo "$top_dirs" | grep -qx "POPS" || { echo "ERROR: missing POPS/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
           echo "$top_dirs" | grep -qx "PS1_POPSLOADER" || { echo "ERROR: missing PS1_POPSLOADER/ at root" >&2; printf '%s\n' "$top_dirs"; exit 1; }
 
-          # No files at zip root
           if printf '%s\n' "$file_paths" | awk -F'/' 'NF == 1 {found=1} END {exit (found?0:1)}'; then
             echo "ERROR: archive must not contain files at zip root" >&2
             printf '%s\n' "$file_paths"
             exit 1
           fi
 
-          # Exact file count
           file_count="$(printf '%s\n' "$file_paths" | wc -l | tr -d ' ')"
           if [ "$file_count" -ne 27 ]; then
             echo "ERROR: package must contain exactly 27 files, found $file_count" >&2
@@ -161,7 +158,6 @@ EOF
             exit 1
           fi
 
-          # Exact file set
           cat > /tmp/expected_files.txt <<'EOF'
 POPS/IGR_BG.tm2
 POPS/IGR_NO.tm2
@@ -194,7 +190,6 @@ EOF
 
           actual_names="$(printf '%s\n' "$file_paths" | sort)"
           expected_names="$(sort /tmp/expected_files.txt)"
-
           if [ "$actual_names" != "$expected_names" ]; then
             echo "ERROR: package file set mismatch" >&2
             echo "Expected:" >&2
@@ -204,7 +199,6 @@ EOF
             exit 1
           fi
 
-          # Forbidden patterns (incl PATCH5.bin)
           if printf '%s\n' "$file_paths" | grep -Eiq '(PATCH_?5\.BIN$)|(PATCH5\.BIN$)|(\.lua$)|(\.png$)|(\.o$)|(\.a$)|(\.c$)|(\.tmp$)'; then
             echo "ERROR: forbidden file patterns detected in package" >&2
             printf '%s\n' "$file_paths"


### PR DESCRIPTION
### Motivation
- Align CI packaging with the release layout requirement so the single zip `POPSLOADER.zip` has exactly two top-level folders: `PS1_POPSLOADER/` and `POPS/`.
- Ensure `PATCH5.bin`/`PATCH_5.BIN` is never included in the release package by removing it from the allowlist.
- Keep changes minimal and packaging-only (no runtime/source changes) while making output deterministic by staging into a clean `dist_root/`.

### Description
- Reworked CI packaging in `.github/workflows/compilation.yml` to stage files into `dist_root/PS1_POPSLOADER` and `dist_root/POPS` and build `POPSLOADER.zip` (replacing the previous `APP_POPSLOADER.zip`).
- Replaced flat allowlist with explicit mappings that copy release files into the two folders and removed the `bin/POPSLDR/PATCH_5.BIN` entry from the allowlist.
- Updated zip creation to preserve the folder root (`find ... | sort | zip -@`) and added structural verification that the zip root contains exactly `POPS/` and `PS1_POPSLOADER/` and no files at zip root.
- Changed artifact upload name/path to publish `POPSLOADER.zip` and added checks to reject archives containing `PATCH5.bin`/`PATCH_5.BIN` and other forbidden patterns.

### Testing
- Attempted full build with `make clean elfloader all`, which failed in this environment because `/samples/Makefile.eeglobal` is missing (external dependency), so CI compilation cannot be validated here (failure expected in this sandbox).
- Simulated the CI packaging step locally by copying allowed files from `bin/` into `dist_root/` and running the same zip commands; `unzip -Z1 POPSLOADER.zip` produced the expected listing with `PS1_POPSLOADER/` and `POPS/` as the only top-level entries and the expected files under them, and a grep check confirmed no `PATCH5.bin`/`PATCH_5.BIN` entries (simulation succeeded).
- Verified repository change with `git show --stat --oneline HEAD` (commit `f774098`) and inspected the `.github/workflows/compilation.yml` diff to confirm the exact CI/workflow edits (displayed in PR validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2930c66308321816d16bd7963571e)