### PR TITLE
Fix BOOT.ELF launch args and implement Disc (DKWDRV) chainload

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1001,7 +1001,7 @@ end
         end
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          local ok, ret = pcall(System.loadELF, boot_path, 1)
+          local ok, ret = pcall(System.loadELF, boot_path, 1, "BOOT")
           if (not ok) or ret == false or ret == nil then
             UI.LAUNCHING = false
             UI.Notif_queue.add("BOOT.ELF launch failed")
@@ -1031,7 +1031,7 @@ end
           return
         end
         UI.LAUNCHING = true
-        local ok, ret = pcall(System.loadELF, dkwdrv_path, 1)
+        local ok, ret = pcall(System.loadELF, dkwdrv_path, 1, "DKWDRV")
         if (not ok) or ret == false or ret == nil then
           UI.LAUNCHING = false
           UI.Notif_queue.add("DKWDRV launch failed")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -926,6 +926,16 @@ end
         UI.Modal.triangle_action = UI.Modal.LaunchBootElf
         UI.Modal.ignore_until_release = true
       end;
+      OpenDKWDRV = function ()
+        UI.Modal.active = true
+        UI.Modal.title = "Exit"
+        UI.Modal.body = "Exit to DKWDRV?"
+        UI.Modal.options = {"DKWDRV", "Cancel"}
+        UI.Modal.confirm_action = UI.Modal.LaunchDKWDRV
+        UI.Modal.cancel_action = UI.Modal.Close
+        UI.Modal.triangle_action = nil
+        UI.Modal.ignore_until_release = true
+      end;
       OpenDeviceLock = function (reason, active, target)
         local active_name = UI.device_lock_name(active)
         local target_name = UI.device_lock_name(target)
@@ -991,7 +1001,41 @@ end
         end
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          System.loadELF(boot_path, 1)
+          local ok, ret = pcall(System.loadELF, boot_path, 1)
+          if (not ok) or ret == false or ret == nil then
+            UI.LAUNCHING = false
+            UI.Notif_queue.add("BOOT.ELF launch failed")
+            return
+          end
+        end
+      end;
+      LaunchDKWDRV = function ()
+        local dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+        local dkwdrv_exists = false
+        if type(doesFileExist) == "function" then
+          local okcall, exists = pcall(doesFileExist, dkwdrv_path)
+          dkwdrv_exists = okcall and exists == true
+        end
+        if not dkwdrv_exists and type(System) == "table" and type(System.openFile) == "function" then
+          local okfd, fd = pcall(System.openFile, dkwdrv_path, FREAD)
+          if okfd and type(fd) == "number" and fd >= 0 then
+            if type(System.closeFile) == "function" then
+              pcall(System.closeFile, fd)
+            end
+            dkwdrv_exists = true
+          end
+        end
+        if not dkwdrv_exists then
+          UI.Notif_queue.add("mc0:/PS1_DKWDRV/DKWDRV.ELF not found")
+          UI.LAUNCHING = false
+          return
+        end
+        UI.LAUNCHING = true
+        local ok, ret = pcall(System.loadELF, dkwdrv_path, 1)
+        if (not ok) or ret == false or ret == nil then
+          UI.LAUNCHING = false
+          UI.Notif_queue.add("DKWDRV launch failed")
+          return
         end
       end;
       HandleInput = function ()
@@ -1735,27 +1779,7 @@ end
             if type(System) == "table" and type(System.ensureCDFS) == "function" then
               System.ensureCDFS()
             end
