### PR TITLE
ui: add minimal DKWDRV modal and direct BOOT chainload

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -815,6 +815,21 @@ UI = {
         UI.Modal.triangle_action = UI.Modal.LaunchBootElf
         UI.Modal.ignore_until_release = true
       end;
+      OpenDKWDRV = function ()
+        UI.Modal.active = true
+        UI.Modal.title = "Disc (DKWDRV)"
+        UI.Modal.body = "Launch DKWDRV?"
+        UI.Modal.options = {"Yes", "Cancel"}
+        UI.Modal.confirm_action = function ()
+          local elf_path = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
+          UI.LAUNCHING = true
+          System.loadELF(elf_path, 1, elf_path)
+          return
+        end
+        UI.Modal.cancel_action = UI.Modal.Close
+        UI.Modal.triangle_action = nil
+        UI.Modal.ignore_until_release = true
+      end;
       OpenDeviceLock = function (reason, active, target)
         local active_name = UI.device_lock_name(active)
         local target_name = UI.device_lock_name(target)
@@ -846,42 +861,10 @@ UI = {
         System.exitToBrowser()
       end;
       LaunchBootElf = function ()
-        local candidates = {
-          "mc0:/BOOT/BOOT.ELF",
-          "mc1:/BOOT/BOOT.ELF"
-        }
-        local boot_path = nil
-        if type(doesFileExist) == "function" then
-          for _, path in ipairs(candidates) do
-            local okcall, exists = pcall(doesFileExist, path)
-            if okcall and exists == true then
-              boot_path = path
-              break
-            end
-          end
-        end
-        if boot_path == nil and type(System) == "table" and type(System.openFile) == "function" then
-          for _, path in ipairs(candidates) do
-            local okfd, fd = pcall(System.openFile, path, FREAD)
-            if okfd and type(fd) == "number" and fd >= 0 then
-              if type(System.closeFile) == "function" then
-                pcall(System.closeFile, fd)
-              end
-              boot_path = path
-              break
-            end
-          end
-        end
-        if boot_path == nil then
-          if UI.Notif_queue ~= nil and type(UI.Notif_queue.add) == "function" then
-            UI.Notif_queue.add("mc?:/BOOT/BOOT.ELF not found")
-          end
-          return
-        end
-        if type(System) == "table" and type(System.loadELF) == "function" then
-          UI.LAUNCHING = true
-          System.loadELF(boot_path, 1, boot_path)
-        end
+        local elf_path = "mc0:/BOOT/BOOT.ELF"
+        UI.LAUNCHING = true
+        System.loadELF(elf_path, 1, elf_path)
+        return
       end;
       HandleInput = function ()
         if not UI.Modal.active then return end
@@ -1624,7 +1607,7 @@ UI = {
             if type(System) == "table" and type(System.ensureCDFS) == "function" then
               System.ensureCDFS()
             end
-            UI.Notif_queue.add("Not Implemented Yet")
+            UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
         end
       end


### PR DESCRIPTION
### Motivation
- Provide a minimal, explicit ELF chainload path for the Disc (DKWDRV) and BOOT flows while keeping all existing game launch logic untouched.
- Allow the Disc menu item (OPT == 7) to present a confirmation before directly chainloading the DKWDRV ELF.
- Keep changes minimal and scoped to the UI layer so device routing, POPSTARTER calls, and mass/USB/MMCE logic remain unchanged.

### Description
- Added `UI.Modal.OpenDKWDRV()` which shows a "Disc (DKWDRV)" confirmation modal and directly calls `System.loadELF("mc0:/PS1_DKWDRV/DKWDRV.ELF", 1, elf_path)` inside the YES handler followed by `return`.
- Replaced the body of `UI.Modal.LaunchBootElf()` with a direct chainload that sets `UI.LAUNCHING = true` and calls `System.loadELF("mc0:/BOOT/BOOT.ELF", 1, elf_path)` followed by `return`.
- Wired Main Menu `UI.MainMenu.OPT == 7` to call `UI.Modal.OpenDKWDRV()` while preserving the existing `System.ensureCDFS()` call, and limited edits to only `bin/POPSLDR/ui.lua`.

### Testing
- Executed `grep -n "OpenDKWDRV" bin/POPSLDR/ui.lua`, `grep -n "LaunchBootElf" bin/POPSLDR/ui.lua`, `grep -n "mc0:/PS1_DKWDRV/DKWDRV.ELF" bin/POPSLDR/ui.lua`, `grep -n "mc0:/BOOT/BOOT.ELF" bin/POPSLDR/ui.lua`, and `grep -n "System.loadELF" bin/POPSLDR/ui.lua` and each command returned the expected occurrences in the modified file.
- Performed a static check to confirm only `bin/POPSLDR/ui.lua` was modified.
- No automated runtime tests were added or modified; the edits are minimal and intended to be exercised in the target environment where `System.loadELF` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b454ebac832197dcc05a3ffbc076)