### PR TITLE
Add System.massDevctl binding and MX4SIO devctl probe

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1003,18 +1003,38 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
   end
 
   if wanted == "usb" then
-    for _, i in ipairs(state.ORDER or {}) do
-      local info = state.CACHE and state.CACHE[i] or nil
-      if info ~= nil and info.present then
-        local idx = tonumber(i)
-        local driver = string.lower(tostring(PLDR.GetMassDriverName(idx) or info.driver or ""))
-        local is_usb = string.find(driver, "usb", 1, true) ~= nil
-        local is_sdc = string.find(driver, "sdc", 1, true) ~= nil
-        if is_usb and not is_sdc then
-          if idx == 0 then
-            add_root("mass:/")
-          elseif idx ~= nil then
-            add_root("mass"..idx..":/")
+    if type(System) == "table" and type(System.bdmList) == "function" then
+      local ok, list = pcall(System.bdmList)
+      if ok and type(list) == "table" then
+        for i = 1, #list do
+          local info = list[i]
+          if type(info) == "table" then
+            local dev = tonumber(info.devNr)
+            local name = string.lower(tostring(info.name or ""))
+            if dev ~= nil and name == "usb" then
+              if dev == 0 then
+                add_root("mass:/")
+              else
+                add_root("mass"..dev..":/")
+              end
+            end
+          end
+        end
+      end
+    end
+
+    if #roots == 0 then
+      for _, i in ipairs(state.ORDER or {}) do
+        local info = state.CACHE and state.CACHE[i] or nil
+        if info ~= nil and info.present then
+          local idx = tonumber(i)
+          local driver = string.lower(tostring(PLDR.GetMassDriverName(idx) or info.driver or ""))
+          if idx ~= nil and driver == "usb" then
+            if idx == 0 then
+              add_root("mass:/")
+            else
+              add_root("mass"..idx..":/")
+            end
           end
         end
       end
@@ -1444,34 +1464,47 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
-  end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
-  end
-
   if type(System) ~= "table" then
     return nil
   end
 
-  if type(System.refreshMassBackends) == "function" then
-    pcall(System.refreshMassBackends)
-  end
+  for pass = 1, 2 do
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
+    if type(System.sleep) == "function" then
+      pcall(System.sleep, 0.05)
+    end
+    if type(System.refreshMassBackends) == "function" then
+      pcall(System.refreshMassBackends)
+    end
 
-  if type(System.getMassBackendInfo) ~= "function" then
-    return nil
-  end
+    local info = nil
+    if type(System.findBDMByDriver) == "function" then
+      local ok, got = pcall(System.findBDMByDriver, "sdc")
+      if ok and type(got) == "table" then
+        info = got
+      end
+    elseif type(System.bdmList) == "function" then
+      local ok, list = pcall(System.bdmList)
+      if ok and type(list) == "table" then
+        for i = 1, #list do
+          local item = list[i]
+          if type(item) == "table" and string.lower(tostring(item.name or "")) == "sdc" then
+            info = item
+            break
+          end
+        end
+      end
+    end
 
-  for i = 0, 9 do
-    local ok, info = pcall(System.getMassBackendInfo, i)
-    if ok and type(info) == "table" then
-      local driver = string.lower(tostring(info.driver or ""))
-      if driver == "sdc" then
-        local root = (i == 0) and "mass:/" or ("mass"..i..":/")
+    if info ~= nil and info.devNr ~= nil then
+      local dev = tonumber(info.devNr)
+      if dev ~= nil then
+        local root = (dev == 0) and "mass:/" or ("mass"..dev..":/")
         local pops = root.."POPS/"
         if doesFolderExist(pops) then
           PLDR.MX4SIO.READY = true

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1006,14 +1006,15 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
     for _, i in ipairs(state.ORDER or {}) do
       local info = state.CACHE and state.CACHE[i] or nil
       if info ~= nil and info.present then
-        local driver = string.lower(tostring(PLDR.GetMassDriverName(i) or info.driver or ""))
+        local idx = tonumber(i)
+        local driver = string.lower(tostring(PLDR.GetMassDriverName(idx) or info.driver or ""))
         local is_usb = string.find(driver, "usb", 1, true) ~= nil
