### PR TITLE
Deterministic MX4SIO identity via exact "sdc" backend mapping

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -988,9 +988,25 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") then
-    if type(System) == "table" and type(System.initUSB) == "function" then
-      local ok = pcall(System.initUSB)
-      if ok then return true end
+    local mx4_root_now = PLDR.GetMX4SIOMassRootNow()
+    local is_mx4_mass_path = false
+    if mx4_root_now ~= nil then
+      is_mx4_mass_path = string.sub(path, 1, string.len(mx4_root_now)) == mx4_root_now
+    end
+    if is_mx4_mass_path then
+      if type(_G.ensureMx4sioInit) == "function" then
+        local ok = pcall(_G.ensureMx4sioInit)
+        if ok then return true end
+      end
+      if type(System) == "table" and type(System.initMX4SIO) == "function" then
+        local ok = pcall(System.initMX4SIO)
+        if ok then return true end
+      end
+    else
+      if type(System) == "table" and type(System.initUSB) == "function" then
+        local ok = pcall(System.initUSB)
+        if ok then return true end
+      end
     end
     return true
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -879,94 +879,18 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
-function PLDR.NormalizeDriverCode(driver)
-  if type(driver) ~= "string" then return nil end
-  local d = string.lower(driver)
-  if string.find(d, "sdc", 1, true) ~= nil then
-    return "sdc"
+function PLDR.GetMX4SIOMassRootNow()
+  if type(System) ~= "table" or type(System.getMassRootByBackendName) ~= "function" then
+    return nil
   end
-  if string.find(d, "usb", 1, true) ~= nil then
-    return "usb"
-  end
-  if string.find(d, "mmce", 1, true) ~= nil then
-    return "mmce"
+  local ok, root = pcall(System.getMassRootByBackendName, "sdc")
+  if ok and type(root) == "string" and root ~= "" then
+    return root
   end
   return nil
 end
 
 function PLDR.RefreshMassBackends()
-  local new_cache = {}
-  local new_order = {}
-  local seen_index = {}
-
-  local function classify_driver(driver)
-    local d = string.lower(tostring(driver or ""))
-    if string.find(d, "usb", 1, true) ~= nil then
-      return "usb"
-    end
-    if string.find(d, "sdc", 1, true) ~= nil then
-      return "mx4sio"
-    end
-    return "other"
-  end
-
-  if type(System) == "table" and type(System.refreshMassBackends) == "function" then
-    local ok, refreshed = pcall(System.refreshMassBackends)
-    if not ok or not refreshed then
-      return false
-    end
-  end
-
-  local listed = false
-  if type(System) == "table" and type(System.bdmList) == "function" then
-    local ok, list = pcall(System.bdmList)
-    if ok and type(list) == "table" then
-      listed = true
-      for i = 1, #list do
-        local info = list[i]
-        if type(info) == "table" and type(info.devNr) == "number" then
-          local idx = tonumber(info.devNr)
-          local driver = string.lower(tostring(info.name or ""))
-          local kind = classify_driver(driver)
-          new_cache[idx] = {
-            present = true,
-            driver = driver,
-            kind = kind
-          }
-          if not seen_index[idx] then
-            table.insert(new_order, idx)
-            seen_index[idx] = true
-          end
-        end
-      end
-    end
-  end
-
-  if not listed and type(System) == "table" and type(System.getMassBackendInfo) == "function" then
-    -- Compatibility fallback: bounded probe for older runtimes without bdmList details.
-    for i = 0, 9 do
-      local ok, info = pcall(System.getMassBackendInfo, i)
-      if ok and type(info) == "table" and info.present == true then
-        local idx = tonumber(info.index or i)
-        local driver = string.lower(tostring(info.driver or ""))
-        local kind = classify_driver(driver)
-        new_cache[idx] = {
-          present = true,
-          driver = driver,
-          kind = kind
-        }
-        if not seen_index[idx] then
-          table.insert(new_order, idx)
-          seen_index[idx] = true
-        end
-      end
-    end
-  end
-
-  table.sort(new_order)
-  PLDR.MASS.CACHE = new_cache
-  PLDR.MASS.ORDER = new_order
-  PLDR.MASS.REFRESHED = true
   return true
 end
 
@@ -1000,83 +924,40 @@ function PLDR.InvalidateMassBackends()
 end
 
 function PLDR.RefreshMassStateSnapshot()
