### PR TITLE
Unify POPSTARTER UI assets to *.bdma and fix build/embed/CI references

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -86,15 +86,9 @@ jobs:
           req bin/POPSLDR/list.icn
           req bin/POPSLDR/copy.icn
           req bin/POPSLDR/del.icn
-          req bin/POPSLDR/icon.sys.mmce
-          req bin/POPSLDR/icon.sys.mx4sio
-          req bin/POPSLDR/icon.sys.usbexfat
-          req bin/POPSLDR/list.icn.mmce
-          req bin/POPSLDR/list.icn.mx4sio
-          req bin/POPSLDR/list.icn.usbexfat
-          req bin/POPSLDR/del.icn.mmce
-          req bin/POPSLDR/del.icn.mx4sio
-          req bin/POPSLDR/del.icn.usbexfat
+          req bin/POPSLDR/icon.sys.bdma
+          req bin/POPSLDR/list.icn.bdma
+          req bin/POPSLDR/del.icn.bdma
           req bin/POPSLDR/usbd.irx.mmce
           req bin/POPSLDR/usbd.irx.mx4sio
           req bin/POPSLDR/usbd.irx.usbexfat
@@ -114,15 +108,9 @@ jobs:
           cp -f bin/POPSLDR/list.icn dist_root/PS1_POPSLOADER/list.icn
           cp -f bin/POPSLDR/copy.icn dist_root/PS1_POPSLOADER/copy.icn
           cp -f bin/POPSLDR/del.icn dist_root/PS1_POPSLOADER/del.icn
-          cp -f bin/POPSLDR/icon.sys.mmce dist_root/PS1_POPSLOADER/icon.sys.mmce
-          cp -f bin/POPSLDR/icon.sys.mx4sio dist_root/PS1_POPSLOADER/icon.sys.mx4sio
-          cp -f bin/POPSLDR/icon.sys.usbexfat dist_root/PS1_POPSLOADER/icon.sys.usbexfat
-          cp -f bin/POPSLDR/list.icn.mmce dist_root/PS1_POPSLOADER/list.icn.mmce
-          cp -f bin/POPSLDR/list.icn.mx4sio dist_root/PS1_POPSLOADER/list.icn.mx4sio
-          cp -f bin/POPSLDR/list.icn.usbexfat dist_root/PS1_POPSLOADER/list.icn.usbexfat
-          cp -f bin/POPSLDR/del.icn.mmce dist_root/PS1_POPSLOADER/del.icn.mmce
-          cp -f bin/POPSLDR/del.icn.mx4sio dist_root/PS1_POPSLOADER/del.icn.mx4sio
-          cp -f bin/POPSLDR/del.icn.usbexfat dist_root/PS1_POPSLOADER/del.icn.usbexfat
+          cp -f bin/POPSLDR/icon.sys.bdma dist_root/PS1_POPSLOADER/icon.sys.bdma
+          cp -f bin/POPSLDR/list.icn.bdma dist_root/PS1_POPSLOADER/list.icn.bdma
+          cp -f bin/POPSLDR/del.icn.bdma dist_root/PS1_POPSLOADER/del.icn.bdma
           cp -f bin/POPSLDR/usbd.irx.mmce dist_root/PS1_POPSLOADER/usbd.irx.mmce
           cp -f bin/POPSLDR/usbd.irx.mx4sio dist_root/PS1_POPSLOADER/usbd.irx.mx4sio
           cp -f bin/POPSLDR/usbd.irx.usbexfat dist_root/PS1_POPSLOADER/usbd.irx.usbexfat
@@ -159,17 +147,11 @@ jobs:
               "PS1_POPSLOADER/boot.adp",
               "PS1_POPSLOADER/copy.icn",
               "PS1_POPSLOADER/del.icn",
-              "PS1_POPSLOADER/del.icn.mmce",
-              "PS1_POPSLOADER/del.icn.mx4sio",
-              "PS1_POPSLOADER/del.icn.usbexfat",
+              "PS1_POPSLOADER/del.icn.bdma",
               "PS1_POPSLOADER/icon.sys",
-              "PS1_POPSLOADER/icon.sys.mmce",
-              "PS1_POPSLOADER/icon.sys.mx4sio",
-              "PS1_POPSLOADER/icon.sys.usbexfat",
+              "PS1_POPSLOADER/icon.sys.bdma",
               "PS1_POPSLOADER/list.icn",
