### PR TITLE
Implement strict slot-based MX4SIO / USB mass-slot mapping

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1012,7 +1012,7 @@ function PLDR.RefreshMassBackends()
       new_cache[slot] = {
         present = true,
         driver = info.name,
-        kind = (info.name == "sdc") and "mx4sio" or "usb"
+        kind = (info.name == "sdc") and "mx4sio" or ((string.find(info.name, "usb", 1, true) ~= nil) and "usb" or "other")
       }
       table.insert(new_order, slot)
     end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -976,8 +976,9 @@ function PLDR.GetUsbRootsFromSlots(slots)
   slots = slots or PLDR.GetMassSlots()
   for slot = 0, 9 do
     local item = slots[slot]
-    if item ~= nil and item.present == true and item.name ~= "sdc" then
-      table.insert(roots, item.root)
+    local name = string.lower(tostring(item and item.name or ""))
+    if item ~= nil and item.present == true and name ~= "sdc" then
+      table.insert(roots, GetMassRootFromSlot(slot))
     end
   end
   return roots
@@ -987,8 +988,9 @@ function PLDR.GetMx4RootFromSlots(slots)
   slots = slots or PLDR.GetMassSlots()
   for slot = 0, 9 do
     local item = slots[slot]
-    if item ~= nil and item.present == true and item.name == "sdc" then
-      return item.root
+    local name = string.lower(tostring(item and item.name or ""))
+    if item ~= nil and item.present == true and name == "sdc" then
+      return GetMassRootFromSlot(slot)
     end
   end
   return nil

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -882,7 +882,7 @@ end
 function PLDR.NormalizeDriverCode(driver)
   if type(driver) ~= "string" then return nil end
   local d = string.lower(driver)
-  if string.find(d, "sdc", 1, true) ~= nil then
+  if d == "sdc" then
     return "sdc"
   end
   if string.find(d, "usb", 1, true) ~= nil then
@@ -894,21 +894,109 @@ function PLDR.NormalizeDriverCode(driver)
   return nil
 end
 
+local function GetMassRootFromSlot(slot)
+  if slot == 0 then
+    return "mass:/"
+  end
+  return "mass"..slot..":/"
+end
+
+function PLDR.GetMassSlots()
+  local slots = {}
+
+  local function should_replace(prev_name, new_name)
+    if prev_name == nil then
+      return true
+    end
+    if prev_name == "sdc" then
+      return false
+    end
+    if new_name == "sdc" then
+      return true
+    end
+    local prev_usb = string.find(prev_name, "usb", 1, true) ~= nil
+    local new_usb = string.find(new_name, "usb", 1, true) ~= nil
+    if new_usb and not prev_usb then
+      return true
+    end
+    return false
+  end
+
+  local function merge(slot, name)
+    if type(slot) ~= "number" then
+      return
+    end
+    if slot < 0 or slot > 9 then
+      return
+    end
+    if type(name) ~= "string" or name == "" then
+      return
+    end
+    local lowered = string.lower(name)
+    local existing = slots[slot]
+    if existing == nil then
+      slots[slot] = {
+        present = true,
+        name = lowered,
+        root = GetMassRootFromSlot(slot)
+      }
+      return
+    end
+    if should_replace(existing.name, lowered) then
+      existing.name = lowered
+    end
+  end
+
+  if type(System) == "table" and type(System.getMassBackends) == "function" then
+    local ok, list = pcall(System.getMassBackends)
+    if ok and type(list) == "table" then
+      for i = 1, #list do
+        local info = list[i]
+        if type(info) == "table" then
+          merge(tonumber(info.slot), info.name)
+        end
+      end
+    end
+  end
+
+  for slot = 0, 9 do
+    if slots[slot] == nil and type(System) == "table" and type(System.getMassBackendInfo) == "function" then
+      local ok, info = pcall(System.getMassBackendInfo, slot)
+      if ok and type(info) == "table" and info.present == true then
+        merge(slot, info.driver)
+      end
+    end
+  end
+
+  return slots
+end
+
+function PLDR.GetUsbRootsFromSlots(slots)
+  local roots = {}
+  slots = slots or PLDR.GetMassSlots()
+  for slot = 0, 9 do
+    local item = slots[slot]
+    if item ~= nil and item.present == true and item.name ~= "sdc" then
+      table.insert(roots, item.root)
+    end
+  end
+  return roots
+end
+
+function PLDR.GetMx4RootFromSlots(slots)
+  slots = slots or PLDR.GetMassSlots()
+  for slot = 0, 9 do
+    local item = slots[slot]
+    if item ~= nil and item.present == true and item.name == "sdc" then
+      return item.root
+    end
+  end
+  return nil
+end
+
 function PLDR.RefreshMassBackends()
   local new_cache = {}
   local new_order = {}
