### PR TITLE
Fix MX4SIO page freeze and embed BDMA assets for USB boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,11 @@ EMBEDDED_RSC = boot.o builtin_font.o \
 	asset_bdhdd_png.o asset_bg_png.o asset_bkg_png.o asset_bgm_png.o asset_disc_png.o asset_splash_bg_png.o \
 	asset_splash_logo_png.o asset_splash_appname_png.o asset_splash_credits_png.o asset_select_png.o \
 	asset_start_png.o asset_triangle_png.o asset_circle_png.o asset_cross_png.o asset_r2_png.o asset_square_png.o \
-	asset_system_lua.o asset_ui_lua.o asset_images_lua.o asset_pops_profiles_lua.o
+	asset_system_lua.o asset_ui_lua.o asset_images_lua.o asset_pops_profiles_lua.o \
+	asset_usbd_irx_usbexfat.o asset_usbhdfsd_irx_usbexfat.o asset_usbd_irx_mx4sio.o asset_usbhdfsd_irx_mx4sio.o \
+	asset_usbd_irx_mmce.o asset_usbhdfsd_irx_mmce.o asset_icon_sys_mx4sio.o asset_list_icn_mx4sio.o asset_del_icn_mx4sio.o \
+	asset_icon_sys_mmce.o asset_list_icn_mmce.o asset_del_icn_mmce.o asset_icon_sys_usbexfat.o asset_list_icn_usbexfat.o \
+	asset_del_icn_usbexfat.o
 
 EE_OBJS = $(APP_CORE) $(LUA_LIBS) $(IOP_MODULES) $(EMBEDDED_RSC)
 
@@ -165,6 +169,37 @@ $(EE_ASM_DIR)asset_images_lua.c: bin/POPSLDR/images.lua | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_images_lua
 $(EE_ASM_DIR)asset_pops_profiles_lua.c: bin/POPSLDR/pops_profiles.lua | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_pops_profiles_lua
+
+$(EE_ASM_DIR)asset_usbd_irx_usbexfat.c: bin/POPSLDR/usbd.irx.usbexfat | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbd_irx_usbexfat
+$(EE_ASM_DIR)asset_usbhdfsd_irx_usbexfat.c: bin/POPSLDR/usbhdfsd.irx.usbexfat | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbhdfsd_irx_usbexfat
+$(EE_ASM_DIR)asset_usbd_irx_mx4sio.c: bin/POPSLDR/usbd.irx.mx4sio | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbd_irx_mx4sio
+$(EE_ASM_DIR)asset_usbhdfsd_irx_mx4sio.c: bin/POPSLDR/usbhdfsd.irx.mx4sio | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbhdfsd_irx_mx4sio
+$(EE_ASM_DIR)asset_usbd_irx_mmce.c: bin/POPSLDR/usbd.irx.mmce | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbd_irx_mmce
+$(EE_ASM_DIR)asset_usbhdfsd_irx_mmce.c: bin/POPSLDR/usbhdfsd.irx.mmce | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_usbhdfsd_irx_mmce
+$(EE_ASM_DIR)asset_icon_sys_mx4sio.c: bin/POPSLDR/icon.sys.mx4sio | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_icon_sys_mx4sio
+$(EE_ASM_DIR)asset_list_icn_mx4sio.c: bin/POPSLDR/list.icn.mx4sio | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_list_icn_mx4sio
+$(EE_ASM_DIR)asset_del_icn_mx4sio.c: bin/POPSLDR/del.icn.mx4sio | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_del_icn_mx4sio
+$(EE_ASM_DIR)asset_icon_sys_mmce.c: bin/POPSLDR/icon.sys.mmce | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_icon_sys_mmce
+$(EE_ASM_DIR)asset_list_icn_mmce.c: bin/POPSLDR/list.icn.mmce | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_list_icn_mmce
+$(EE_ASM_DIR)asset_del_icn_mmce.c: bin/POPSLDR/del.icn.mmce | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_del_icn_mmce
+$(EE_ASM_DIR)asset_icon_sys_usbexfat.c: bin/POPSLDR/icon.sys.usbexfat | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_icon_sys_usbexfat
+$(EE_ASM_DIR)asset_list_icn_usbexfat.c: bin/POPSLDR/list.icn.usbexfat | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_list_icn_usbexfat
+$(EE_ASM_DIR)asset_del_icn_usbexfat.c: bin/POPSLDR/del.icn.usbexfat | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_del_icn_usbexfat
 
 #------------------------------------------------------------------#
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -11,6 +11,8 @@
 
   Licensed under GNU General public license v3.0
 --]]
+_G.PLDR = _G.PLDR or {}
+PLDR = _G.PLDR
 local BOOT_PATH_RAW = System.currentDirectory()
 local function EnsureTrailingSlash(path)
   if path == nil then
@@ -200,7 +202,7 @@ if not loadedIrx then
   LoadIrxFromDir(JoinPath(APP_DIR_LOCAL, "POPSLDR/IRX"))
 end
 HDD_DIAG_BYPASS = 0
-PLDR = {
+local pldr_defaults = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
   POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
   CHECK_POPSTARTER_FILES = false;
@@ -234,6 +236,11 @@ PLDR = {
     INDEX = 1
   }
 }
+for k, v in pairs(pldr_defaults) do
+  if PLDR[k] == nil then
+    PLDR[k] = v
+  end
+end
 local function DetectMX4SIOPrefixHint()
   local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
   if doesFileExist(mx_marker) then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -490,7 +490,7 @@ local function GetFileSizeSafe(path)
   return size_val
 end
 