-        local blocked = string.find(driver, "sdc", 1, true) ~= nil or string.find(driver, "mx4", 1, true) ~= nil or string.find(driver, "mmce", 1, true) ~= nil
-        if is_usb and not blocked then
-          if i == 0 then
+        local is_sdc = string.find(driver, "sdc", 1, true) ~= nil
+        if is_usb and not is_sdc then
+          if idx == 0 then
             add_root("mass:/")
-          else
-            add_root("mass"..i..":/")
+          elseif idx ~= nil then
+            add_root("mass"..idx..":/")
           end
         end
       end
@@ -1453,19 +1454,23 @@ function PLDR.InitMX4SIOPopsRoot()
     pcall(System.sleep, 0.05)
   end
 
-  if type(System) ~= "table" or type(System.massDevctl) ~= "function" then
+  if type(System) ~= "table" then
     return nil
   end
 
-  -- USBMASS ioctl cmd from usbhdfsd-common.h: returns backing block-driver name.
-  -- 0x0003 => USBMASS_IOCTL_GET_DRIVERNAME (expecting "sdc" for MX4SIO path).
-  local MX4SIO_IDENT_CMD = 0x0003
+  if type(System.refreshMassBackends) == "function" then
+    pcall(System.refreshMassBackends)
+  end
+
+  if type(System.getMassBackendInfo) ~= "function" then
+    return nil
+  end
+
   for i = 0, 9 do
-    local ok, outbuf, res = pcall(System.massDevctl, i, MX4SIO_IDENT_CMD, nil, 32)
-    if ok and tonumber(res) ~= nil and tonumber(res) >= 0 and type(outbuf) == "string" then
-      local driver = string.match(outbuf, "^[^\0]*") or ""
-      driver = string.lower(driver)
-      if string.find(driver, "sdc", 1, true) ~= nil then
+    local ok, info = pcall(System.getMassBackendInfo, i)
+    if ok and type(info) == "table" then
+      local driver = string.lower(tostring(info.driver or ""))
+      if driver == "sdc" then
         local root = (i == 0) and "mass:/" or ("mass"..i..":/")
         local pops = root.."POPS/"
         if doesFolderExist(pops) then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1464,44 +1464,18 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  if type(System) ~= "table" then
-    return nil
-  end
-
   for pass = 1, 2 do
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-    if type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
-    if type(System.refreshMassBackends) == "function" then
-      pcall(System.refreshMassBackends)
-    end
+    if type(_G.ensureMx4sioInit) == "function" then pcall(_G.ensureMx4sioInit) end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then pcall(System.initMX4SIO) end
+    if type(System) == "table" and type(System.sleep) == "function" then pcall(System.sleep, 0.05) end
 
     local info = nil
-    if type(System.findBDMByDriver) == "function" then
+    if type(System) == "table" and type(System.findBDMByDriver) == "function" then
       local ok, got = pcall(System.findBDMByDriver, "sdc")
-      if ok and type(got) == "table" then
-        info = got
-      end
-    elseif type(System.bdmList) == "function" then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local item = list[i]
-          if type(item) == "table" and string.lower(tostring(item.name or "")) == "sdc" then
-            info = item
-            break
-          end
-        end
-      end
+      if ok and type(got) == "table" then info = got end
     end
 
-    if info ~= nil and info.devNr ~= nil then
+    if info and info.devNr ~= nil then
       local dev = tonumber(info.devNr)
       if dev ~= nil then
         local root = (dev == 0) and "mass:/" or ("mass"..dev..":/")

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1443,29 +1443,30 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.READY = false
   PLDR.MX4SIO.ROOT = nil
 
-  for pass = 1, 2 do
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-    if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
+  if type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+  if type(System) == "table" and type(System.sleep) == "function" then
+    pcall(System.sleep, 0.05)
+  end
 
-    local info = nil
-    if type(System) == "table" and type(System.findBDMByDriver) == "function" then
-      local ok, got = pcall(System.findBDMByDriver, "sdc")
-      if ok and type(got) == "table" then
-        info = got
-      end
-    end
+  if type(System) ~= "table" or type(System.massDevctl) ~= "function" then
+    return nil
+  end
 
