### PR TITLE
Short-circuit mc0:/ and mc1:/ paths in resolve_exec_path

### DIFF
--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -34,12 +34,21 @@ static bool build_host_alt_path(const char *filename, char *out, size_t out_size
 
 static int resolve_exec_path(const char *filename, char *out, size_t out_size) {
 	struct stat buffer;
+	if (filename != NULL && (strncmp(filename, "mc0:/", 5) == 0 || strncmp(filename, "mc1:/", 5) == 0)) {
+		snprintf(out, out_size, "%s", filename);
+		return 0;
+	}
 	if (stat(filename, &buffer) == 0) {
 		snprintf(out, out_size, "%s", filename);
 		return 0;
 	}
-	if (build_host_alt_path(filename, out, out_size) && stat(out, &buffer) == 0) {
-		return 0;
+	if (build_host_alt_path(filename, out, out_size)) {
+		if (strncmp(out, "mc0:/", 5) == 0 || strncmp(out, "mc1:/", 5) == 0) {
+			return 0;
+		}
+		if (stat(out, &buffer) == 0) {
+			return 0;
+		}
 	}
 	return -1;
 }


### PR DESCRIPTION
### Motivation
- ELF launch from memory card paths (`mc0:/...` / `mc1:/...`) can fail because `stat()` is unreliable on mc paths, causing black-screen launches while POPSTARTER still works.
- The loader must accept memory-card paths directly without attempting `stat()` to match the guaranteed locations `mc0:/BOOT/BOOT.ELF` and `mc0:/PS1_DKWDRV/DKWDRV.ELF`.

### Description
- Added an early check in `resolve_exec_path()` to copy `filename` to `out` and return success if `filename` starts with `mc0:/` or `mc1:/` before any `stat()` call.
- Preserved existing behavior for non-mc paths by keeping the `stat(filename)` check unchanged.
- Applied the same mc short-circuit to the `host_alt` path produced by `build_host_alt_path()` so that if the alt resolves to `mc0:/` or `mc1:/` it is accepted without `stat()`; otherwise existing `host_alt` `stat()` logic still runs.
- Only `src/elf_loader/src/elf.c` was modified and only `resolve_exec_path()` logic was changed.

### Testing
- Ran `git show --stat --oneline HEAD` and it completed successfully showing the change summary.
- Ran `git show -- src/elf_loader/src/elf.c` and it completed successfully showing the updated file diff.
- Ran `git show --name-only --oneline --pretty=format: HEAD` and it completed successfully confirming only `src/elf_loader/src/elf.c` was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a422690e848321ba5923a7167f71a1)