-local function CopyExternalAtomicBounded(source, dest)
+local function CopyExternalAtomicBounded(source, dest, expected_size)
   local tmp = dest..".tmp"
   if doesFileExist(tmp) then
     pcall(System.removeFile, tmp)
@@ -502,9 +502,18 @@ local function CopyExternalAtomicBounded(source, dest)
   end
 
   local expected = nil
-  local ok_size, size_val = pcall(System.sizeFile, src_fd)
-  if ok_size and type(size_val) == "number" and size_val > 0 then
-    expected = size_val
+  if type(expected_size) == "number" and expected_size > 0 then
+    expected = expected_size
+  else
+    local ok_size, size_val = pcall(System.sizeFile, src_fd)
+    if ok_size and type(size_val) == "number" and size_val > 0 then
+      expected = size_val
+    end
+  end
+
+  if expected == nil then
+    pcall(System.closeFile, src_fd)
+    return false, "size unknown"
   end
 
   local ok_dst, dst_fd = pcall(System.openFile, tmp, FCREATE)
@@ -520,7 +529,7 @@ local function CopyExternalAtomicBounded(source, dest)
 
   while true do
     iters = iters + 1
-    if expected ~= nil and copied_bytes >= expected then
+    if copied_bytes >= expected then
       break
     end
     if iters > MAX_ITERS then
@@ -545,7 +554,7 @@ local function CopyExternalAtomicBounded(source, dest)
     end
 
     copied_bytes = copied_bytes + chunk_len
-    if expected ~= nil and copied_bytes > expected + 65536 then
+    if copied_bytes > expected + 65536 then
       copied = false
       break
     end
@@ -855,13 +864,17 @@ function PLDR.EnsureUsbMassReadyOnce()
     return true
   end
 
-  if type(System) == "table" and type(System.initUSBMass) == "function" then
+  if type(System) == "table" and type(System.ensureUsbMass) == "function" then
+    pcall(System.ensureUsbMass)
+  elseif type(System) == "table" and type(System.initUSBMass) == "function" then
     pcall(System.initUSBMass)
   end
   if type(System) == "table" and type(System.initUSB) == "function" then
     pcall(System.initUSB)
   end
-  if type(PLDR.RefreshMassBackends) == "function" then
+  if type(PLDR.RefreshMassStateSnapshot) == "function" then
+    pcall(PLDR.RefreshMassStateSnapshot)
+  elseif type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
   end
 
@@ -1055,7 +1068,7 @@ function PLDR.ApplyBdmaMode(mode_key)
       local src_size = GetFileSizeSafe(source)
       local dst_size = GetFileSizeSafe(dest)
       if src_size == nil or dst_size == nil or src_size ~= dst_size then
-        local ok, copied = pcall(CopyExternalAtomicBounded, source, dest)
+        local ok, copied = pcall(CopyExternalAtomicBounded, source, dest, src_size)
         if not ok or not copied then
           had_failure = true
           return false

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -115,6 +115,10 @@ local function IsAbsoluteDevicePath(path)
   return path ~= nil and string.match(path, "^[%a]+%d*:/") ~= nil
 end
 
+local function IsMassPath(path)
+  return path ~= nil and string.match(path, "^mass%d*:/") ~= nil
+end
+
 local function ResolvePopstarterPath(path)
   local chosen = path
   if chosen == nil or chosen == "" then
@@ -124,6 +128,12 @@ local function ResolvePopstarterPath(path)
   end
   if doesFileExist(chosen) then
     return chosen
