### PR TITLE
Use BDM backend enumeration for MX4SIO detection

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -227,10 +227,6 @@ static bool ProbeDir(const char *path, int *out_ret)
 	return false;
 }
 
-#ifndef USBMASS_IOCTL_GET_DRIVERNAME
-#define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
-#endif
-
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz)
 {
 	if (index == 0) {
@@ -240,64 +236,35 @@ static void BuildMassRootPath(int index, char *out_root, size_t out_sz)
 	}
 }
 
-static void DecodeDriverCodePair(int rc, char *out_code, size_t out_code_sz, char *out_rev, size_t out_rev_sz)
+static bool IsMx4sioBackendName(const char *name)
 {
-	unsigned char b[4];
-	b[0] = (unsigned char)(rc & 0xFF);
-	b[1] = (unsigned char)((rc >> 8) & 0xFF);
-	b[2] = (unsigned char)((rc >> 16) & 0xFF);
-	b[3] = (unsigned char)((rc >> 24) & 0xFF);
-
-	size_t n = 0;
-	for (size_t i = 0; i < 4 && n + 1 < out_code_sz; ++i) {
-		char c = (char)b[i];
-		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-			if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-			out_code[n++] = c;
-		}
-	}
-	out_code[n] = '\0';
-
-	n = 0;
-	for (size_t i = 0; i < 4 && n + 1 < out_rev_sz; ++i) {
-		char c = (char)b[3 - i];
-		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-			if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-			out_rev[n++] = c;
-		}
-	}
-	out_rev[n] = '\0';
-}
-
-static bool QueryMassDriverCode(int index, char *out_code, size_t out_code_sz, char *out_rev, size_t out_rev_sz)
-{
-	if (out_code == NULL || out_code_sz == 0 || out_rev == NULL || out_rev_sz == 0) {
+	if (name == NULL || name[0] == '\0') {
 		return false;
 	}
-	char root[16];
-	BuildMassRootPath(index, root, sizeof(root));
-	int dd = fileXioDopen(root);
-	if (dd < 0) {
-		out_code[0] = '\0';
-		out_rev[0] = '\0';
-		return false;
-	}
-	int rc = fileXioIoctl(dd, USBMASS_IOCTL_GET_DRIVERNAME, (void*)"");
-	fileXioDclose(dd);
-	DecodeDriverCodePair(rc, out_code, out_code_sz, out_rev, out_rev_sz);
-	return out_code[0] != '\0' || out_rev[0] != '\0';
-}
-
-static bool IsDriverCodeMatch(const char *code, const char *rev, const char *want)
-{
-	if (want == NULL || want[0] == '\0') {
-		return false;
-	}
-	if (code != NULL && strcmp(code, want) == 0) {
+	if (strcmp(name, "sdc") == 0) {
 		return true;
 	}
-	if (rev != NULL && strcmp(rev, want) == 0) {
-		return true;
+	return strstr(name, "sdc") != NULL || strstr(name, "mx4sio") != NULL;
+}
+
+static bool FindMx4sioDevNr(int *out_devnr)
+{
+	if (out_devnr == NULL) {
+		return false;
+	}
+	for (int attempt = 0; attempt < 2; ++attempt) {
+		bool cache_ok = (attempt == 0) ? EnsureMassBackendCache() : RefreshMassBackendCache();
+		if (!cache_ok) {
+			continue;
+		}
+		for (u32 i = 0; i < mass_backend_cache.count; ++i) {
+			const bdm_dev_info_t *info = &mass_backend_cache.devs[i];
+			if (!IsMx4sioBackendName(info->name)) {
+				continue;
+			}
+			*out_devnr = (int)info->devNr;
+			return true;
+		}
 	}
 	return false;
 }
@@ -331,19 +298,12 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 		mx4sio_irx_loaded = true;
 	}
 
-	for (int i = 0; i <= 9; ++i) {
-		char code[5];
-		char rev[5];
-		if (!QueryMassDriverCode(i, code, sizeof(code), rev, sizeof(rev))) {
-			continue;
-		}
-		if (!IsDriverCodeMatch(code, rev, "sdc")) {
-			continue;
-		}
+	int mx4sio_devnr = -1;
+	if (FindMx4sioDevNr(&mx4sio_devnr)) {
 		saw_sdc_driver = true;
 		char root[16];
 		char pops_path[32];
-		BuildMassRootPath(i, root, sizeof(root));
+		BuildMassRootPath(mx4sio_devnr, root, sizeof(root));
 		snprintf(pops_path, sizeof(pops_path), "%sPOPS/", root);
 		int pops_ret = -1;
 		if (ProbeDir(pops_path, &pops_ret)) {
@@ -381,23 +341,21 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 	}
 
 	if (!saw_sdc_driver) {
-		for (int i = 0; i <= 9; ++i) {
-			char code[5];
-			char rev[5];
-			if (!QueryMassDriverCode(i, code, sizeof(code), rev, sizeof(rev))) {
-				continue;
-			}
-			if (IsDriverCodeMatch(code, rev, "usb")) {
-				continue;
-			}
-			char root[16];
-			char pops_path[32];
-			BuildMassRootPath(i, root, sizeof(root));
-			snprintf(pops_path, sizeof(pops_path), "%sPOPS/", root);
-			int pops_ret = -1;
-			if (ProbeDir(pops_path, &pops_ret)) {
-				snprintf(out_root, out_sz, "%s", root);
-				return MX4SIO_INIT_OK;
+		if (EnsureMassBackendCache()) {
+			for (u32 i = 0; i < mass_backend_cache.count; ++i) {
+				const bdm_dev_info_t *info = &mass_backend_cache.devs[i];
+				if (info->name[0] == '\0' || strstr(info->name, "usb") != NULL) {
+					continue;
+				}
+				char root[16];
+				char pops_path[32];
+				BuildMassRootPath((int)info->devNr, root, sizeof(root));
+				snprintf(pops_path, sizeof(pops_path), "%sPOPS/", root);
+				int pops_ret = -1;
+				if (ProbeDir(pops_path, &pops_ret)) {
+					snprintf(out_root, out_sz, "%s", root);
+					return MX4SIO_INIT_OK;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation
- MX4SIO detection currently relied on a USB-mass ioctl probe which is invalid for BDM backends and caused real hardware MX4SIO devices to be missed.

### Description
- Replace the USB-mass ioctl driven scan in `mx4sio_init_and_get_root()` with enumeration of the existing BDM backend cache (`mass_backend_cache`) so BDM backends (e.g. MX4SIO) are detected correctly.
- Add `IsMx4sioBackendName()` to match MX4SIO backends (strict `"sdc"` plus safe substring fallbacks) and `FindMx4sioDevNr()` which calls `EnsureMassBackendCache()` and allows exactly one `RefreshMassBackendCache()` retry.
- Map the discovered `devNr` to the mass root using `BuildMassRootPath()` and probe only the single path `"<root>POPS/"` instead of broad ioctl-based driver name probing.
- Preserve existing hint and `mx4sio:/`/`mx4sio0:/` fallbacks and keep original return codes, while removing the obsolete USB ioctl helper functions.

### Testing
- Ran automated repository checks (pattern search and file diff) to confirm the USB-ioctl helpers were removed and the new helpers and call sites were added; these checks succeeded.
- Performed source review of `mx4sio_init_and_get_root()` to verify that detection now uses `EnsureMassBackendCache()`/`RefreshMassBackendCache()` with a bounded retry and probes only `"<root>POPS/"` for the discovered backend; review passed.
- No unit tests exist for this hardware-specific path; runtime validation on actual MX4SIO hardware was recommended to confirm the change meets acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36e6d03788321bca4c7aa51eeb81e)