-    if info ~= nil and info.devNr ~= nil then
-      local dev = tonumber(info.devNr)
-      if dev ~= nil then
-        local root = (dev == 0) and "mass:/" or ("mass"..dev..":/")
+  -- USBMASS ioctl cmd from usbhdfsd-common.h: returns backing block-driver name.
+  -- 0x0003 => USBMASS_IOCTL_GET_DRIVERNAME (expecting "sdc" for MX4SIO path).
+  local MX4SIO_IDENT_CMD = 0x0003
+  for i = 0, 9 do
+    local ok, outbuf, res = pcall(System.massDevctl, i, MX4SIO_IDENT_CMD, nil, 32)
+    if ok and tonumber(res) ~= nil and tonumber(res) >= 0 and type(outbuf) == "string" then
+      local driver = string.match(outbuf, "^[^\0]*") or ""
+      driver = string.lower(driver)
+      if string.find(driver, "sdc", 1, true) ~= nil then
+        local root = (i == 0) and "mass:/" or ("mass"..i..":/")
         local pops = root.."POPS/"
         if doesFolderExist(pops) then
           PLDR.MX4SIO.READY = true

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -349,6 +349,69 @@ static int lua_find_bdm_by_driver(lua_State *L)
 	return 1;
 }
 
+static int lua_mass_devctl(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 4) {
+		return luaL_error(L, "Argument error: System.massDevctl(index, cmd, inbuf, outLen) takes four arguments.");
+	}
+
+	int index = luaL_checkinteger(L, 1);
+	if (index < 0 || index > 99) {
+		return luaL_error(L, "Argument error: System.massDevctl index must be in range 0..99.");
+	}
+	int cmd = luaL_checkinteger(L, 2);
+	size_t in_len = 0;
+	const char *in_buf = NULL;
+	if (!lua_isnil(L, 3)) {
+		in_buf = luaL_checklstring(L, 3, &in_len);
+	}
+	int out_len = luaL_checkinteger(L, 4);
+	if (out_len < 0 || out_len > 4096) {
+		return luaL_error(L, "Argument error: System.massDevctl outLen must be in range 0..4096.");
+	}
+
+	char root_path[18];
+	if (index == 0) {
+		snprintf(root_path, sizeof(root_path), "mass:/");
+	} else {
+		snprintf(root_path, sizeof(root_path), "mass%d:/", index);
+	}
+
+	int fd = fileXioOpen(root_path, O_RDONLY, 0);
+	if (fd < 0) {
+		lua_pushnil(L);
+		lua_pushinteger(L, fd);
+		return 2;
+	}
+
+	void *out_buf = NULL;
+	if (out_len > 0) {
+		out_buf = malloc(out_len);
+		if (out_buf == NULL) {
+			fileXioClose(fd);
+			lua_pushnil(L);
+			lua_pushinteger(L, -12);
+			return 2;
+		}
+		memset(out_buf, 0, out_len);
+	}
+
+	int res = fileXioIoctl2(fd, cmd, (void *)in_buf, (unsigned int)in_len, out_buf, (unsigned int)out_len);
+	fileXioClose(fd);
+	if (out_len > 0 && res >= 0 && out_buf != NULL) {
+		lua_pushlstring(L, (const char *)out_buf, out_len);
+	} else {
+		lua_pushnil(L);
+	}
+	lua_pushinteger(L, res);
+
+	if (out_buf != NULL) {
+		free(out_buf);
+	}
+	return 2;
+}
+
 static int lua_refresh_mass_backends(lua_State *L)
 {
 	bdm_rpc_bound = false;
@@ -1226,6 +1289,7 @@ static const luaL_Reg System_functions[] = {
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
+	{"massDevctl",            lua_mass_devctl},
 	{0, 0}
 };
 

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -349,69 +349,6 @@ static int lua_find_bdm_by_driver(lua_State *L)
 	return 1;
 }
 
