### PR TITLE
Guard ELF exits, enable DKWDRV, UI tweaks, and embed boot audio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ EMBEDDED_RSC = boot.o builtin_font.o \
 	asset_usbd_irx_usbexfat.o asset_usbhdfsd_irx_usbexfat.o asset_usbd_irx_mx4sio.o asset_usbhdfsd_irx_mx4sio.o \
 	asset_usbd_irx_mmce.o asset_usbhdfsd_irx_mmce.o asset_icon_sys_mx4sio.o asset_list_icn_mx4sio.o asset_del_icn_mx4sio.o \
 	asset_icon_sys_mmce.o asset_list_icn_mmce.o asset_del_icn_mmce.o asset_icon_sys_usbexfat.o asset_list_icn_usbexfat.o \
-	asset_del_icn_usbexfat.o
+	asset_del_icn_usbexfat.o asset_boot_audio_adp.o
 
 EE_OBJS = $(APP_CORE) $(LUA_LIBS) $(IOP_MODULES) $(EMBEDDED_RSC)
 
@@ -169,6 +169,9 @@ $(EE_ASM_DIR)asset_images_lua.c: bin/POPSLDR/images.lua | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_images_lua
 $(EE_ASM_DIR)asset_pops_profiles_lua.c: bin/POPSLDR/pops_profiles.lua | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_pops_profiles_lua