-            local dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
-            local dkwdrv_exists = false
-            if type(doesFileExist) == "function" then
-              local okcall, exists = pcall(doesFileExist, dkwdrv_path)
-              dkwdrv_exists = okcall and exists == true
-            end
-            if not dkwdrv_exists and type(System) == "table" and type(System.openFile) == "function" then
-              local okfd, fd = pcall(System.openFile, dkwdrv_path, FREAD)
-              if okfd and type(fd) == "number" and fd >= 0 then
-                if type(System.closeFile) == "function" then
-                  pcall(System.closeFile, fd)
-                end
-                dkwdrv_exists = true
-              end
-            end
-            if not dkwdrv_exists then
-              UI.Notif_queue.add("mc0:/PS1_DKWDRV/DKWDRV.ELF not found")
-              return
-            end
-            UI.LAUNCHING = true
-            System.loadELF(dkwdrv_path, 1)
+            UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
         end
       end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -991,7 +991,7 @@ end
         end
         if type(System) == "table" and type(System.loadELF) == "function" then
           UI.LAUNCHING = true
-          System.loadELF(boot_path, 1, boot_path)
+          System.loadELF(boot_path, 1)
         end
       end;
       HandleInput = function ()
@@ -1735,7 +1735,27 @@ end
             if type(System) == "table" and type(System.ensureCDFS) == "function" then
               System.ensureCDFS()
             end
-            UI.Notif_queue.add("Not Implemented Yet")
+            local dkwdrv_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+            local dkwdrv_exists = false
+            if type(doesFileExist) == "function" then
+              local okcall, exists = pcall(doesFileExist, dkwdrv_path)
+              dkwdrv_exists = okcall and exists == true
+            end
+            if not dkwdrv_exists and type(System) == "table" and type(System.openFile) == "function" then
+              local okfd, fd = pcall(System.openFile, dkwdrv_path, FREAD)
+              if okfd and type(fd) == "number" and fd >= 0 then
+                if type(System.closeFile) == "function" then
+                  pcall(System.closeFile, fd)
+                end
+                dkwdrv_exists = true
+              end
+            end
+            if not dkwdrv_exists then
+              UI.Notif_queue.add("mc0:/PS1_DKWDRV/DKWDRV.ELF not found")
+              return
+            end
+            UI.LAUNCHING = true
+            System.loadELF(dkwdrv_path, 1)
           end --because we still dont support SMB
         end
       end


### PR DESCRIPTION
### Motivation
- BOOT.ELF should be chainloaded without passing its own path as an argv string so it receives no extra args when launched. 
- The main menu needs a direct chainload path for the “Disc (DKWDRV)” option to boot `mc0:/PS1_DKWDRV/DKWDRV.ELF` when present.

### Description
- Changed the `UI.Modal.LaunchBootElf` loader call from `System.loadELF(boot_path, 1, boot_path)` to `System.loadELF(boot_path, 1)` to remove the extra argv payload. 
- Implemented `UI.MainMenu` handling for `OPT == 7` to probe `mc0:/PS1_DKWDRV/DKWDRV.ELF` using the existing `doesFileExist` and `System.openFile(..., FREAD)` pattern, show `"mc0:/PS1_DKWDRV/DKWDRV.ELF not found"` if missing, and, if found, set `UI.LAUNCHING = true` and call `System.loadELF("mc0:/PS1_DKWDRV/DKWDRV.ELF", 1)`. 
- Kept the existing `System.ensureCDFS()` call and preserved all notifications, modal behavior, and `reboot_iop` value (`1`). 
- Only file modified: `bin/POPSLDR/ui.lua` and changes are localized to `UI.Modal.LaunchBootElf` and the `OPT == 7` branch in `UI.MainMenu.Play()`.

### Testing
- Ran `apply_patch` and staging/commit commands which completed successfully and produced the commit `Fix BOOT.ELF launch args and add DKWDRV chainload`. 
- Verified repository state with `git status --short` and `git diff -- bin/POPSLDR/ui.lua`, which showed only the intended localized changes. 
- Confirmed patch contents with `git show --stat --oneline HEAD` and `git show -- bin/POPSLDR/ui.lua`, both of which succeeded and display the updated loader call and the new DKWDRV probe/chainload logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d9913308832190beea0250f766ae)