-              "PS1_POPSLOADER/list.icn.mmce",
-              "PS1_POPSLOADER/list.icn.mx4sio",
-              "PS1_POPSLOADER/list.icn.usbexfat",
+              "PS1_POPSLOADER/list.icn.bdma",
               "PS1_POPSLOADER/title.cfg",
               "PS1_POPSLOADER/usbd.irx.mmce",
               "PS1_POPSLOADER/usbd.irx.mx4sio",

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,8 @@ EMBEDDED_RSC = boot.o builtin_font.o \
 	asset_start_png.o asset_triangle_png.o asset_circle_png.o asset_cross_png.o asset_r2_png.o asset_square_png.o \
 	asset_system_lua.o asset_ui_lua.o asset_images_lua.o asset_pops_profiles_lua.o \
 	asset_usbd_irx_usbexfat.o asset_usbhdfsd_irx_usbexfat.o asset_usbd_irx_mx4sio.o asset_usbhdfsd_irx_mx4sio.o \
-	asset_usbd_irx_mmce.o asset_usbhdfsd_irx_mmce.o asset_icon_sys_mx4sio.o asset_list_icn_mx4sio.o asset_del_icn_mx4sio.o \
-	asset_icon_sys_mmce.o asset_list_icn_mmce.o asset_del_icn_mmce.o asset_icon_sys_usbexfat.o asset_list_icn_usbexfat.o \
-	asset_del_icn_usbexfat.o
+	asset_usbd_irx_mmce.o asset_usbhdfsd_irx_mmce.o \
+	asset_icon_sys_bdma.o asset_list_icn_bdma.o asset_del_icn_bdma.o
 
 EE_OBJS = $(APP_CORE) $(LUA_LIBS) $(IOP_MODULES) $(EMBEDDED_RSC)
 
@@ -182,24 +181,12 @@ $(EE_ASM_DIR)asset_usbd_irx_mmce.c: bin/POPSLDR/usbd.irx.mmce | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_usbd_irx_mmce
 $(EE_ASM_DIR)asset_usbhdfsd_irx_mmce.c: bin/POPSLDR/usbhdfsd.irx.mmce | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ asset_usbhdfsd_irx_mmce