+
+$(EE_ASM_DIR)asset_boot_audio_adp.c: bin/POPSLDR/boot.adp | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_boot_audio_adp
 
 $(EE_ASM_DIR)asset_usbd_irx_usbexfat.c: bin/POPSLDR/usbd.irx.usbexfat | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_usbd_irx_usbexfat

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -179,8 +179,8 @@ UI = {
     boot_locks = {};
     BOOT_SOUND = {
       ENABLED = true,
-      PATH = "boot.adp",      -- relative to CWD (same folder as ui.lua on HostFS)
-      SECONDS = 3.0,          -- splash minimum hold to cover audio (adjust to match boot.adp)
+      PATH = "embed:/boot_audio.adp",
+      SECONDS = 4.0,
       PAD_SECONDS = 0.5,      -- extra padding to keep splash visible after audio starts
       BOOT_PHASE_SECONDS = 8.0,
       CREDITS_PHASE_SECONDS = 7.0,
@@ -477,7 +477,10 @@ UI = {
           if icon ~= nil then
             local w = Graphics.getImageWidth(icon)
             local h = Graphics.getImageHeight(icon)
-            Graphics.drawImage(icon, x - (w / 2), y - (h / 2), UI.CCOL.GREY)
+            local scale = 0.75
+            local draw_w = Round(w * scale)
+            local draw_h = Round(h * scale)
+            Graphics.drawScaleImage(icon, x - (draw_w / 2), y - (draw_h / 2), draw_w, draw_h, UI.CCOL.GREY)
           end
           local label = labels and labels[key] or nil
           if label ~= nil then
@@ -553,115 +556,7 @@ UI = {
             return
           end
 
-          local primary = UI.BOOT_SOUND.PATH or "boot.adp"
-          local names = { primary }
-          if primary ~= "boot.adpcm" then
-            table.insert(names, "boot.adpcm")
-          end
-
-local function file_exists(p)
-  if p == nil then return false end
-  if type(doesFileExist) == "function" then
-    local okcall, res = pcall(doesFileExist, p)
-    return okcall and res == true
-  end
-  if type(System) == "table" and type(System.openFile) == "function" and type(System.closeFile) == "function" then
-    local okfd, fd = pcall(System.openFile, p, O_RDONLY)
-    if okfd and fd ~= nil and fd >= 0 then
-      pcall(System.closeFile, fd)
-      return true
-    end
-  end
-  return false
-end
-
-local function resolve(p)
-  if p == nil then return nil end
-  if type(System) == "table" and type(System.resolveAsset) == "function" then
-    local ok, r = pcall(System.resolveAsset, p)
-    if ok and type(r) == "string" and r ~= "" then return r end
-  end
-  return p
-end
-
-local function ensure_dir(path)
-  if path == nil or path == "" then return nil end
-  if type(EnsureTrailingSlash) == "function" then
-    return EnsureTrailingSlash(path)
-  end
-  if string.sub(path, -1) ~= "/" then
-    return path .. "/"
-  end
-  return path
-end
-
-local function add_candidate(list, path)
-  if path ~= nil and path ~= "" then
-    table.insert(list, path)
-  end
-end
-
-local function resolve_candidates(name)
-  local candidates = {}
-  add_candidate(candidates, resolve(name))
-  add_candidate(candidates, resolve("./" .. name))
-
-  local app_dir = APP_DIR
-  if type(System) == "table" and type(System.getAppDir) == "function" then
-    local ok, dir = pcall(System.getAppDir)
-    if ok and dir ~= nil and dir ~= "" then
-      app_dir = dir
-    end
-  end
-  local app_dir_norm = ensure_dir(app_dir)
-  if app_dir_norm ~= nil then
-    add_candidate(candidates, app_dir_norm .. name)
-    add_candidate(candidates, app_dir_norm .. "POPSLDR/" .. name)
-  end
-
-  local cwd = nil
-  if type(System) == "table" and type(System.currentDirectory) == "function" then
-    local ok, dir = pcall(System.currentDirectory)
-    if ok then
-      cwd = dir
-    end
-  end
-  local cwd_norm = ensure_dir(cwd)
-  if cwd_norm ~= nil then
-    add_candidate(candidates, cwd_norm .. name)
-    add_candidate(candidates, cwd_norm .. "POPSLDR/" .. name)
-  end
-
-  add_candidate(candidates, name)
-  add_candidate(candidates, "./" .. name)
-
-  return candidates
-end
-
-          local found = nil
-          local requested = nil
-          for _, rel in ipairs(names) do
-            requested = rel
-            local candidates = resolve_candidates(rel)
-            for _, p in ipairs(candidates) do
-              if file_exists(p) then
-                found = p
-                break
-              end
-            end
-            if found ~= nil then break end
-          end
-
-          if found == nil and requested ~= nil then
-            -- Last resort: try HostFS prefix in PCSX2 setups.
-            local host_p = "host:" .. requested
-            if file_exists(host_p) then found = host_p end
-          end
-
-          if found == nil then
-            return
-          end
-
+          local source = UI.BOOT_SOUND.PATH or "embed:/boot_audio.adp"
 
 -- Set volumes/formats defensively; some builds may ignore these.
           local function normalize_volume(value)
@@ -693,7 +588,7 @@ end
             end
           end)
 
-          local ok_load, audio = pcall(Sound.loadADPCM, found)
+          local ok_load, audio = pcall(Sound.loadADPCM, source)
           if not ok_load then
             return
           end
@@ -860,8 +755,8 @@ end
 
         -- Start boot sound once; explicit holds must not be lengthened by audio duration.
         TryBootSound()
-        local SPLASH_HOLD_MS = 3000
-        local CREDITS_HOLD_MS = 4000
+        local SPLASH_HOLD_MS = 4000
+        local CREDITS_HOLD_MS = 3000
 
         StepFade(DrawSplash, 128, 0, FADE_IN_MS)
         StepHold(DrawSplash, SPLASH_HOLD_MS)
@@ -957,38 +852,52 @@ end
         System.exitToBrowser()
       end;
       LaunchBootElf = function ()
-        local candidates = {
-          "mc0:/BOOT/BOOT.ELF",
-          "mc1:/BOOT/BOOT.ELF"
-        }
-        local boot_path = nil
+        local boot_path = "mc0:/BOOT/BOOT.ELF"
+        local exists = false
         if type(doesFileExist) == "function" then
-          for _, path in ipairs(candidates) do
-            local okcall, exists = pcall(doesFileExist, path)
-            if okcall and exists == true then
-              boot_path = path
-              break
+          local okcall, result = pcall(doesFileExist, boot_path)
+          exists = okcall and result == true
+        elseif type(System) == "table" and type(System.openFile) == "function" then
+          local okfd, fd = pcall(System.openFile, boot_path, FREAD)
+          if okfd and type(fd) == "number" and fd >= 0 then
+            exists = true
+            if type(System.closeFile) == "function" then
+              pcall(System.closeFile, fd)
             end
           end
         end
-        if boot_path == nil and type(System) == "table" and type(System.openFile) == "function" then
-          for _, path in ipairs(candidates) do
-            local okfd, fd = pcall(System.openFile, path, FREAD)
-            if okfd and type(fd) == "number" and fd >= 0 then
-              if type(System.closeFile) == "function" then
-                pcall(System.closeFile, fd)
-              end
-              boot_path = path
-              break
-            end
-          end
-        end
-        if boot_path == nil then
-          if UI.Notif_queue ~= nil and type(UI.Notif_queue.add) == "function" then
-            UI.Notif_queue.add("mc?:/BOOT/BOOT.ELF not found")
-          end
+
+        if not exists then
+          UI.Modal.active = true
+          UI.Modal.title = "Exit"
+          UI.Modal.body = "BOOT.ELF not found"
+          UI.Modal.options = {"OK", "Back"}
+          UI.Modal.confirm_action = UI.Modal.Close
+          UI.Modal.cancel_action = UI.Modal.Close
+          UI.Modal.triangle_action = nil
+          UI.Modal.ignore_until_release = true
           return
         end
+
+        if UI.Transition ~= nil and UI.Transition.StepFadeToBlack ~= nil then
+          pcall(UI.Transition.StepFadeToBlack, 240)
+        else
+          pcall(function()
+            Screen.clear(Color.new(0, 0, 0))
+            Screen.flip()
+          end)
+        end
+
+        if type(Sound) == "table" and type(Sound.pause) == "function" then
+          pcall(Sound.pause)
+        elseif type(Sound) == "table" and type(Sound.stop) == "function" then
+          pcall(Sound.stop)
+        end
+
+        if type(System) == "table" and type(System.sleep) == "function" then
+          pcall(System.sleep, 0.3)
+        end
+
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
           System.loadELF(boot_path, 1, boot_path)
@@ -1076,6 +985,28 @@ end
         UI.Transition.start = Timer.getTime(UI.Transition.timer)
         UI.Transition.elapsed = 0
         UI.Transition.last_time = UI.Transition.start
+      end,
+      StepFadeToBlack = function (duration_ms)
+        local fade_ms = tonumber(duration_ms) or 240
+        if fade_ms < 0 then fade_ms = 0 end
+        local timer = Timer.new()
+        local start = Timer.getTime(timer)
+        while true do
+          local now = Timer.getTime(timer)
+          local elapsed = now - start
+          if elapsed < 0 then elapsed = 0 end
+          if elapsed > fade_ms then elapsed = fade_ms end
+          local t = (fade_ms > 0) and (elapsed / fade_ms) or 1
+          local alpha = Round(128 * t)
+          Screen.clear(Color.new(0, 0, 0))
+          if alpha > 0 then
+            Graphics.drawRect(0, 0, UI.SCR.X, UI.SCR.Y, Color.new(0, 0, 0, alpha))
+          end
+          Screen.flip()
+          if elapsed >= fade_ms then
+            break
+          end
+        end
       end,
       Update = function ()
         if not UI.Transition.active then
@@ -1548,6 +1479,7 @@ end
 	        if layout.CAROUSEL_Y_OFFSET ~= nil then
 	          center_y = center_y + layout.CAROUSEL_Y_OFFSET
 	        end
+        center_y = center_y + 10
         local function Clamp(value, min_val, max_val)
           if value < min_val then return min_val end
           if value > max_val then return max_val end
@@ -1732,10 +1664,55 @@ end
           elseif UI.MainMenu.OPT == 6 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 7 then
-            if type(System) == "table" and type(System.ensureCDFS) == "function" then
-              System.ensureCDFS()
+            UI.Modal.active = true
+            UI.Modal.title = "Disc"
+            UI.Modal.body = "Launch DKWDRV?"
+            UI.Modal.options = {"Yes", "No"}
+            UI.Modal.confirm_action = function ()
+              local dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+              local exists = false
+              if type(doesFileExist) == "function" then
+                local okcall, result = pcall(doesFileExist, dkwdrv_path)
+                exists = okcall and result == true
+              elseif type(System) == "table" and type(System.openFile) == "function" then
+                local okfd, fd = pcall(System.openFile, dkwdrv_path, FREAD)
+                if okfd and type(fd) == "number" and fd >= 0 then
+                  exists = true
+                  if type(System.closeFile) == "function" then
+                    pcall(System.closeFile, fd)
+                  end
+                end
+              end
+
+              if not exists then
+                UI.Modal.title = "Disc"
+                UI.Modal.body = "DKWDRV not found"
+                UI.Modal.options = {"OK", "Back"}
+                UI.Modal.confirm_action = UI.Modal.Close
+                UI.Modal.cancel_action = UI.Modal.Close
+                UI.Modal.triangle_action = nil
+                UI.Modal.ignore_until_release = true
+                return
+              end
+
+              UI.Modal.Close()
+              if UI.Transition ~= nil and UI.Transition.StepFadeToBlack ~= nil then
+                pcall(UI.Transition.StepFadeToBlack, 240)
+              else
+                pcall(function()
+                  Screen.clear(Color.new(0, 0, 0))
+                  Screen.flip()
+                end)
+              end
+
+              if type(System) == "table" and type(System.loadELF) == "function" then
+                UI.LAUNCHING = true
+                System.loadELF(dkwdrv_path)
+              end
             end
-            UI.Notif_queue.add("Not Implemented Yet")
+            UI.Modal.cancel_action = UI.Modal.Close
+            UI.Modal.triangle_action = nil
+            UI.Modal.ignore_until_release = true
           end --because we still dont support SMB
         end
       end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -900,8 +900,35 @@ UI = {
 
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          local reboot_iop = 0
-          System.loadELF(boot_path, reboot_iop)
+          local reboot_iop = 1
+          local ok_load, _ = pcall(System.loadELF, boot_path, reboot_iop, boot_path)
+          if not ok_load then
+            UI.LAUNCHING = false
+            if UI.CURSCENE ~= UI.SCENES.MMAIN then
+              UI.SceneChange(UI.SCENES.MMAIN)
+            end
+            UI.Modal.active = true
+            UI.Modal.title = "Exit"
+            UI.Modal.body = "Failed to launch BOOT.ELF"
+            UI.Modal.options = {"OK", "Back"}
+            UI.Modal.confirm_action = UI.Modal.Close
+            UI.Modal.cancel_action = UI.Modal.Close
+            UI.Modal.triangle_action = nil
+            UI.Modal.ignore_until_release = true
+            return
+          end
+          UI.LAUNCHING = false
+          if UI.CURSCENE ~= UI.SCENES.MMAIN then
+            UI.SceneChange(UI.SCENES.MMAIN)
+          end
+          UI.Modal.active = true
+          UI.Modal.title = "Exit"
+          UI.Modal.body = "Failed to launch BOOT.ELF"
+          UI.Modal.options = {"OK", "Back"}
+          UI.Modal.confirm_action = UI.Modal.Close
+          UI.Modal.cancel_action = UI.Modal.Close
+          UI.Modal.triangle_action = nil
+          UI.Modal.ignore_until_release = true
         end
       end;
       HandleInput = function ()
@@ -1705,10 +1732,47 @@ UI = {
                 end)
               end
 
+              if type(Sound) == "table" and type(Sound.pause) == "function" then
+                pcall(Sound.pause)
+              elseif type(Sound) == "table" and type(Sound.stop) == "function" then
+                pcall(Sound.stop)
+              end
+
+              if type(System) == "table" and type(System.sleep) == "function" then
+                pcall(System.sleep, 0.3)
+              end
+
               if type(System) == "table" and type(System.loadELF) == "function" then
                 UI.LAUNCHING = true
-                local reboot_iop = 0
-                System.loadELF(dkwdrv_path, reboot_iop)
+                local reboot_iop = 1
+                local ok_load, _ = pcall(System.loadELF, dkwdrv_path, reboot_iop, dkwdrv_path)
+                if not ok_load then
+                  UI.LAUNCHING = false
+                  if UI.CURSCENE ~= UI.SCENES.MMAIN then
+                    UI.SceneChange(UI.SCENES.MMAIN)
+                  end
+                  UI.Modal.active = true
+                  UI.Modal.title = "Disc"
+                  UI.Modal.body = "Failed to launch DKWDRV"
+                  UI.Modal.options = {"OK", "Back"}
+                  UI.Modal.confirm_action = UI.Modal.Close
+                  UI.Modal.cancel_action = UI.Modal.Close
+                  UI.Modal.triangle_action = nil
+                  UI.Modal.ignore_until_release = true
+                  return
+                end
+                UI.LAUNCHING = false
+                if UI.CURSCENE ~= UI.SCENES.MMAIN then
+                  UI.SceneChange(UI.SCENES.MMAIN)
+                end
+                UI.Modal.active = true
+                UI.Modal.title = "Disc"
+                UI.Modal.body = "Failed to launch DKWDRV"
+                UI.Modal.options = {"OK", "Back"}
+                UI.Modal.confirm_action = UI.Modal.Close
+                UI.Modal.cancel_action = UI.Modal.Close
+                UI.Modal.triangle_action = nil
+                UI.Modal.ignore_until_release = true
               end
             end
             UI.Modal.cancel_action = UI.Modal.Close

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -269,7 +269,7 @@ UI = {
       PREVIEW_W = 240;
       PREVIEW_H = 240;
 	      -- Raised/tighter footer to avoid overscan and allow icon reflections to overlap slightly.
-	      CAROUSEL_Y_OFFSET = 18;
+	      CAROUSEL_Y_OFFSET = 28;
       FOOTER_LABEL_W = 140;
       FOOTER_ICON_Y_OFFSET = 24;
       FOOTER_LABEL_Y_OFFSET = 10;
@@ -900,7 +900,8 @@ UI = {
 
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          System.loadELF(boot_path, 1, boot_path)
+          local reboot_iop = 0
+          System.loadELF(boot_path, reboot_iop)
         end
       end;
       HandleInput = function ()
@@ -1479,7 +1480,6 @@ UI = {
 	        if layout.CAROUSEL_Y_OFFSET ~= nil then
 	          center_y = center_y + layout.CAROUSEL_Y_OFFSET
 	        end
-        center_y = center_y + 10
         local function Clamp(value, min_val, max_val)
           if value < min_val then return min_val end
           if value > max_val then return max_val end
@@ -1707,7 +1707,8 @@ UI = {
 
               if type(System) == "table" and type(System.loadELF) == "function" then
                 UI.LAUNCHING = true
-                System.loadELF(dkwdrv_path)
+                local reboot_iop = 0
+                System.loadELF(dkwdrv_path, reboot_iop)
               end
             end
             UI.Modal.cancel_action = UI.Modal.Close

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -879,6 +879,7 @@ UI = {
           return
         end
 
+        UI.Modal.Close()
         if UI.Transition ~= nil and UI.Transition.StepFadeToBlack ~= nil then
           pcall(UI.Transition.StepFadeToBlack, 240)
         else
@@ -898,26 +899,13 @@ UI = {
           pcall(System.sleep, 0.3)
         end
 
-        if type(System) == "table" and type(System.loadELF) == "function" then
-          UI.LAUNCHING = true
-          local reboot_iop = 1
-          local ok_load, _ = pcall(System.loadELF, boot_path, reboot_iop, boot_path)
-          if not ok_load then
-            UI.LAUNCHING = false
-            if UI.CURSCENE ~= UI.SCENES.MMAIN then
-              UI.SceneChange(UI.SCENES.MMAIN)
-            end
-            UI.Modal.active = true
-            UI.Modal.title = "Exit"
-            UI.Modal.body = "Failed to launch BOOT.ELF"
-            UI.Modal.options = {"OK", "Back"}
-            UI.Modal.confirm_action = UI.Modal.Close
-            UI.Modal.cancel_action = UI.Modal.Close
-            UI.Modal.triangle_action = nil
-            UI.Modal.ignore_until_release = true
-            return
-          end
+        local function RecoverBootLaunchFailure()
           UI.LAUNCHING = false
+          if UI.Transition ~= nil then
+            UI.Transition.active = false
+            UI.Transition.target = nil
+            UI.Transition.next_target = nil
+          end
           if UI.CURSCENE ~= UI.SCENES.MMAIN then
             UI.SceneChange(UI.SCENES.MMAIN)
           end
@@ -929,6 +917,17 @@ UI = {
           UI.Modal.cancel_action = UI.Modal.Close
           UI.Modal.triangle_action = nil
           UI.Modal.ignore_until_release = true
+        end
+
+        if type(System) == "table" and type(System.loadELF) == "function" then
+          UI.LAUNCHING = true
+          local reboot_iop = 1
+          local ok_load, _ = pcall(System.loadELF, boot_path, reboot_iop, boot_path)
+          if not ok_load then
+            RecoverBootLaunchFailure()
+            return
+          end
+          RecoverBootLaunchFailure()
         end
       end;
       HandleInput = function ()

--- a/src/embed_assets.cpp
+++ b/src/embed_assets.cpp
@@ -91,6 +91,8 @@ extern unsigned char asset_list_icn_usbexfat[];
 extern unsigned int size_asset_list_icn_usbexfat;
 extern unsigned char asset_del_icn_usbexfat[];
 extern unsigned int size_asset_del_icn_usbexfat;
+extern unsigned char asset_boot_audio_adp[];
+extern unsigned int size_asset_boot_audio_adp;
 
 #define ASSET_ENTRY(key_name, symbol_name) { key_name, symbol_name, (size_t)size_##symbol_name }
 
@@ -136,6 +138,7 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("icon.sys.usbexfat", asset_icon_sys_usbexfat),
 	ASSET_ENTRY("list.icn.usbexfat", asset_list_icn_usbexfat),
 	ASSET_ENTRY("del.icn.usbexfat", asset_del_icn_usbexfat),
+	ASSET_ENTRY("boot_audio.adp", asset_boot_audio_adp),
 
 
 	ASSET_ENTRY("POPSLDR/IMG/USB.png", asset_usb_png),
@@ -178,7 +181,8 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("POPSLDR/del.icn.mmce", asset_del_icn_mmce),
 	ASSET_ENTRY("POPSLDR/icon.sys.usbexfat", asset_icon_sys_usbexfat),
 	ASSET_ENTRY("POPSLDR/list.icn.usbexfat", asset_list_icn_usbexfat),
-	ASSET_ENTRY("POPSLDR/del.icn.usbexfat", asset_del_icn_usbexfat)
+	ASSET_ENTRY("POPSLDR/del.icn.usbexfat", asset_del_icn_usbexfat),
+	ASSET_ENTRY("POPSLDR/boot_audio.adp", asset_boot_audio_adp)
 };
 
 static const embedded_asset_t *embedded_find(const char *key)


### PR DESCRIPTION
### Motivation
- Fix the black-screen/hang when exiting to `mc0:/BOOT/BOOT.ELF` by making the launch flow guarded and fail-safe. 
- Allow the existing carousel `Disc (DKWDRV)` item to actually launch `DKWDRV.ELF` via a confirmation flow. 
- Apply small, targeted UI adjustments (carousel position and footer icon scale) and change splash/credits durations without altering layout math or device handling. 
- Ensure boot audio is loaded from embedded assets only so startup audio is self-contained and non-blocking. 

### Description
- Reworked exit flow in `bin/POPSLDR/ui.lua` to target only `mc0:/BOOT/BOOT.ELF`, verify existence via the safe checks, show a modal `"BOOT.ELF not found"` when missing, and on success perform a fade-to-black, stop/pause audio, small delay, then call `System.loadELF(...)` (guarded with `pcall`).
- Enabled the existing Disc carousel option by adding a Yes/No modal that verifies `mc0:/PS1_DKWDRV/DKWDRV.ELF`, shows `"DKWDRV not found"` when missing, and otherwise fades and launches the ELF via `System.loadELF(...)`.
- Lowered the carousel final draw position by adding `center_y = center_y + 10` and reduced footer/button-bar icon render size by drawing icons at `scale = 0.75` (using `Graphics.drawScaleImage`) while preserving anchors and spacing logic, all in `bin/POPSLDR/ui.lua`.
- Adjusted hold durations used by the splash/credits sequence to `SPLASH = 4.0s` and `CREDITS = 3.0s` while preserving the existing fade/transition ordering and sequencing.
- Switched boot audio resolution to embedded-only by changing the boot audio path to `embed:/boot_audio.adp`, removing the previous filesystem probing/fallback logic, and calling `Sound.loadADPCM` with the embedded source while keeping playback non-fatal.
- Added the `boot.adp` embedding into the build pipeline and VFS by adding the `asset_boot_audio_adp` rules to `Makefile` and registering `boot_audio.adp` in `src/embed_assets.cpp` so `embed:/boot_audio.adp` resolves from embedded assets.

### Testing
- Attempted Lua syntax check with `luac -p bin/POPSLDR/ui.lua`, which could not run in this environment because `luac` is not installed (failure due to missing tool). 
- Ran a dry-run of the build with `make -n`, which failed to proceed because the container lacks PS2SDK includes (`/samples/Makefile.eeglobal`) (environment limitation, not a code regression). 
- Performed repository checks (`git status`, `git diff`) and committed the changes successfully using `git commit` (commit succeeded). 
- Performed local static edits and grep/inspection to confirm the intended substitutions were applied to `bin/POPSLDR/ui.lua`, `src/embed_assets.cpp`, and `Makefile` (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a53a14fc8321827c79e1ab65b98e)