+  end
+  if IsMassPath(chosen) and type(PLDR) == "table" and type(PLDR.EnsureUsbMassReadyOnce) == "function" then
+    pcall(PLDR.EnsureUsbMassReadyOnce)
+    if doesFileExist(chosen) then
+      return chosen
+    end
   end
 
   local fallbacks = {
@@ -837,6 +847,25 @@ function PLDR.RefreshMassBackends()
   PLDR.MASS.CACHE = new_cache
   PLDR.MASS.ORDER = new_order
   PLDR.MASS.REFRESHED = true
+  return true
+end
+
+function PLDR.EnsureUsbMassReadyOnce()
+  if PLDR._usb_mass_ready then
+    return true
+  end
+
+  if type(System) == "table" and type(System.initUSBMass) == "function" then
+    pcall(System.initUSBMass)
+  end
+  if type(System) == "table" and type(System.initUSB) == "function" then
+    pcall(System.initUSB)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
+
+  PLDR._usb_mass_ready = true
   return true
 end
 
@@ -1751,6 +1780,10 @@ end
 
 local function TryOpenForLaunch(path)
   local ok, fd_or_err = pcall(System.openFile, path, FREAD)
+  if (not ok or type(fd_or_err) ~= "number" or fd_or_err < 0) and IsMassPath(path) and type(PLDR) == "table" and type(PLDR.EnsureUsbMassReadyOnce) == "function" then
+    pcall(PLDR.EnsureUsbMassReadyOnce)
+    ok, fd_or_err = pcall(System.openFile, path, FREAD)
+  end
   if not ok or type(fd_or_err) ~= "number" or fd_or_err < 0 then
     local alt = HostAltPath(path)
     if alt ~= nil then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1073,25 +1073,53 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  local hints = {
+  if type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+
+  local roots = {
     "mx4sio0:/",
     "mx4sio:/"
   }
-  for i = 1, #hints do
-    local hint = hints[i]
+
+  for i = 1, #roots do
+    local candidate = roots[i]
+    local call_ok = false
+    local ret1, ret2 = nil, nil
+
     if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      local ok_init, ok, root = pcall(System.initMX4SIO, hint)
-      if ok_init and ok and root ~= nil and root ~= "" then
-        local normalized_root = EnsureTrailingSlash(root)
-        local pops_root = normalized_root.."POPS/"
-        if doesFolderExist(pops_root) then
-          PLDR.MX4SIO.READY = true
-          PLDR.MX4SIO.ROOT = normalized_root
-          return pops_root
-        end
+      call_ok, ret1, ret2 = pcall(System.initMX4SIO, candidate)
+      if not call_ok then
+        call_ok, ret1, ret2 = pcall(System.initMX4SIO)
+      end
+    end
+
+    local init_ok = false
+    if call_ok then
+      if ret1 == true then
+        init_ok = true
+      elseif type(ret1) == "string" and ret1 ~= "" then
+        init_ok = true
+      end
+    end
+
+    if init_ok then
+      local final_root = candidate
+      if type(ret1) == "string" and ret1 ~= "" then
+        final_root = ret1
+      elseif type(ret2) == "string" and ret2 ~= "" then
+        final_root = ret2
+      end
+      final_root = EnsureTrailingSlash(final_root)
+      local pops_root = final_root.."POPS/"
+      if doesFolderExist(pops_root) then
+        PLDR.MX4SIO.READY = true
+        PLDR.MX4SIO.ROOT = final_root
+        return pops_root
       end
     end
   end
+
   return nil
 end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -522,6 +522,63 @@ local function CopyExternalAtomicBounded(source, dest)
 end
 
 
+local function WriteBytesAtomicBounded(data, dest)
+  if type(data) ~= "string" then
+    return false, "invalid data"
+  end
+
+  local tmp = dest..".tmp"
+  if doesFileExist(tmp) then
+    pcall(System.removeFile, tmp)
+  end
+
+  local ok_open, fd = pcall(System.openFile, tmp, FCREATE)
+  if not ok_open or fd == nil or (type(fd) == "number" and fd < 0) then
+    return false, "open destination failed"
+  end
+
+  local expected = string.len(data)
+  local offset = 1
+  local iters = 0
+  local MAX_ITERS = 4096
+  local wrote_all = true
+
+  while offset <= expected and iters < MAX_ITERS do
+    iters = iters + 1
+    local chunk = string.sub(data, offset, math.min(offset + 32768 - 1, expected))
+    local chunk_len = string.len(chunk)
+    local ok_write, wrote = pcall(System.writeFile, fd, chunk, chunk_len)
+    if not ok_write or type(wrote) ~= "number" or wrote ~= chunk_len then
+      wrote_all = false
+      break
+    end
+    offset = offset + chunk_len
+  end
+
+  if offset <= expected then
+    wrote_all = false
+  end
+
+  pcall(System.closeFile, fd)
+
+  if not wrote_all then
+    pcall(System.removeFile, tmp)
+    return false, "write failed"
+  end
+
+  if doesFileExist(dest) then
+    pcall(System.removeFile, dest)
+  end
+  local ok_rename = pcall(System.rename, tmp, dest)
+  if not ok_rename then
+    pcall(System.removeFile, tmp)
+    return false, "rename failed"
+  end
+  return true
+end
+
+
+
 local function EnsureDirectory(path)
   if doesFolderExist(path) then
     return true
@@ -788,11 +845,16 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
   if wanted == "usb" then
     for _, i in ipairs(state.ORDER or {}) do
       local info = state.CACHE and state.CACHE[i] or nil
-      if info ~= nil and info.present and info.kind == "usb" then
-        if i == 0 then
-          table.insert(roots, "mass:/")
+      if info ~= nil and info.present then
+        local driver = string.lower(tostring(PLDR.GetMassDriverName(i) or info.driver or ""))
+        local is_usb = string.find(driver, "usb", 1, true) ~= nil
+        local blocked = string.find(driver, "sdc", 1, true) ~= nil or string.find(driver, "mx4", 1, true) ~= nil or string.find(driver, "mmce", 1, true) ~= nil
+        if is_usb and not blocked then
+          if i == 0 then
+            table.insert(roots, "mass:/")
+          end
+          table.insert(roots, "mass"..i..":/")
         end
-        table.insert(roots, "mass"..i..":/")
       end
     end
   elseif wanted == "mx4sio" then
@@ -911,7 +973,7 @@ function PLDR.ApplyBdmaMode(mode_key)
         return false
       end
       local dest = POPSTARTER_PACK_ROOT.."/"..name
-      local ok_write, wrote = pcall(WriteAtomic, dest, bytes)
+      local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
       if not ok_write or not wrote then
         had_failure = true
         return false
@@ -1159,18 +1221,27 @@ function PLDR.InitMX4SIOPopsRoot()
       pcall(System.initMX4SIO)
     end
     if type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.1)
+      pcall(System.sleep, 0.05)
     end
 
-    local snapshot = PLDR.RefreshMassStateSnapshot()
-    local roots = PLDR.GetRootsByType("mx4sio", snapshot)
-    for i = 1, #roots do
-      local root = EnsureTrailingSlash(roots[i])
-      local pops_root = root.."POPS/"
-      if doesFolderExist(pops_root) then
-        PLDR.MX4SIO.READY = true
-        PLDR.MX4SIO.ROOT = root
-        return pops_root
+    for i = 0, 9 do
+      local driver = string.lower(tostring(PLDR.GetMassDriverName(i) or ""))
+      if string.find(driver, "sdc", 1, true) ~= nil or string.find(driver, "mx4", 1, true) ~= nil then
+        local candidates = {}
+        if i == 0 then
+          table.insert(candidates, "mass:/")
+        end
+        table.insert(candidates, "mass"..i..":/")
+
+        for j = 1, #candidates do
+          local root = EnsureTrailingSlash(candidates[j])
+          local pops_root = root.."POPS/"
+          if doesFolderExist(pops_root) then
+            PLDR.MX4SIO.READY = true
+            PLDR.MX4SIO.ROOT = root
+            return pops_root
+          end
+        end
       end
     end
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -441,6 +441,87 @@ local function CopyExternalAtomic(source, dest)
 end
 
 
+local function CopyExternalAtomicBounded(source, dest)
+  local tmp = dest..".tmp"
+  if doesFileExist(tmp) then
+    pcall(System.removeFile, tmp)
+  end
+
+  local ok_src, src_fd = pcall(System.openFile, source, FREAD)
+  if not ok_src or src_fd == nil or (type(src_fd) == "number" and src_fd < 0) then
+    return false, "open source failed"
+  end
+
+  local expected = nil
+  local ok_size, size_val = pcall(System.sizeFile, src_fd)
+  if ok_size and type(size_val) == "number" and size_val > 0 then
+    expected = size_val
+  end
+
+  local ok_dst, dst_fd = pcall(System.openFile, tmp, FCREATE)
+  if not ok_dst or dst_fd == nil or (type(dst_fd) == "number" and dst_fd < 0) then
+    pcall(System.closeFile, src_fd)
+    return false, "open destination failed"
+  end
+
+  local copied = true
+  local copied_bytes = 0
+  local iters = 0
+  local MAX_ITERS = 4096
+
+  while true do
+    iters = iters + 1
+    if expected ~= nil and copied_bytes >= expected then
+      break
+    end
+    if iters > MAX_ITERS then
+      copied = false
+      break
+    end
+
+    local ok_read, chunk = pcall(System.readFile, src_fd, 32768)
+    if not ok_read then
+      copied = false
+      break
+    end
+    if chunk == nil or chunk == "" then
+      break
+    end
+
+    local chunk_len = string.len(chunk)
+    local ok_write, wrote = pcall(System.writeFile, dst_fd, chunk, chunk_len)
+    if not ok_write or type(wrote) ~= "number" or wrote ~= chunk_len then
+      copied = false
+      break
+    end
+
+    copied_bytes = copied_bytes + chunk_len
+    if expected ~= nil and copied_bytes > expected + 65536 then
+      copied = false
+      break
+    end
+  end
+
+  pcall(System.closeFile, src_fd)
+  pcall(System.closeFile, dst_fd)
+
+  if not copied then
+    pcall(System.removeFile, tmp)
+    return false, "copy failed"
+  end
+
+  if doesFileExist(dest) then
+    pcall(System.removeFile, dest)
+  end
+  local ok_rename = pcall(System.rename, tmp, dest)
+  if not ok_rename then
+    pcall(System.removeFile, tmp)
+    return false, "rename failed"
+  end
+  return true
+end
+
+
 local function EnsureDirectory(path)
   if doesFolderExist(path) then
     return true
@@ -715,17 +796,14 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
       end
     end
   elseif wanted == "mx4sio" then
-    local has_mx = false
     for _, i in ipairs(state.ORDER or {}) do
       local info = state.CACHE and state.CACHE[i] or nil
       if info ~= nil and info.present and info.kind == "mx4sio" then
-        has_mx = true
-        break
+        if i == 0 then
+          table.insert(roots, "mass:/")
+        end
+        table.insert(roots, "mass"..i..":/")
       end
-    end
-    if has_mx then
-      table.insert(roots, "mx4sio0:/")
-      table.insert(roots, "mx4sio:/")
     end
   end
   return roots
@@ -840,7 +918,7 @@ function PLDR.ApplyBdmaMode(mode_key)
       end
     else
       local dest = POPSTARTER_PACK_ROOT.."/"..name
-      local ok, copied = pcall(CopyExternalAtomic, source, dest)
+      local ok, copied = pcall(CopyExternalAtomicBounded, source, dest)
       if not ok or not copied then
         had_failure = true
         return false
@@ -1074,6 +1152,9 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.ROOT = nil
 
   for pass = 1, 2 do
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
     if type(System) == "table" and type(System.initMX4SIO) == "function" then
       pcall(System.initMX4SIO)
     end
@@ -1081,24 +1162,15 @@ function PLDR.InitMX4SIOPopsRoot()
       pcall(System.sleep, 0.1)
     end
 
-    for i = 0, 9 do
-      local driver = string.lower(tostring(PLDR.GetMassDriverName(i) or ""))
-      if string.find(driver, "sdc", 1, true) ~= nil or string.find(driver, "mx4", 1, true) ~= nil then
-        local candidates = {}
-        if i == 0 then
-          table.insert(candidates, "mass:/")
-        end
-        table.insert(candidates, "mass"..i..":/")
-
-        for j = 1, #candidates do
-          local root = EnsureTrailingSlash(candidates[j])
-          local pops_root = root.."POPS/"
-          if doesFolderExist(pops_root) then
-            PLDR.MX4SIO.READY = true
-            PLDR.MX4SIO.ROOT = root
-            return pops_root
-          end
-        end
+    local snapshot = PLDR.RefreshMassStateSnapshot()
+    local roots = PLDR.GetRootsByType("mx4sio", snapshot)
+    for i = 1, #roots do
+      local root = EnsureTrailingSlash(roots[i])
+      local pops_root = root.."POPS/"
+      if doesFolderExist(pops_root) then
+        PLDR.MX4SIO.READY = true
+        PLDR.MX4SIO.ROOT = root
+        return pops_root
       end
     end
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -114,7 +114,6 @@ local function IsAbsoluteDevicePath(path)
 end
 
 local function ResolvePopstarterPath(path)
-  local fallback = "mass:/POPS/POPSTARTER.ELF"
   local chosen = path
   if chosen == nil or chosen == "" then
     chosen = JoinPath(APP_DIR_LOCAL, "POPSTARTER.ELF")
@@ -124,14 +123,28 @@ local function ResolvePopstarterPath(path)
   if doesFileExist(chosen) then
     return chosen
   end
-  if chosen ~= fallback and doesFileExist(fallback) then
-    return fallback
+
+  local fallbacks = {
+    JoinPath(APP_DIR_LOCAL, "POPSTARTER.ELF"),
+    "mc0:/POPSTARTER/POPSTARTER.ELF",
+    "mc1:/POPSTARTER/POPSTARTER.ELF"
+  }
+  for i = 1, #fallbacks do
+    local candidate = fallbacks[i]
+    if candidate ~= chosen and doesFileExist(candidate) then
+      return candidate
+    end
   end
+
   return chosen
 end
 
 local function ResolveIrx(name)
   return System.resolveAssetType(name, ASSET_IRX) or JoinPath(APP_DIR_LOCAL, name)
+end
+
+function PLDR.ResolvePopstarterPath(path)
+  return ResolvePopstarterPath(path)
 end
 
 local function DetectBootDevice()
@@ -440,6 +453,25 @@ local function CopyExternalAtomic(source, dest)
   return true
 end
 
+
+local function GetFileSizeSafe(path)
+  if path == nil or path == "" then
+    return nil
+  end
+  if not doesFileExist(path) then
+    return nil
+  end
+  local ok_open, fd = pcall(System.openFile, path, FREAD)
+  if not ok_open or fd == nil or (type(fd) == "number" and fd < 0) then
+    return nil
+  end
+  local ok_size, size_val = pcall(System.sizeFile, fd)
+  pcall(System.closeFile, fd)
+  if not ok_size or type(size_val) ~= "number" or size_val < 0 then
+    return nil
+  end
+  return size_val
+end
 
 local function CopyExternalAtomicBounded(source, dest)
   local tmp = dest..".tmp"
@@ -973,17 +1005,25 @@ function PLDR.ApplyBdmaMode(mode_key)
         return false
       end
       local dest = POPSTARTER_PACK_ROOT.."/"..name
-      local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
-      if not ok_write or not wrote then
-        had_failure = true
-        return false
+      local expected = string.len(bytes)
+      local current_size = GetFileSizeSafe(dest)
+      if current_size == nil or current_size ~= expected then
+        local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
+        if not ok_write or not wrote then
+          had_failure = true
+          return false
+        end
       end
     else
       local dest = POPSTARTER_PACK_ROOT.."/"..name
-      local ok, copied = pcall(CopyExternalAtomicBounded, source, dest)
-      if not ok or not copied then
-        had_failure = true
-        return false
+      local src_size = GetFileSizeSafe(source)
+      local dst_size = GetFileSizeSafe(dest)
+      if src_size == nil or dst_size == nil or src_size ~= dst_size then
+        local ok, copied = pcall(CopyExternalAtomicBounded, source, dest)
+        if not ok or not copied then
+          had_failure = true
+          return false
+        end
       end
     end
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1073,49 +1073,32 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-
-  local roots = {
-    "mx4sio0:/",
-    "mx4sio:/"
-  }
-
-  for i = 1, #roots do
-    local candidate = roots[i]
-    local call_ok = false
-    local ret1, ret2 = nil, nil
-
+  for pass = 1, 2 do
     if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      call_ok, ret1, ret2 = pcall(System.initMX4SIO, candidate)
-      if not call_ok then
-        call_ok, ret1, ret2 = pcall(System.initMX4SIO)
-      end
+      pcall(System.initMX4SIO)
+    end
+    if type(System) == "table" and type(System.sleep) == "function" then
+      pcall(System.sleep, 0.1)
     end
 
-    local init_ok = false
-    if call_ok then
-      if ret1 == true then
-        init_ok = true
-      elseif type(ret1) == "string" and ret1 ~= "" then
-        init_ok = true
-      end
-    end
+    for i = 0, 9 do
+      local driver = string.lower(tostring(PLDR.GetMassDriverName(i) or ""))
+      if string.find(driver, "sdc", 1, true) ~= nil or string.find(driver, "mx4", 1, true) ~= nil then
+        local candidates = {}
+        if i == 0 then
+          table.insert(candidates, "mass:/")
+        end
+        table.insert(candidates, "mass"..i..":/")
 
-    if init_ok then
-      local final_root = candidate
-      if type(ret1) == "string" and ret1 ~= "" then
-        final_root = ret1
-      elseif type(ret2) == "string" and ret2 ~= "" then
-        final_root = ret2
-      end
-      final_root = EnsureTrailingSlash(final_root)
-      local pops_root = final_root.."POPS/"
-      if doesFolderExist(pops_root) then
-        PLDR.MX4SIO.READY = true
-        PLDR.MX4SIO.ROOT = final_root
-        return pops_root
+        for j = 1, #candidates do
+          local root = EnsureTrailingSlash(candidates[j])
+          local pops_root = root.."POPS/"
+          if doesFolderExist(pops_root) then
+            PLDR.MX4SIO.READY = true
+            PLDR.MX4SIO.ROOT = root
+            return pops_root
+          end
+        end
       end
     end
   end
@@ -1435,7 +1418,8 @@ local function BuildPopstarterSelectorPath(device_page, game_name)
     return "mass:/POPS/XX."..game_name..".ELF"
   end
   if device_page == "MX4SIO" then
-    local root = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.ROOT or "mx4sio:/"
+    local root = PLDR and PLDR.MX4SIO and PLDR.MX4SIO.ROOT or "mass:/"
+    root = EnsureTrailingSlash(root)
     return root.."POPS/XX."..game_name..".ELF"
   end
   return game_name..".ELF"

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -819,16 +819,32 @@ function PLDR.ApplyBdmaMode(mode_key)
       System.closeFile(fd)
     end
     if source == nil then
-      if UI ~= nil and UI.Notif_queue ~= nil then
-        UI.Notif_queue.add("Missing BDMA source (tried):\n"..table.concat(paths, "\n"))
+      local bytes = nil
+      if type(System) == "table" and type(System.getEmbeddedAsset) == "function" then
+        local ok_embedded, embedded = pcall(System.getEmbeddedAsset, rel)
+        if ok_embedded and embedded ~= nil then
+          bytes = embedded
+        end
       end
-      return false
-    end
-    local dest = POPSTARTER_PACK_ROOT.."/"..name
-    local ok, copied = pcall(CopyExternalAtomic, source, dest)
-    if not ok or not copied then
-      had_failure = true
-      return false
+      if bytes == nil then
+        if UI ~= nil and UI.Notif_queue ~= nil then
+          UI.Notif_queue.add("Missing BDMA source (tried):\n"..table.concat(paths, "\n"))
+        end
+        return false
+      end
+      local dest = POPSTARTER_PACK_ROOT.."/"..name
+      local ok_write, wrote = pcall(WriteAtomic, dest, bytes)
+      if not ok_write or not wrote then
+        had_failure = true
+        return false
+      end
+    else
+      local dest = POPSTARTER_PACK_ROOT.."/"..name
+      local ok, copied = pcall(CopyExternalAtomic, source, dest)
+      if not ok or not copied then
+        had_failure = true
+        return false
+      end
     end
   end
   return not had_failure
@@ -1057,21 +1073,22 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  for pass = 1, 2 do
+  local hints = {
+    "mx4sio0:/",
+    "mx4sio:/"
+  }
+  for i = 1, #hints do
+    local hint = hints[i]
     if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 1)