-  PLDR.InvalidateMassBackends()
-  if not PLDR.RefreshMassBackends() then
-    return nil
-  end
-  local snapshot = {
-    CACHE = {},
-    ORDER = {}
+  return {
+    mx4_root = PLDR.GetMX4SIOMassRootNow()
   }
-  for i = 1, #PLDR.MASS.ORDER do
-    local idx = PLDR.MASS.ORDER[i]
-    local item = PLDR.MASS.CACHE[idx]
-    snapshot.ORDER[i] = idx
-    if item ~= nil then
-      snapshot.CACHE[idx] = {
-        present = item.present == true,
-        driver = item.driver,
-        kind = item.kind
-      }
+end
+
+function PLDR.GetPresentMassRootsBounded()
+  local roots = {}
+  for i = 0, 9 do
+    local root = (i == 0) and "mass:/" or ("mass"..i..":/")
+    if doesFolderExist(root) then
+      table.insert(roots, root)
     end
   end
-  return snapshot
+  return roots
 end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local roots = {}
-  local seen = {}
-  local function add_root(root)
-    if root ~= nil and not seen[root] then
-      seen[root] = true
-      table.insert(roots, root)
-    end
-  end
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot
-  if state == nil then
-    if not PLDR.MASS.REFRESHED then
-      PLDR.RefreshMassBackends()
-    end
-    state = PLDR.MASS
-  end
+  local state = mass_snapshot or {}
 
   if wanted == "usb" then
-    local mx4_idx = PLDR.MX4SIO and PLDR.MX4SIO.MASSINDX or nil
-    local mx4_root = PLDR.MX4SIO and PLDR.MX4SIO.ROOT or nil
-    for i = 0, 4 do
-      local root = (i == 0) and "mass:/" or ("mass"..i..":/")
-      local is_mx4_idx = (mx4_idx ~= nil and i == mx4_idx)
-      local is_mx4_root = (mx4_root ~= nil and root == mx4_root)
-      if not is_mx4_idx and not is_mx4_root then
-        local name = PLDR.GetMassDriverName(i)
-        local norm, rev = PLDR.NormalizeDriverCode(name)
-        if norm == "usb" or rev == "usb" then
-          add_root(root)
-        else
-          local has_pops = false
-          if type(System) == "table" and type(System.doesDirExist) == "function" then
-            local ok, exists = pcall(System.doesDirExist, root.."POPS/")
-            has_pops = ok and exists == true
-          else
-            has_pops = doesFolderExist(root.."POPS/")
-          end
-          if has_pops then
-            add_root(root)
-          end
-        end
+    local mx4_root = state.mx4_root
+    local present = PLDR.GetPresentMassRootsBounded()
+    for i = 1, #present do
+      local root = present[i]
+      if mx4_root == nil or root ~= mx4_root then
+        table.insert(roots, root)
       end
     end
   elseif wanted == "mx4sio" then
-    for _, i in ipairs(state.ORDER or {}) do
-      local info = state.CACHE and state.CACHE[i] or nil
-      if info ~= nil and info.present and info.kind == "mx4sio" then
-        if i == 0 then
-          add_root("mass:/")
-        else
-          add_root("mass"..i..":/")
-        end
-      end
+    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
+    if mx4_root ~= nil then
+      table.insert(roots, mx4_root)
     end
   end
   return roots
@@ -1107,24 +988,9 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") then
-    local idx = PLDR.ParseMassIndexFromPath(path)
-    local driver = PLDR.GetMassDriverName(idx)
-    if driver ~= nil then
-      if string.find(driver, "sdc", 1, true) ~= nil then
-        if type(_G.ensureMx4sioInit) == "function" then
-          local ok = pcall(_G.ensureMx4sioInit)
-          if ok then return true end
-        end
-        if type(System) == "table" and type(System.initMX4SIO) == "function" then
-          local ok = pcall(System.initMX4SIO)
-          if ok then return true end
-        end
-      elseif string.find(driver, "usb", 1, true) ~= nil then
-        if type(System) == "table" and type(System.initUSB) == "function" then
-          local ok = pcall(System.initUSB)
-          if ok then return true end
-        end
-      end
+    if type(System) == "table" and type(System.initUSB) == "function" then
+      local ok = pcall(System.initUSB)
+      if ok then return true end
     end
     return true
   end
@@ -1488,20 +1354,7 @@ function PLDR.RefreshMassBackendsBoundedOnce()
     return true
   end
 
-  if type(System) == "table" and type(System.refreshMassBackends) == "function" then
-    pcall(System.refreshMassBackends)
-  end
-  if type(System) == "table" and type(System.bdmList) == "function" then
-    pcall(System.bdmList)
-  end
-  if type(System) == "table" and type(System.getMassBackendInfo) == "function" then
-    for i = 0, 9 do
-      pcall(System.getMassBackendInfo, i)
-    end
-  end
-  if type(PLDR.RefreshMassBackends) == "function" then
-    pcall(PLDR.RefreshMassBackends)
-  end
+  pcall(PLDR.GetMX4SIOMassRootNow)
 
   PLDR._mass_refreshed_bounded = true
   return true
@@ -1513,35 +1366,22 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
 
-  for pass = 1, 2 do
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-    if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
+  if type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+  if type(System) == "table" and type(System.sleep) == "function" then
+    pcall(System.sleep, 0.05)
+  end
 
-    local info = nil
-    if type(System) == "table" and type(System.findBDMByDriver) == "function" then
-      local ok, got = pcall(System.findBDMByDriver, "sdc")
-      if ok and type(got) == "table" then
-        info = got
-      end
-    end
-
-    if info ~= nil and info.devNr ~= nil then
-      local dev = tonumber(info.devNr)
-      if dev ~= nil then
-        local root = (dev == 0) and "mass:/" or ("mass"..dev..":/")
-        local pops = root.."POPS/"
-        if doesFolderExist(pops) then
-          PLDR.SetMX4SIORoot(root)
-          return pops
-        end
-      end
+  local root = PLDR.GetMX4SIOMassRootNow()
+  if root ~= nil then
+    local pops = root.."POPS/"
+    if doesFolderExist(pops) then
+      PLDR.SetMX4SIORoot(root)
+      return pops
     end
   end
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1680,45 +1680,11 @@ end
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            local mx4sio_root = nil
-            local mx4sio_err = nil
             PLDR.CleanupGameList()
             PLDR.GAMEPATH = ""
-            if type(System) == "table" and type(System.initMX4SIO) == "function" then
-              local ok, ready, root, err = pcall(System.initMX4SIO, "mx4sio0:/")
-              if ok and ready and root ~= nil then
-                mx4sio_root = root.."POPS/"
-              else
-                if ok then mx4sio_err = err end
-                ok, ready, root, err = pcall(System.initMX4SIO, "mx4sio:/")
-                if ok and ready and root ~= nil then
-                  mx4sio_root = root.."POPS/"
-                elseif ok then
-                  mx4sio_err = err
-                end
-              end
-            end
-            if mx4sio_root ~= nil and type(PLDR) == "table" then
-              local mx4_root = string.gsub(mx4sio_root, "POPS/$", "")
-              PLDR.MX4SIO = PLDR.MX4SIO or {}
-              PLDR.MX4SIO.ROOT = mx4_root
-              PLDR.MX4SIO.MASSINDX = nil
-              local mx4_idx = mx4_root:match("^mass(%d+):/")
-              if mx4_idx then
-                PLDR.MX4SIO.MASSINDX = tonumber(mx4_idx)
-              elseif mx4_root:match("^mass:/") then
-                PLDR.MX4SIO.MASSINDX = 0
-              end
-              if type(PLDR.SetMX4SIORoot) == "function" then
-                pcall(PLDR.SetMX4SIORoot, mx4_root)
-              end
-            end
+            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
             if mx4sio_root == nil then
-              local suffix = ""
-              if mx4sio_err ~= nil and mx4sio_err ~= "" then
-                suffix = " ("..tostring(mx4sio_err)..")"
-              end
-              UI.Notif_queue.add("No MX4SIO device found (POPS/ missing)"..suffix)
+              UI.Notif_queue.add("No MX4SIO device found")
               return
             else
               PLDR.CleanupGameList()

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -36,6 +36,7 @@ extern unsigned int size_cdfs_irx;
 
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
+static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
 
 #define BDM_QUERY_RPC_ID 0xB0D10B00
 #define BDM_QUERY_RPC_GET_LIST 0
@@ -197,6 +198,31 @@ static bool EnsureMassBackendCache()
 	return RefreshMassBackendCache();
 }
 