-  local seen_index = {}
-
-  local function classify_driver(driver)
-    local d = string.lower(tostring(driver or ""))
-    if string.find(d, "usb", 1, true) ~= nil then
-      return "usb"
-    end
-    if string.find(d, "sdc", 1, true) ~= nil then
-      return "mx4sio"
-    end
-    return "other"
-  end
 
   if type(System) == "table" and type(System.refreshMassBackends) == "function" then
     local ok, refreshed = pcall(System.refreshMassBackends)
@@ -917,53 +1005,19 @@ function PLDR.RefreshMassBackends()
     end
   end
 
-  local listed = false
-  if type(System) == "table" and type(System.bdmList) == "function" then
-    local ok, list = pcall(System.bdmList)
-    if ok and type(list) == "table" then
-      listed = true
-      for i = 1, #list do
-        local info = list[i]
-        if type(info) == "table" and type(info.devNr) == "number" then
-          local idx = tonumber(info.devNr)
-          local driver = string.lower(tostring(info.name or ""))
-          local kind = classify_driver(driver)
-          new_cache[idx] = {
-            present = true,
-            driver = driver,
-            kind = kind
-          }
-          if not seen_index[idx] then
-            table.insert(new_order, idx)
-            seen_index[idx] = true
-          end
-        end
-      end
+  local slots = PLDR.GetMassSlots()
+  for slot = 0, 9 do
+    local info = slots[slot]
+    if info ~= nil and info.present then
+      new_cache[slot] = {
+        present = true,
+        driver = info.name,
+        kind = (info.name == "sdc") and "mx4sio" or "usb"
+      }
+      table.insert(new_order, slot)
     end
   end
 
-  if not listed and type(System) == "table" and type(System.getMassBackendInfo) == "function" then
-    -- Compatibility fallback: bounded probe for older runtimes without bdmList details.
-    for i = 0, 9 do
-      local ok, info = pcall(System.getMassBackendInfo, i)
-      if ok and type(info) == "table" and info.present == true then
-        local idx = tonumber(info.index or i)
-        local driver = string.lower(tostring(info.driver or ""))
-        local kind = classify_driver(driver)
-        new_cache[idx] = {
-          present = true,
-          driver = driver,
-          kind = kind
-        }
-        if not seen_index[idx] then
-          table.insert(new_order, idx)
-          seen_index[idx] = true
-        end
-      end
-    end
-  end
-
-  table.sort(new_order)
   PLDR.MASS.CACHE = new_cache
   PLDR.MASS.ORDER = new_order
   PLDR.MASS.REFRESHED = true
@@ -1024,62 +1078,18 @@ function PLDR.RefreshMassStateSnapshot()
 end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
-  local seen = {}
-  local function add_root(root)
-    if root ~= nil and not seen[root] then
-      seen[root] = true
-      table.insert(roots, root)
-    end
-  end
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot
-  if state == nil then
-    if not PLDR.MASS.REFRESHED then
-      PLDR.RefreshMassBackends()
-    end
-    state = PLDR.MASS
-  end
-
+  local slots = mass_snapshot or PLDR.GetMassSlots()
   if wanted == "usb" then