-    end
-    local snapshot = PLDR.RefreshMassStateSnapshot()
-    local roots = PLDR.GetRootsByType("mx4sio", snapshot)
-    for i = 1, #roots do
-      local pops_root = roots[i].."POPS/"
-      if doesFolderExist(pops_root) then
-        PLDR.MX4SIO.READY = true
-        PLDR.MX4SIO.ROOT = roots[i]
-        return pops_root
+      local ok_init, ok, root = pcall(System.initMX4SIO, hint)
+      if ok_init and ok and root ~= nil and root ~= "" then
+        local normalized_root = EnsureTrailingSlash(root)
+        local pops_root = normalized_root.."POPS/"
+        if doesFolderExist(pops_root) then
+          PLDR.MX4SIO.READY = true
+          PLDR.MX4SIO.ROOT = normalized_root
+          return pops_root
+        end
       end
     end
   end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1284,9 +1284,15 @@ end
         if UI.Pad.Events.CONFIRM then
           if ammount <= 0 then
             UI.Notif_queue.add("No games found")
-          elseif not doesFileExist(PLDR.POPSTARTER_PATH) then
-            UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..PLDR.POPSTARTER_PATH)
           else
+            local popstarter_path = PLDR.POPSTARTER_PATH
+            if type(PLDR.ResolvePopstarterPath) == "function" then
+              popstarter_path = PLDR.ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
+            end
+            if not doesFileExist(popstarter_path) then
+              UI.Notif_queue.add("Cant find POPSTARTER ELF\n"..tostring(popstarter_path))
+              return
+            end
             local entry = PLDR.GAMES[UI.GameList.CURR]
             local root, rel = string.match(entry or "", "^([^|]+)|(.+)$")
             local vcd_full = nil
