### PR TITLE
Ensure FAT32 BDMA always removes legacy IRX files

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1147,6 +1147,24 @@ local function WriteBdmaModeMarker(mode_key)
   return WriteAtomic(BDMA_MODE_MARKER_PATH, tostring(mode_key or ""))
 end
 
+local function DeleteIfExists(path)
+  local exists = false
+  local ok_exists, file_exists = pcall(doesFileExist, path)
+  if ok_exists and file_exists == true then
+    exists = true
+  end
+  if not exists then
+    local ok_open, fd = pcall(System.openFile, path, FREAD)
+    if ok_open and type(fd) == "number" and fd >= 0 then
+      exists = true
+      pcall(System.closeFile, fd)
+    end
+  end
+  if exists then
+    pcall(System.removeFile, path)
+  end
+end
+
 function PLDR.NextBdmaApplyToken()
   PLDR._bdma_apply_seq = (tonumber(PLDR._bdma_apply_seq) or 0) + 1
   return "bdma:"..tostring(PLDR._bdma_apply_seq)
@@ -1185,14 +1203,15 @@ function PLDR.ApplyBdmaMode(mode_key)
     return false
   end
 
-  local last_applied = ReadBdmaModeMarker()
-  if last_applied == selected then
+  if selected == "FAT32" then
+    DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbd.irx")
+    DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbhdfsd.irx")
+    WriteBdmaModeMarker(selected)
     return true
   end
-  if selected == "FAT32" then
-    pcall(System.removeFile, POPSTARTER_PACK_ROOT.."/usbd.irx")
-    pcall(System.removeFile, POPSTARTER_PACK_ROOT.."/usbhdfsd.irx")
-    WriteBdmaModeMarker(selected)
+
+  local last_applied = ReadBdmaModeMarker()
+  if last_applied == selected then
     return true
   end
 


### PR DESCRIPTION
### Motivation
- Ensure that selecting BDMA mode `FAT32` always removes legacy BDMA IRX files from the memory card to prevent stale IRXs from being used.
- Make the deletion deterministic and non-fatal so applying/saving BDMA settings never crashes or hangs if the files or device are missing.
- Keep the change minimal and localized to the BDMA apply/save logic without affecting MX4SIO/USB isolation flows.

### Description
- Add a local helper `DeleteIfExists(path)` in `bin/POPSLDR/system.lua` that safely probes `doesFileExist` with a `System.openFile` fallback and calls `System.removeFile` under `pcall` so failures are non-fatal.
- Modify `PLDR.ApplyBdmaMode` to perform the `FAT32` branch before the marker short-circuit so it always attempts deterministic cleanup, calling `DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbd.irx")` and `DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbhdfsd.irx")` on every apply/save and then writing the BDMA mode marker.
- Preserve existing behavior for non-`FAT32` BDMA modes and keep all file operations guarded with `pcall` to avoid crashes.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it completed successfully.
- Ran `git show --stat --oneline HEAD` to confirm the change is present and the check completed successfully.
- Ran `git show -- bin/POPSLDR/system.lua` to inspect the updated file and confirm the helper and FAT32 branch reorder were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3683be3a8832195348d13152c5689)