-    local mx4_idx = PLDR.MX4SIO and PLDR.MX4SIO.MASSINDX or nil
-    local mx4_root = PLDR.MX4SIO and PLDR.MX4SIO.ROOT or nil
-    for i = 0, 4 do
-      local root = (i == 0) and "mass:/" or ("mass"..i..":/")
-      local is_mx4_idx = (mx4_idx ~= nil and i == mx4_idx)
-      local is_mx4_root = (mx4_root ~= nil and root == mx4_root)
-      if not is_mx4_idx and not is_mx4_root then
-        local name = PLDR.GetMassDriverName(i)
-        local norm, rev = PLDR.NormalizeDriverCode(name)
-        if norm == "usb" or rev == "usb" then
-          add_root(root)
-        else
-          local has_pops = false
-          if type(System) == "table" and type(System.doesDirExist) == "function" then
-            local ok, exists = pcall(System.doesDirExist, root.."POPS/")
-            has_pops = ok and exists == true
-          else
-            has_pops = doesFolderExist(root.."POPS/")
-          end
-          if has_pops then
-            add_root(root)
-          end
-        end
-      end
-    end
-  elseif wanted == "mx4sio" then
-    for _, i in ipairs(state.ORDER or {}) do
-      local info = state.CACHE and state.CACHE[i] or nil
-      if info ~= nil and info.present and info.kind == "mx4sio" then
-        if i == 0 then
-          add_root("mass:/")
-        else
-          add_root("mass"..i..":/")
-        end
-      end
+    return PLDR.GetUsbRootsFromSlots(slots)
+  end
+  if wanted == "mx4sio" then
+    local root = PLDR.GetMx4RootFromSlots(slots)
+    if root ~= nil then
+      return {root}
     end
   end
-  return roots
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()
@@ -1110,7 +1120,7 @@ function PLDR.EnsureBackendForAppDir()
     local idx = PLDR.ParseMassIndexFromPath(path)
     local driver = PLDR.GetMassDriverName(idx)
     if driver ~= nil then
-      if string.find(driver, "sdc", 1, true) ~= nil then
+      if driver == "sdc" then
         if type(_G.ensureMx4sioInit) == "function" then
           local ok = pcall(_G.ensureMx4sioInit)
           if ok then return true end
@@ -1513,36 +1523,21 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
 
-  for pass = 1, 2 do
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-    if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
+  if type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+  if type(System) == "table" and type(System.refreshMassBackends) == "function" then
+    pcall(System.refreshMassBackends)
+  end
 
-    local info = nil
-    if type(System) == "table" and type(System.findBDMByDriver) == "function" then
-      local ok, got = pcall(System.findBDMByDriver, "sdc")
-      if ok and type(got) == "table" then
-        info = got
-      end
-    end
-
-    if info ~= nil and info.devNr ~= nil then
-      local dev = tonumber(info.devNr)
-      if dev ~= nil then
-        local root = (dev == 0) and "mass:/" or ("mass"..dev..":/")
-        local pops = root.."POPS/"
-        if doesFolderExist(pops) then
-          PLDR.SetMX4SIORoot(root)
-          return pops
-        end
-      end
-    end
+  local slots = PLDR.GetMassSlots()
+  local root = PLDR.GetMx4RootFromSlots(slots)
+  if root ~= nil then
+    PLDR.SetMX4SIORoot(root)
+    return root.."POPS/"
   end
 
   return nil

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1735,7 +1735,13 @@ end
             end
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
-            local slots = PLDR.GetMassSlots()
+            local slots = nil
+            if type(PLDR.RefreshMassStateSnapshot) == "function" then
+              slots = PLDR.RefreshMassStateSnapshot()
+            elseif type(PLDR.RefreshMassBackends) == "function" then
+              pcall(PLDR.RefreshMassBackends)
+            end
+            slots = slots or PLDR.GetMassSlots()
             PLDR.BuildMassGameListByType("usb", slots)
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBFAT)

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1680,49 +1680,25 @@ end
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            local mx4sio_root = nil
-            local mx4sio_err = nil
+            local mx4_root = nil
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
             if type(System) == "table" and type(System.initMX4SIO) == "function" then