@@ -1363,7 +1369,10 @@ end
             UI.SavingActive = true
             local ok_run, result = xpcall(function()
               local saved = PLDR.SaveSettingsAtomic()
-              local applied = PLDR.ApplyBdmaMode(PLDR.BDMA_MODE_KEY)
+              local applied = true
+              if UI.BdmaDirty then
+                applied = PLDR.ApplyBdmaMode(PLDR.BDMA_MODE_KEY)
+              end
               return saved and applied
             end, function(e) return e end)
             UI.SavingActive = false

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1653,7 +1653,8 @@ end
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
             if type(PLDR) == "table" and type(PLDR.InitMX4SIOPopsRoot) == "function" then
-              mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+              local ok, res = pcall(PLDR.InitMX4SIOPopsRoot)
+              if ok then mx4sio_root = res else mx4sio_root = nil end
             end
             if mx4sio_root == nil then
               UI.Notif_queue.add("No MX4SIO device found (POPS/ missing)")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1360,11 +1360,14 @@ end
             PLDR.SELECTED_PROFILE = UI.ProfileQuery.curopt
             PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
             PLDR.BDMA_MODE_KEY = UI.BdmaModes[UI.BdmaModeIndex].key
-            local ok1, saved = pcall(PLDR.SaveSettingsAtomic)
-            local ok2, applied = pcall(PLDR.ApplyBdmaMode, PLDR.BDMA_MODE_KEY)
-            saved = ok1 and saved
-            applied = ok2 and applied
-            if saved and applied then
+            UI.SavingActive = true
+            local ok_run, result = xpcall(function()
+              local saved = PLDR.SaveSettingsAtomic()
+              local applied = PLDR.ApplyBdmaMode(PLDR.BDMA_MODE_KEY)
+              return saved and applied
+            end, function(e) return e end)
+            UI.SavingActive = false
+            if ok_run and result then
               UI.ProfileDirty = false
               UI.BdmaDirty = false
             else

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1360,8 +1360,10 @@ end
             PLDR.SELECTED_PROFILE = UI.ProfileQuery.curopt
             PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
             PLDR.BDMA_MODE_KEY = UI.BdmaModes[UI.BdmaModeIndex].key