+static bool GetMassRootByBackendNameInternal(const char *backend_name, char *out_root, size_t out_sz)
+{
+	if (backend_name == NULL || backend_name[0] == '\0' || out_root == NULL || out_sz == 0) {
+		return false;
+	}
+
+	mass_backend_cache_valid = false;
+	bdm_rpc_bound = false;
+
+	bdm_dev_list_t list;
+	if (!FetchBdmList(&list)) {
+		return false;
+	}
+
+	for (u32 i = 0; i < list.count; ++i) {
+		const bdm_dev_info_t *info = &list.devs[i];
+		if (strcmp(info->name, backend_name) == 0) {
+			BuildMassRootPath((int)info->devNr, out_root, out_sz);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret)
 {
 	int id = -1;
@@ -227,10 +253,6 @@ static bool ProbeDir(const char *path, int *out_ret)
 	return false;
 }
 
-#ifndef USBMASS_IOCTL_GET_DRIVERNAME
-#define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
-#endif
-
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz)
 {
 	if (index == 0) {
@@ -238,68 +260,6 @@ static void BuildMassRootPath(int index, char *out_root, size_t out_sz)
 	} else {
 		snprintf(out_root, out_sz, "mass%d:/", index);
 	}
-}
-
-static void DecodeDriverCodePair(int rc, char *out_code, size_t out_code_sz, char *out_rev, size_t out_rev_sz)
-{
-	unsigned char b[4];
-	b[0] = (unsigned char)(rc & 0xFF);
-	b[1] = (unsigned char)((rc >> 8) & 0xFF);
-	b[2] = (unsigned char)((rc >> 16) & 0xFF);
-	b[3] = (unsigned char)((rc >> 24) & 0xFF);
-
-	size_t n = 0;
-	for (size_t i = 0; i < 4 && n + 1 < out_code_sz; ++i) {
-		char c = (char)b[i];
-		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-			if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-			out_code[n++] = c;
-		}
-	}
-	out_code[n] = '\0';
-
-	n = 0;
-	for (size_t i = 0; i < 4 && n + 1 < out_rev_sz; ++i) {
-		char c = (char)b[3 - i];
-		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-			if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
-			out_rev[n++] = c;
-		}
-	}
-	out_rev[n] = '\0';
-}
-
-static bool QueryMassDriverCode(int index, char *out_code, size_t out_code_sz, char *out_rev, size_t out_rev_sz)
-{
-	if (out_code == NULL || out_code_sz == 0 || out_rev == NULL || out_rev_sz == 0) {
-		return false;
-	}
-	char root[16];
-	BuildMassRootPath(index, root, sizeof(root));
-	int dd = fileXioDopen(root);
-	if (dd < 0) {
-		out_code[0] = '\0';
-		out_rev[0] = '\0';
-		return false;
-	}
-	int rc = fileXioIoctl(dd, USBMASS_IOCTL_GET_DRIVERNAME, (void*)"");
-	fileXioDclose(dd);
-	DecodeDriverCodePair(rc, out_code, out_code_sz, out_rev, out_rev_sz);
-	return out_code[0] != '\0' || out_rev[0] != '\0';
-}
-
-static bool IsDriverCodeMatch(const char *code, const char *rev, const char *want)
-{
-	if (want == NULL || want[0] == '\0') {
-		return false;
-	}
-	if (code != NULL && strcmp(code, want) == 0) {
-		return true;
-	}
-	if (rev != NULL && strcmp(rev, want) == 0) {
-		return true;
-	}
-	return false;
 }
 
 // MX4SIO init notes:
@@ -316,7 +276,6 @@ enum {
 int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 {
 	static bool mx4sio_irx_loaded = false;
-	bool saw_sdc_driver = false;
 
 	if (out_root == NULL || out_sz == 0) {
 		return MX4SIO_INIT_ROOT_NOT_FOUND;
@@ -331,22 +290,10 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 		mx4sio_irx_loaded = true;
 	}
 
-	for (int i = 0; i <= 9; ++i) {
-		char code[5];
-		char rev[5];
-		if (!QueryMassDriverCode(i, code, sizeof(code), rev, sizeof(rev))) {
-			continue;
-		}
-		if (!IsDriverCodeMatch(code, rev, "sdc")) {
-			continue;
-		}
-		saw_sdc_driver = true;
-		char root[16];
-		char pops_path[32];
-		BuildMassRootPath(i, root, sizeof(root));
-		snprintf(pops_path, sizeof(pops_path), "%sPOPS/", root);
-		int pops_ret = -1;
-		if (ProbeDir(pops_path, &pops_ret)) {
+	char root[16];
+	if (GetMassRootByBackendNameInternal("sdc", root, sizeof(root))) {
+		int root_ret = -1;
+		if (ProbeDir(root, &root_ret)) {
 			snprintf(out_root, out_sz, "%s", root);
 			return MX4SIO_INIT_OK;
 		}
@@ -377,28 +324,6 @@ int mx4sio_init_and_get_root(const char *hint, char *out_root, size_t out_sz)
 		if (ProbeDir(pops_path, &pops_ret)) {
 			snprintf(out_root, out_sz, "%s", prefix);
 			return MX4SIO_INIT_OK;
-		}
-	}
-
-	if (!saw_sdc_driver) {
-		for (int i = 0; i <= 9; ++i) {
-			char code[5];
-			char rev[5];
-			if (!QueryMassDriverCode(i, code, sizeof(code), rev, sizeof(rev))) {
-				continue;
-			}
-			if (IsDriverCodeMatch(code, rev, "usb")) {
-				continue;
-			}
-			char root[16];
-			char pops_path[32];
-			BuildMassRootPath(i, root, sizeof(root));
-			snprintf(pops_path, sizeof(pops_path), "%sPOPS/", root);
-			int pops_ret = -1;
-			if (ProbeDir(pops_path, &pops_ret)) {
-				snprintf(out_root, out_sz, "%s", root);
-				return MX4SIO_INIT_OK;
-			}
 		}
 	}
 
@@ -497,6 +422,24 @@ static int lua_get_mass_backend_info(lua_State *L)
 			return 1;
 		}
 	}
+	lua_pushnil(L);
+	return 1;
+}
+
+static int lua_get_mass_root_by_backend_name(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1) {
+		return luaL_error(L, "Argument error: System.getMassRootByBackendName(name) takes one argument.");
+	}
+
+	const char *backend_name = luaL_checkstring(L, 1);
+	char root[16];
+	if (GetMassRootByBackendNameInternal(backend_name, root, sizeof(root))) {
+		lua_pushstring(L, root);
+		return 1;
+	}
+
 	lua_pushnil(L);
 	return 1;
 }