-$(EE_ASM_DIR)asset_icon_sys_mx4sio.c: bin/POPSLDR/icon.sys.mx4sio | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_icon_sys_mx4sio
-$(EE_ASM_DIR)asset_list_icn_mx4sio.c: bin/POPSLDR/list.icn.mx4sio | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_list_icn_mx4sio
-$(EE_ASM_DIR)asset_del_icn_mx4sio.c: bin/POPSLDR/del.icn.mx4sio | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_del_icn_mx4sio
-$(EE_ASM_DIR)asset_icon_sys_mmce.c: bin/POPSLDR/icon.sys.mmce | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_icon_sys_mmce
-$(EE_ASM_DIR)asset_list_icn_mmce.c: bin/POPSLDR/list.icn.mmce | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_list_icn_mmce
-$(EE_ASM_DIR)asset_del_icn_mmce.c: bin/POPSLDR/del.icn.mmce | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_del_icn_mmce
-$(EE_ASM_DIR)asset_icon_sys_usbexfat.c: bin/POPSLDR/icon.sys.usbexfat | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_icon_sys_usbexfat
-$(EE_ASM_DIR)asset_list_icn_usbexfat.c: bin/POPSLDR/list.icn.usbexfat | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_list_icn_usbexfat
-$(EE_ASM_DIR)asset_del_icn_usbexfat.c: bin/POPSLDR/del.icn.usbexfat | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ asset_del_icn_usbexfat
+$(EE_ASM_DIR)asset_icon_sys_bdma.c: bin/POPSLDR/icon.sys.bdma | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_icon_sys_bdma
+$(EE_ASM_DIR)asset_list_icn_bdma.c: bin/POPSLDR/list.icn.bdma | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_list_icn_bdma
+$(EE_ASM_DIR)asset_del_icn_bdma.c: bin/POPSLDR/del.icn.bdma | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ asset_del_icn_bdma
 
 #------------------------------------------------------------------#
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -418,10 +418,12 @@ local POPSTARTER_PACK_ROOT = PLDR.POPSTARTER_DIR
 local BDMA_MODE_MARKER_PATH = POPSTARTER_PACK_ROOT.."/.pldr_bdma_mode"
 local BDMA_COPY_FILES = {
   "usbd.irx",
-  "usbhdfsd.irx",
-  "icon.sys",
-  "list.icn",
-  "del.icn"
+  "usbhdfsd.irx"
+}
+local BDMA_UI_FILES = {
+  { src = "icon.sys.bdma", dst = "icon.sys" },
+  { src = "list.icn.bdma", dst = "list.icn" },
+  { src = "del.icn.bdma", dst = "del.icn" }
 }
 local BDMA_SUFFIX = {
   USBEXFAT = ".usbexfat",
@@ -1078,6 +1080,9 @@ end
 
 function PLDR.ApplyBdmaMode(mode_key)
   local selected = mode_key or "FAT32"
+  if not PLDR.EnsurePopstarterUiAssets() then
+    return false
+  end
   if not PLDR.EnsurePopstarterDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then
       UI.Notif_queue.add("Cannot access mc0:/POPSTARTER")
@@ -1136,25 +1141,18 @@ function PLDR.ApplyBdmaMode(mode_key)
         return false
       end
       local dest = POPSTARTER_PACK_ROOT.."/"..name
-      local expected = string.len(bytes)
-      local current_size = GetFileSizeSafe(dest)
-      if current_size == nil or current_size ~= expected then
-        local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
-        if not ok_write or not wrote then
-          had_failure = true
-          return false
-        end
+      local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
+      if not ok_write or not wrote then
+        had_failure = true
+        return false
       end
     else
       local dest = POPSTARTER_PACK_ROOT.."/"..name
       local src_size = GetFileSizeSafe(source)
-      local dst_size = GetFileSizeSafe(dest)
-      if src_size == nil or dst_size == nil or src_size ~= dst_size then
-        local ok, copied = pcall(CopyExternalAtomicBounded, source, dest, src_size)
-        if not ok or not copied then
-          had_failure = true
-          return false
-        end
+      local ok, copied = pcall(CopyExternalAtomicBounded, source, dest, src_size)
+      if not ok or not copied then
+        had_failure = true
+        return false
       end
     end
   end
@@ -1162,6 +1160,67 @@ function PLDR.ApplyBdmaMode(mode_key)
     return false
   end
   WriteBdmaModeMarker(selected)
+  return true
+end
+
+function PLDR.EnsurePopstarterUiAssets()
+  if not PLDR.EnsurePopstarterDir() then
+    if UI ~= nil and UI.Notif_queue ~= nil then
+      UI.Notif_queue.add("Cannot access mc0:/POPSTARTER")
+    end
+    return false
+  end
+
+  if not PLDR.EnsureBackendForAppDir() then
+    if UI ~= nil and UI.Notif_queue ~= nil then
+      UI.Notif_queue.add("BDMA source backend not ready:\n"..APP_DIR_NORM)
+    end
+    return false
+  end
+
+  for i = 1, #BDMA_UI_FILES do
+    local asset = BDMA_UI_FILES[i]
+    local paths = PLDR.BdmaSourceCandidates(asset.src)
+    local fd, source = PLDR.TryOpenFirst(paths)
+    if fd ~= nil and (type(fd) ~= "number" or fd >= 0) then
+      System.closeFile(fd)
+    end
+
+    local dest = POPSTARTER_PACK_ROOT.."/"..asset.dst
+    if source == nil then
+      local bytes = nil
+      if type(System) == "table" and type(System.getEmbeddedAsset) == "function" then
+        local ok_embedded, embedded = pcall(System.getEmbeddedAsset, asset.src)
+        if ok_embedded and embedded ~= nil then
+          bytes = embedded
+        end
+      end
+      if bytes == nil then
+        if UI ~= nil and UI.Notif_queue ~= nil then
+          UI.Notif_queue.add("Missing BDMA UI source (tried):\n"..table.concat(paths, "\n"))
+        end
+        return false
+      end
+      local expected = string.len(bytes)
+      local current_size = GetFileSizeSafe(dest)
+      if current_size == nil or current_size ~= expected then
+        local ok_write, wrote = pcall(WriteBytesAtomicBounded, bytes, dest)
+        if not ok_write or not wrote then
+          return false
+        end
+      end
+    else
+      local src_size = GetFileSizeSafe(source)
+      local dst_size = GetFileSizeSafe(dest)
+      if src_size == nil or dst_size == nil or src_size ~= dst_size then
+        local ok_copy, copied = pcall(CopyExternalAtomicBounded, source, dest, src_size)
+        if not ok_copy or not copied then
+          return false
+        end
+      end
+    end
+  end
+
   return true
 end
 

--- a/src/embed_assets.cpp
+++ b/src/embed_assets.cpp
@@ -73,24 +73,12 @@ extern unsigned char asset_usbd_irx_mmce[];
 extern unsigned int size_asset_usbd_irx_mmce;
 extern unsigned char asset_usbhdfsd_irx_mmce[];
 extern unsigned int size_asset_usbhdfsd_irx_mmce;
-extern unsigned char asset_icon_sys_mx4sio[];
-extern unsigned int size_asset_icon_sys_mx4sio;
-extern unsigned char asset_list_icn_mx4sio[];
-extern unsigned int size_asset_list_icn_mx4sio;
-extern unsigned char asset_del_icn_mx4sio[];
-extern unsigned int size_asset_del_icn_mx4sio;
-extern unsigned char asset_icon_sys_mmce[];
-extern unsigned int size_asset_icon_sys_mmce;
-extern unsigned char asset_list_icn_mmce[];
-extern unsigned int size_asset_list_icn_mmce;
-extern unsigned char asset_del_icn_mmce[];
-extern unsigned int size_asset_del_icn_mmce;
-extern unsigned char asset_icon_sys_usbexfat[];
-extern unsigned int size_asset_icon_sys_usbexfat;
-extern unsigned char asset_list_icn_usbexfat[];
-extern unsigned int size_asset_list_icn_usbexfat;
-extern unsigned char asset_del_icn_usbexfat[];
-extern unsigned int size_asset_del_icn_usbexfat;
+extern unsigned char asset_icon_sys_bdma[];
+extern unsigned int size_asset_icon_sys_bdma;
+extern unsigned char asset_list_icn_bdma[];
+extern unsigned int size_asset_list_icn_bdma;
+extern unsigned char asset_del_icn_bdma[];
+extern unsigned int size_asset_del_icn_bdma;
 
 #define ASSET_ENTRY(key_name, symbol_name) { key_name, symbol_name, (size_t)size_##symbol_name }
 
@@ -127,15 +115,9 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("usbhdfsd.irx.mx4sio", asset_usbhdfsd_irx_mx4sio),
 	ASSET_ENTRY("usbd.irx.mmce", asset_usbd_irx_mmce),
 	ASSET_ENTRY("usbhdfsd.irx.mmce", asset_usbhdfsd_irx_mmce),
-	ASSET_ENTRY("icon.sys.mx4sio", asset_icon_sys_mx4sio),
-	ASSET_ENTRY("list.icn.mx4sio", asset_list_icn_mx4sio),
-	ASSET_ENTRY("del.icn.mx4sio", asset_del_icn_mx4sio),
-	ASSET_ENTRY("icon.sys.mmce", asset_icon_sys_mmce),
-	ASSET_ENTRY("list.icn.mmce", asset_list_icn_mmce),
-	ASSET_ENTRY("del.icn.mmce", asset_del_icn_mmce),
-	ASSET_ENTRY("icon.sys.usbexfat", asset_icon_sys_usbexfat),
-	ASSET_ENTRY("list.icn.usbexfat", asset_list_icn_usbexfat),
-	ASSET_ENTRY("del.icn.usbexfat", asset_del_icn_usbexfat),
+	ASSET_ENTRY("icon.sys.bdma", asset_icon_sys_bdma),
+	ASSET_ENTRY("list.icn.bdma", asset_list_icn_bdma),
+	ASSET_ENTRY("del.icn.bdma", asset_del_icn_bdma),
 
 
 	ASSET_ENTRY("POPSLDR/IMG/USB.png", asset_usb_png),
@@ -170,15 +152,9 @@ static const embedded_asset_t g_embedded_assets[] = {
 	ASSET_ENTRY("POPSLDR/usbhdfsd.irx.mx4sio", asset_usbhdfsd_irx_mx4sio),
 	ASSET_ENTRY("POPSLDR/usbd.irx.mmce", asset_usbd_irx_mmce),
 	ASSET_ENTRY("POPSLDR/usbhdfsd.irx.mmce", asset_usbhdfsd_irx_mmce),
-	ASSET_ENTRY("POPSLDR/icon.sys.mx4sio", asset_icon_sys_mx4sio),
-	ASSET_ENTRY("POPSLDR/list.icn.mx4sio", asset_list_icn_mx4sio),
-	ASSET_ENTRY("POPSLDR/del.icn.mx4sio", asset_del_icn_mx4sio),
-	ASSET_ENTRY("POPSLDR/icon.sys.mmce", asset_icon_sys_mmce),
-	ASSET_ENTRY("POPSLDR/list.icn.mmce", asset_list_icn_mmce),
-	ASSET_ENTRY("POPSLDR/del.icn.mmce", asset_del_icn_mmce),
-	ASSET_ENTRY("POPSLDR/icon.sys.usbexfat", asset_icon_sys_usbexfat),
-	ASSET_ENTRY("POPSLDR/list.icn.usbexfat", asset_list_icn_usbexfat),
-	ASSET_ENTRY("POPSLDR/del.icn.usbexfat", asset_del_icn_usbexfat)
+	ASSET_ENTRY("POPSLDR/icon.sys.bdma", asset_icon_sys_bdma),
+	ASSET_ENTRY("POPSLDR/list.icn.bdma", asset_list_icn_bdma),
+	ASSET_ENTRY("POPSLDR/del.icn.bdma", asset_del_icn_bdma)
 };
 
 static const embedded_asset_t *embedded_find(const char *key)


### PR DESCRIPTION
### Motivation
- Consolidate POPSTARTER-pack UI assets into a single `*.bdma` pool so UI files are shared across BDMA modes and avoid maintaining per-mode duplicates. 
- Repair build/embed/CI references that still expected removed per-mode UI filenames so CI packaging and embedding succeed with the new naming. 
- Enforce marker-driven IRX switching semantics (no filesize-based skipping) while preserving existing FAT32 and mass/driver behaviors. 

### Description
- Added `PLDR.EnsurePopstarterUiAssets()` in `bin/POPSLDR/system.lua` to install `icon.sys.bdma -> icon.sys`, `list.icn.bdma -> list.icn`, and `del.icn.bdma -> del.icn` into `mc0:/POPSTARTER/` using existing atomic writers and allowing a size-match skip only for these UI files. 
- Made `PLDR.ApplyBdmaMode()` always call `EnsurePopstarterUiAssets()` first and kept BDMA IRX install logic marker-driven so IRX writes are not decided by filesize comparisons, and FAT32 still only deletes `usbd.irx` and `usbhdfsd.irx`. 
- Updated `Makefile` to stop generating per-mode UI asset blobs and to generate/compile only `asset_icon_sys_bdma`, `asset_list_icn_bdma`, and `asset_del_icn_bdma`. 
- Updated `src/embed_assets.cpp` to expose new `asset_*_bdma` symbols and add `ASSET_ENTRY` records for both `"<name>.bdma"` and `"POPSLDR/<name>.bdma"` keys for `icon.sys`, `list.icn`, and `del.icn`. 
- Updated `.github/workflows/compilation.yml` to expect and package `icon.sys.bdma`, `list.icn.bdma`, and `del.icn.bdma` (removed per-mode file checks and copies) while leaving POPSLoader’s own packaged assets (`bin/POPSLDR/icon.sys`, `list.icn`, `del.icn`, `copy.icn`) untouched. 
- No changes to mass/driver detection logic or any USB/MX4SIO/mass handling code. 

### Testing
- Ran an `rg` search to verify removed per-mode UI names and symbols are no longer referenced with: `rg -n "icon\.sys\.(mx4sio|mmce|usbexfat)|list\.icn\.(mx4sio|mmce|usbexfat)|del\.icn\.(mx4sio|mmce|usbexfat)|asset_icon_sys_(mx4sio|mmce|usbexfat)|asset_list_icn_(mx4sio|mmce|usbexfat)|asset_del_icn_(mx4sio|mmce|usbexfat)" Makefile src/embed_assets.cpp .github/workflows/compilation.yml bin/POPSLDR/system.lua` and confirmed no matches. 
- Attempted a local build with `make clean elfloader all` which failed due to missing toolchain/include makefile (`/samples/Makefile.eeglobal`) in this environment, which is an external/toolchain issue and not a logic/regression failure in the changes. 
- Commit recorded as: `859d6cd Unify POPSTARTER UI assets to bdma pool references` with stats: `4 files changed, 101 insertions(+), 97 deletions(-)`, shown as `git show --stat --oneline HEAD` output: `859d6cd Unify POPSTARTER UI assets to bdma pool references
 .github/workflows/compilation.yml | 36 +++++------------
 Makefile                          | 29 ++++---------
 bin/POPSLDR/system.lua            | 85 +++++++++++++++++++++++++++++++++------
 src/embed_assets.cpp              | 48 ++++++----------------`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a459caa27883219856061c2eb3529c)