-            local saved = PLDR.SaveSettingsAtomic()
-            local applied = PLDR.ApplyBdmaMode(PLDR.BDMA_MODE_KEY)
+            local ok1, saved = pcall(PLDR.SaveSettingsAtomic)
+            local ok2, applied = pcall(PLDR.ApplyBdmaMode, PLDR.BDMA_MODE_KEY)
+            saved = ok1 and saved
+            applied = ok2 and applied
             if saved and applied then
               UI.ProfileDirty = false
               UI.BdmaDirty = false

--- a/src/embed_assets.cpp
+++ b/src/embed_assets.cpp
@@ -61,6 +61,36 @@ extern unsigned char asset_images_lua[];
 extern unsigned int size_asset_images_lua;
 extern unsigned char asset_pops_profiles_lua[];
 extern unsigned int size_asset_pops_profiles_lua;
+extern unsigned char asset_usbd_irx_usbexfat[];
+extern unsigned int size_asset_usbd_irx_usbexfat;
+extern unsigned char asset_usbhdfsd_irx_usbexfat[];
+extern unsigned int size_asset_usbhdfsd_irx_usbexfat;
+extern unsigned char asset_usbd_irx_mx4sio[];
+extern unsigned int size_asset_usbd_irx_mx4sio;
+extern unsigned char asset_usbhdfsd_irx_mx4sio[];
+extern unsigned int size_asset_usbhdfsd_irx_mx4sio;
+extern unsigned char asset_usbd_irx_mmce[];
+extern unsigned int size_asset_usbd_irx_mmce;
+extern unsigned char asset_usbhdfsd_irx_mmce[];
+extern unsigned int size_asset_usbhdfsd_irx_mmce;
+extern unsigned char asset_icon_sys_mx4sio[];
+extern unsigned int size_asset_icon_sys_mx4sio;
+extern unsigned char asset_list_icn_mx4sio[];
+extern unsigned int size_asset_list_icn_mx4sio;
+extern unsigned char asset_del_icn_mx4sio[];
+extern unsigned int size_asset_del_icn_mx4sio;
+extern unsigned char asset_icon_sys_mmce[];
+extern unsigned int size_asset_icon_sys_mmce;
+extern unsigned char asset_list_icn_mmce[];
+extern unsigned int size_asset_list_icn_mmce;
+extern unsigned char asset_del_icn_mmce[];
+extern unsigned int size_asset_del_icn_mmce;
+extern unsigned char asset_icon_sys_usbexfat[];
+extern unsigned int size_asset_icon_sys_usbexfat;
+extern unsigned char asset_list_icn_usbexfat[];
+extern unsigned int size_asset_list_icn_usbexfat;
+extern unsigned char asset_del_icn_usbexfat[];
+extern unsigned int size_asset_del_icn_usbexfat;
 
 #define ASSET_ENTRY(key_name, symbol_name) { key_name, symbol_name, (size_t)size_##symbol_name }
 