-              local ok, ready, root, err = pcall(System.initMX4SIO, "mx4sio0:/")
-              if ok and ready and root ~= nil then
-                mx4sio_root = root.."POPS/"
-              else
-                if ok then mx4sio_err = err end
-                ok, ready, root, err = pcall(System.initMX4SIO, "mx4sio:/")
-                if ok and ready and root ~= nil then
-                  mx4sio_root = root.."POPS/"
-                elseif ok then
-                  mx4sio_err = err
-                end
-              end
+              pcall(System.initMX4SIO)
             end
-            if mx4sio_root ~= nil and type(PLDR) == "table" then
-              local mx4_root = string.gsub(mx4sio_root, "POPS/$", "")
-              PLDR.MX4SIO = PLDR.MX4SIO or {}
-              PLDR.MX4SIO.ROOT = mx4_root
-              PLDR.MX4SIO.MASSINDX = nil
-              local mx4_idx = mx4_root:match("^mass(%d+):/")
-              if mx4_idx then
-                PLDR.MX4SIO.MASSINDX = tonumber(mx4_idx)
-              elseif mx4_root:match("^mass:/") then
-                PLDR.MX4SIO.MASSINDX = 0
-              end
-              if type(PLDR.SetMX4SIORoot) == "function" then
-                pcall(PLDR.SetMX4SIORoot, mx4_root)
-              end
+            if type(System) == "table" and type(System.refreshMassBackends) == "function" then
+              pcall(System.refreshMassBackends)
             end
-            if mx4sio_root == nil then
-              local suffix = ""
-              if mx4sio_err ~= nil and mx4sio_err ~= "" then
-                suffix = " ("..tostring(mx4sio_err)..")"
-              end
-              UI.Notif_queue.add("No MX4SIO device found (POPS/ missing)"..suffix)
+            local slots = PLDR.GetMassSlots()
+            mx4_root = PLDR.GetMx4RootFromSlots(slots)
+            if mx4_root ~= nil and type(PLDR.SetMX4SIORoot) == "function" then
+              pcall(PLDR.SetMX4SIORoot, mx4_root)
+            end
+            if mx4_root == nil then
+              UI.Notif_queue.add("No MX4SIO device found")
               return
             else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
+              PLDR.BuildMassGameListByType("mx4sio", slots)
               UI.setDeviceLock(DEVLOCK.MX4SIO)
               UI.SceneChange(UI.SCENES.GMX4SIO)
             end
@@ -1759,8 +1735,8 @@ end
             end
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
-            local snapshot = PLDR.RefreshMassStateSnapshot()
-            PLDR.BuildMassGameListByType("usb", snapshot)
+            local slots = PLDR.GetMassSlots()
+            PLDR.BuildMassGameListByType("usb", slots)
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBFAT)
           elseif UI.MainMenu.OPT == 6 then

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1735,13 +1735,10 @@ end
             end
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
-            local slots = nil
-            if type(PLDR.RefreshMassStateSnapshot) == "function" then
-              slots = PLDR.RefreshMassStateSnapshot()
-            elseif type(PLDR.RefreshMassBackends) == "function" then
+            if type(PLDR.RefreshMassBackends) == "function" then
               pcall(PLDR.RefreshMassBackends)
             end
-            slots = slots or PLDR.GetMassSlots()
+            local slots = PLDR.GetMassSlots()
             PLDR.BuildMassGameListByType("usb", slots)
             UI.setDeviceLock(DEVLOCK.USB)
             UI.SceneChange(UI.SCENES.GUSBFAT)

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -406,9 +406,12 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 }
 static void PushBdmInfo(lua_State *L, const bdm_dev_info_t *info)
 {
+	int slot = (int)info->parNr;
 	lua_newtable(L);
 	lua_pushstring(L, info->name);
 	lua_setfield(L, -2, "name");
+	lua_pushinteger(L, slot);
+	lua_setfield(L, -2, "slot");
 	lua_pushinteger(L, info->devNr);
 	lua_setfield(L, -2, "devNr");
 	lua_pushinteger(L, info->parNr);
@@ -428,13 +431,24 @@ static int lua_bdm_list(lua_State *L)
 		lua_pushnil(L);
 		return 1;
 	}