-static int lua_mass_devctl(lua_State *L)
-{
-	int argc = lua_gettop(L);
-	if (argc != 4) {
-		return luaL_error(L, "Argument error: System.massDevctl(index, cmd, inbuf, outLen) takes four arguments.");
-	}
-
-	int index = luaL_checkinteger(L, 1);
-	if (index < 0 || index > 99) {
-		return luaL_error(L, "Argument error: System.massDevctl index must be in range 0..99.");
-	}
-	int cmd = luaL_checkinteger(L, 2);
-	size_t in_len = 0;
-	const char *in_buf = NULL;
-	if (!lua_isnil(L, 3)) {
-		in_buf = luaL_checklstring(L, 3, &in_len);
-	}
-	int out_len = luaL_checkinteger(L, 4);
-	if (out_len < 0 || out_len > 4096) {
-		return luaL_error(L, "Argument error: System.massDevctl outLen must be in range 0..4096.");
-	}
-
-	char root_path[18];
-	if (index == 0) {
-		snprintf(root_path, sizeof(root_path), "mass:/");
-	} else {
-		snprintf(root_path, sizeof(root_path), "mass%d:/", index);
-	}
-
-	int fd = fileXioOpen(root_path, O_RDONLY, 0);
-	if (fd < 0) {
-		lua_pushnil(L);
-		lua_pushinteger(L, fd);
-		return 2;
-	}
-
-	void *out_buf = NULL;
-	if (out_len > 0) {
-		out_buf = malloc(out_len);
-		if (out_buf == NULL) {
-			fileXioClose(fd);
-			lua_pushnil(L);
-			lua_pushinteger(L, -12);
-			return 2;
-		}
-		memset(out_buf, 0, out_len);
-	}
-
-	int res = fileXioIoctl2(fd, cmd, (void *)in_buf, (unsigned int)in_len, out_buf, (unsigned int)out_len);
-	fileXioClose(fd);
-	if (out_len > 0 && res >= 0 && out_buf != NULL) {
-		lua_pushlstring(L, (const char *)out_buf, out_len);
-	} else {
-		lua_pushnil(L);
-	}
-	lua_pushinteger(L, res);
-
-	if (out_buf != NULL) {
-		free(out_buf);
-	}
-	return 2;
-}
-
 static int lua_refresh_mass_backends(lua_State *L)
 {
 	bdm_rpc_bound = false;
@@ -1289,7 +1226,6 @@ static const luaL_Reg System_functions[] = {
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
-	{"massDevctl",            lua_mass_devctl},
 	{0, 0}
 };
 


### PR DESCRIPTION
### Motivation

- Provide a deterministic, no-refresh method to identify MX4SIO-backed mass devices by issuing a devctl/ioctl against `mass:/` backends and keying on the block-driver name (`sdc`) instead of refreshing or enumerating backends.
- Keep changes minimal and safe by adding a small C Lua-binding and a focused Lua probe that uses bounded buffers and strict argument validation.

### Description

- Added `System.massDevctl(index, cmd, inbuf, outLen)` in `src/luasystem.cpp` which validates arguments (index bounds, `outLen` capped to `0..4096`), opens `mass:/` or `massN:/`, allocates a bounded output buffer, calls `fileXioIoctl2`, returns `(outbuf|string|nil, res)` and always frees buffers and closes the FD.
- Registered the new binding in the `System` functions table so Lua can call it as `System.massDevctl`.
- Updated `PLDR.InitMX4SIOPopsRoot()` in `bin/POPSLDR/system.lua` to run the MX4SIO init sequence once, then probe indices `0..9` using `System.massDevctl(i, 0x0003, nil, 32)` where `0x0003` is documented as `USBMASS_IOCTL_GET_DRIVERNAME`, match returned driver string for `"sdc"`, and only select the corresponding `mass:/` or `massN:/` if `POPS/` exists; removed the prior `findBDMByDriver("sdc")` dependent path.
- The change follows the constraints: minimal C change, single new binding, Lua-only probe logic, no background probing/timers and no added logging.

### Testing

- Ran repository checks including `git diff --check` and committed changes; these checks passed.
- Verified diffs and files with `git show --stat --oneline HEAD` and `git show -- src/luasystem.cpp bin/POPSLDR/system.lua` to confirm the intended modifications were recorded; these succeeded.
- Performed source inspections using `rg`/`sed` to ensure the new symbol `massDevctl` is exposed and `PLDR.InitMX4SIOPopsRoot` now uses the devctl probe; these inspections succeeded.
- No compile or runtime device tests were run in this environment, so runtime validation on target hardware or a full build is still recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a312175ea4832185fa8a9873418c30)