@@ -91,6 +121,22 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("ui.lua", asset_ui_lua),
 	ASSET_ENTRY("images.lua", asset_images_lua),
 	ASSET_ENTRY("pops_profiles.lua", asset_pops_profiles_lua),
+	ASSET_ENTRY("usbd.irx.usbexfat", asset_usbd_irx_usbexfat),
+	ASSET_ENTRY("usbhdfsd.irx.usbexfat", asset_usbhdfsd_irx_usbexfat),
+	ASSET_ENTRY("usbd.irx.mx4sio", asset_usbd_irx_mx4sio),
+	ASSET_ENTRY("usbhdfsd.irx.mx4sio", asset_usbhdfsd_irx_mx4sio),
+	ASSET_ENTRY("usbd.irx.mmce", asset_usbd_irx_mmce),
+	ASSET_ENTRY("usbhdfsd.irx.mmce", asset_usbhdfsd_irx_mmce),
+	ASSET_ENTRY("icon.sys.mx4sio", asset_icon_sys_mx4sio),
+	ASSET_ENTRY("list.icn.mx4sio", asset_list_icn_mx4sio),
+	ASSET_ENTRY("del.icn.mx4sio", asset_del_icn_mx4sio),
+	ASSET_ENTRY("icon.sys.mmce", asset_icon_sys_mmce),
+	ASSET_ENTRY("list.icn.mmce", asset_list_icn_mmce),
+	ASSET_ENTRY("del.icn.mmce", asset_del_icn_mmce),
+	ASSET_ENTRY("icon.sys.usbexfat", asset_icon_sys_usbexfat),
+	ASSET_ENTRY("list.icn.usbexfat", asset_list_icn_usbexfat),
+	ASSET_ENTRY("del.icn.usbexfat", asset_del_icn_usbexfat),
+
 
 	ASSET_ENTRY("POPSLDR/IMG/USB.png", asset_usb_png),
 	ASSET_ENTRY("POPSLDR/IMG/SMB.png", asset_smb_png),