-	DPRINTF("BDM list count=%u\n", list.count);
 	lua_newtable(L);
 	for (u32 i = 0; i < list.count; ++i) {
 		const bdm_dev_info_t *info = &list.devs[i];
-		DPRINTF("BDM device %u name=%s devNr=%u parNr=%u parId=%u sectorSize=%u sectorCount=%llu\n",
-		        i, info->name, info->devNr, info->parNr, info->parId,
-		        info->sectorSize, (unsigned long long)info->sectorCount);
+		PushBdmInfo(L, info);
+		lua_rawseti(L, -2, i + 1);
+	}
+	return 1;
+}
+
+static int lua_get_mass_backends(lua_State *L)
+{
+	if (!EnsureMassBackendCache()) {
+		lua_pushnil(L);
+		return 1;
+	}
+	lua_newtable(L);
+	for (u32 i = 0; i < mass_backend_cache.count; ++i) {
+		const bdm_dev_info_t *info = &mass_backend_cache.devs[i];
 		PushBdmInfo(L, info);
 		lua_rawseti(L, -2, i + 1);
 	}
@@ -484,7 +498,7 @@ static int lua_get_mass_backend_info(lua_State *L)
 	}
 	for (u32 i = 0; i < mass_backend_cache.count; ++i) {
 		const bdm_dev_info_t *info = &mass_backend_cache.devs[i];
-		if ((int)info->devNr == index) {
+		if ((int)info->parNr == index) {
 			lua_newtable(L);
 			lua_pushboolean(L, 1);
 			lua_setfield(L, -2, "present");
@@ -492,8 +506,10 @@ static int lua_get_mass_backend_info(lua_State *L)
 			lua_setfield(L, -2, "driver");
 			lua_pushstring(L, ClassifyMassBackend(info->name));
 			lua_setfield(L, -2, "kind");
-			lua_pushinteger(L, info->devNr);
+			lua_pushinteger(L, info->parNr);
 			lua_setfield(L, -2, "index");
+			lua_pushinteger(L, info->parNr);
+			lua_setfield(L, -2, "slot");
 			return 1;
 		}
 	}
@@ -1345,6 +1361,7 @@ static const luaL_Reg System_functions[] = {
 	{"initMX4SIO",             lua_mx4sio_init},
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
+	{"getMassBackends",        lua_get_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}


### PR DESCRIPTION
### Motivation
- Enforce a simple invariant where MX4SIO is exactly the backend named "sdc" and USB is any other present mass slot, avoiding heuristics, POPS-folder fallbacks, substring collisions, and cross-page coupling.

### Description
- C++: expose canonical backend slot info to Lua by adding `slot` (from `parNr`) to BDM entries, adding `System.getMassBackends()` and changing `System.getMassBackendInfo(index)` to resolve/report by mount slot (`parNr`) instead of `devNr` (`src/luasystem.cpp`).
- Lua (PLDR): add `PLDR.GetMassSlots()` to build a canonical slot-> {present,name,root} map with deterministic conflict resolution (prefer exact `sdc`, else prefer `usb`, else first), and add `PLDR.GetUsbRootsFromSlots()` and `PLDR.GetMx4RootFromSlots()` helpers; update `PLDR.RefreshMassBackends()` to use the canonical slots and make `NormalizeDriverCode` check `sdc` exactly (`bin/POPSLDR/system.lua`).
- Lua (UI): change USB and MX4SIO page entry flows to follow the invariant: USB page initializes USB and lists games from all non-`sdc` mass slots; MX4SIO page initializes MX4SIO (and refreshes backends) then lists games only from the exact `sdc` slot (showing "No MX4SIO device found" when absent) (`bin/POPSLDR/ui.lua`).
- Kept changes minimal and local to the requested files; no debug prints/logging were added.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues and it passed.
- Created commit `e9f5446` and verified with `git show --stat --oneline HEAD` which succeeded.
- Inspected diffs with `git show -- src/luasystem.cpp bin/POPSLDR/system.lua bin/POPSLDR/ui.lua` to confirm the changes were applied; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a384965c108321850f1f16f53a3db1)