@@ -1346,6 +1289,7 @@ static const luaL_Reg System_functions[] = {
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
+	{"getMassRootByBackendName", lua_get_mass_root_by_backend_name},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}
 };

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -215,7 +215,7 @@ static bool GetMassRootByBackendNameInternal(const char *backend_name, char *out
 	for (u32 i = 0; i < list.count; ++i) {
 		const bdm_dev_info_t *info = &list.devs[i];
 		if (strcmp(info->name, backend_name) == 0) {
-			BuildMassRootPath((int)info->devNr, out_root, out_sz);
+			BuildMassRootPath((int)info->parId, out_root, out_sz);
 			return true;
 		}
 	}


### PR DESCRIPTION
### Motivation
- Make MX4SIO identity deterministic and order-independent by using the backend driver name exactly "sdc" as the single authoritative identifier and avoid any heuristic or cached classification logic.
- Ensure USB page never loads MX4SIO and MX4SIO page always scans exactly one root (when present), with bounded probes only (mass:/, mass0..mass9:/).

### Description
- Added a C++ Lua binding `System.getMassRootByBackendName(name)` in `src/luasystem.cpp` that invalidates stale state, forces a fresh BDM RPC `FetchBdmList`, searches for an exact `strcmp(info->name, name)` match, and returns the current mount root string (`mass:/` or `massN:/`) or `nil` if absent.
- Removed previous ioctl/driver-code and substring-matching detection paths used to infer MX4SIO in both C++ and Lua and replaced them with the authoritative backend-name query (exact match to "sdc").
- Updated POPSLDR mass selection logic (`bin/POPSLDR/system.lua`) to:
  - Provide `PLDR.GetMX4SIOMassRootNow()` which calls `System.getMassRootByBackendName("sdc")`.
  - Enumerate present mass roots with `PLDR.GetPresentMassRootsBounded()` by probing `mass:/` and `mass0:/`..`mass9:/` only and exclude exactly the live MX4SIO root when present for USB lists.
  - Make `PLDR.RefreshMassStateSnapshot()` return a minimal snapshot `{ mx4_root = ... }` used by USB/MX4 flows.
  - Make `PLDR.InitMX4SIOPopsRoot()` initialize MX4SIO prerequisites then resolve the single MX4 root and probe only that root for `POPS/`.
- Updated UI flow (`bin/POPSLDR/ui.lua`) to call `PLDR.InitMX4SIOPopsRoot()` for MX4 page entry and to present a single-root MX4 scan; USB page builds lists only from the bounded present-root set computed above.
- Changes intentionally localized (one new Lua API, small edits in two Lua files and the C++ source) and adhere to constraints: exact "sdc" match, no substring heuristics for classification, no reliance on cached slot maps, and bounded loops (0..9).

### Testing
- Ran `git diff --check` to validate whitespace and index issues, which returned clean output.
- Committed the changes on a fresh branch and verified the commit summary with `git show --stat --oneline HEAD` and inspected the three modified files with `git show`; commit was created successfully.
- Attempted to byte-compile Lua scripts with `luac -p` but the `luac` tool is not available in the environment, so Lua parse-check was not performed here.
- No runtime hardware tests were executed in this environment; the changes are designed to be minimal and safe to validate on-device against the acceptance scenario described (2 USB + MX4SIO connected, exercising USB and MX4SIO pages in both orders).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39883c2dc8321a2c782e2e0241bf2)