@@ -117,7 +163,22 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("POPSLDR/system.lua", asset_system_lua),
 	ASSET_ENTRY("POPSLDR/ui.lua", asset_ui_lua),
 	ASSET_ENTRY("POPSLDR/images.lua", asset_images_lua),
-	ASSET_ENTRY("POPSLDR/pops_profiles.lua", asset_pops_profiles_lua)
+	ASSET_ENTRY("POPSLDR/pops_profiles.lua", asset_pops_profiles_lua),
+	ASSET_ENTRY("POPSLDR/usbd.irx.usbexfat", asset_usbd_irx_usbexfat),
+	ASSET_ENTRY("POPSLDR/usbhdfsd.irx.usbexfat", asset_usbhdfsd_irx_usbexfat),
+	ASSET_ENTRY("POPSLDR/usbd.irx.mx4sio", asset_usbd_irx_mx4sio),
+	ASSET_ENTRY("POPSLDR/usbhdfsd.irx.mx4sio", asset_usbhdfsd_irx_mx4sio),
+	ASSET_ENTRY("POPSLDR/usbd.irx.mmce", asset_usbd_irx_mmce),
+	ASSET_ENTRY("POPSLDR/usbhdfsd.irx.mmce", asset_usbhdfsd_irx_mmce),
+	ASSET_ENTRY("POPSLDR/icon.sys.mx4sio", asset_icon_sys_mx4sio),
+	ASSET_ENTRY("POPSLDR/list.icn.mx4sio", asset_list_icn_mx4sio),
+	ASSET_ENTRY("POPSLDR/del.icn.mx4sio", asset_del_icn_mx4sio),
+	ASSET_ENTRY("POPSLDR/icon.sys.mmce", asset_icon_sys_mmce),
+	ASSET_ENTRY("POPSLDR/list.icn.mmce", asset_list_icn_mmce),
+	ASSET_ENTRY("POPSLDR/del.icn.mmce", asset_del_icn_mmce),
+	ASSET_ENTRY("POPSLDR/icon.sys.usbexfat", asset_icon_sys_usbexfat),
+	ASSET_ENTRY("POPSLDR/list.icn.usbexfat", asset_list_icn_usbexfat),
+	ASSET_ENTRY("POPSLDR/del.icn.usbexfat", asset_del_icn_usbexfat)
 };
 
 static const embedded_asset_t *embedded_find(const char *key)


### PR DESCRIPTION
### Motivation
- Prevent UI freeze when entering the MX4SIO page by removing mass-backend enumeration from the fast UI path and using a deterministic probe API. 
- Allow BDMA Apply to succeed when the loader ELF is on USB (`mass:/`) by providing embedded BDMA payloads as a deterministic fallback instead of relying on external sidecar files.

### Description
- Rewrote `PLDR.InitMX4SIOPopsRoot()` to call `System.initMX4SIO(hint)` with bounded hints (`"mx4sio0:/"`, `"mx4sio:/"`) and check for `POPS/` directly, removing sleeps and `RefreshMassStateSnapshot()` usage so entry is fast and deterministic. 
- Updated `PLDR.ApplyBdmaMode()` to preserve external filesystem copy behaviour but fall back to `System.getEmbeddedAsset(rel)` when external BDMA source files are missing and write the payload using the existing `WriteAtomic()` helper. 
- Added `BIN2S` Makefile rules to embed BDMA payload files (IRX + icon/list/del variants for `USBEXFAT`, `MX4SIO`, `MMCE`) into the EE binary. 
- Registered all new embedded BDMA assets in `src/embed_assets.cpp` with exact bare keys (e.g. `usbd.irx.usbexfat`, `icon.sys.mx4sio`) and `POPSLDR/` aliases so Lua can request them by the same names it would use on disk.

### Testing
- Ran automated presence checks for the BDMA source files in `bin/POPSLDR/` and they were present (all listed BDMA payload files reported `OK`).
- Verified diffs and commit via `git show --stat --oneline HEAD` and `git show -- bin/POPSLDR/system.lua src/embed_assets.cpp Makefile` which displayed the expected changes. 
- Attempted `make -n all` to validate embedding rules and build flow; this invocation failed in the current environment due to missing PS2SDK/sample include (`/samples/Makefile.eeglobal`) and therefore a full build could not be executed here. 
- Committed changes (`Fix MX4SIO init freeze and embed BDMA payload assets`) after validation of source edits and asset registrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2997305d08321af6258f9e5cd14b9)