### PR TITLE
Honor IOP reboot on BOOT.ELF exit with minimal loader change

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -863,7 +863,7 @@ UI = {
       LaunchBootElf = function ()
         local elf_path = "mc0:/BOOT/BOOT.ELF"
         UI.LAUNCHING = true
-        System.loadELF(elf_path, 1, elf_path)
+        System.loadELF(elf_path, 1)
         return
       end;
       HandleInput = function ()

--- a/src/elf_loader/include/elf-loader.h
+++ b/src/elf_loader/include/elf-loader.h
@@ -23,6 +23,7 @@ extern "C" {
 // Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileRebootIOP(const char *filename, int argc, char *argv[]);
 
 /** Modify argv[0] when partition info should be kept
  *

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <kernel.h>
 #include <loadfile.h>
+#include <iopcontrol.h>
 #include <sys/stat.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -206,6 +207,44 @@ int LoadELFFromFileWithPartition(const char *filename, int argc, char *argv[]) {
 int LoadELFFromFile(const char *filename, int argc, char *argv[])
 {
 	return LoadELFFromFileWithPartition(filename, argc, argv);
+}
+
+
+int LoadELFFromFileRebootIOP(const char *filename, int argc, char *argv[])
+{
+	t_ExecData elfdata;
+	char resolved_path[256];
+	int ret;
+
+	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {
+		return -1;
+	}
+
+	SifInitRpc(0);
+	SifLoadFileInit();
+	ret = SifLoadElf(resolved_path, &elfdata);
+	SifLoadFileExit();
+
+	if (ret != 0 || elfdata.epc == 0) {
+		return -2;
+	}
+
+	FlushCache(0);
+	FlushCache(2);
+
+	while (!SifIopReset(NULL, 0)) {}
+	while (!SifIopSync()) {}
+
+	SifInitRpc(0);
+	SifLoadFileInit();
+	SifLoadModule("rom0:SIO2MAN", 0, NULL);
+	SifLoadModule("rom0:MCMAN", 0, NULL);
+	SifLoadModule("rom0:MCSERV", 0, NULL);
+	SifLoadFileExit();
+	SifExitRpc();
+
+	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+	return -3;
 }
 
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[])

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -943,6 +943,7 @@ static int lua_checkexist(lua_State *L){
 extern "C" {
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileRebootIOP(const char *filename, int argc, char *argv[]);
 }
 static int lua_loadELF(lua_State *L)
 {
@@ -954,19 +955,16 @@ static int lua_loadELF(lua_State *L)
 	int extra_args = argc - 2;
 	static char selector_buf[256];
 	static char *argv_static[2];
-	printf("# Loading ELF '%s' iop_reboot=%d, extra_args=%d\n", elftoload, rebootIOP, extra_args);
 	if (extra_args > 0) {
 		const char *selector = luaL_checkstring(L, 3);
 		snprintf(selector_buf, sizeof(selector_buf), "%s", selector ? selector : "");
 		argv_static[0] = selector_buf;
 		argv_static[1] = NULL;
-		printf("# Loading ELF argv0='%s' argc=1\n", argv_static[0]);
 		int rc = LoadELFFromFileExecPS2(elftoload, 1, argv_static);
 		lua_pushinteger(L, rc);
 		return 1;
 	}
-	printf("# Loading ELF argv0 default (argc=0)\n");
-	int rc = LoadELFFromFile(elftoload, 0, NULL);
+	int rc = rebootIOP ? LoadELFFromFileRebootIOP(elftoload, 0, NULL) : LoadELFFromFile(elftoload, 0, NULL);
 	lua_pushinteger(L, rc);
 	return 1;
 }


### PR DESCRIPTION
### Motivation
- BOOT.ELF chainloads were hanging on real hardware because the exit path always passed a selector arg and forced ExecPS2 mode, preventing an IOP reboot sequence.
- The intent is to make the smallest, safest change to ensure BOOT.ELF exits can trigger an IOP reset/reload when requested while preserving POPSTARTER selector behavior.

### Description
- Stop passing the selector argument when launching BOOT.ELF from the UI by changing `System.loadELF(elf_path, 1, elf_path)` to `System.loadELF(elf_path, 1)` in `bin/POPSLDR/ui.lua` so `extra_args == 0` for BOOT.ELF.
- Add a new ELF loader API `LoadELFFromFileRebootIOP(const char *filename, int argc, char *argv[])` (declared in `src/elf_loader/include/elf-loader.h`) that resolves the ELF, loads it, flushes caches, performs `SifIopReset`/`SifIopSync`, reloads minimal ROM modules, and calls `ExecPS2`.
- Update `lua_loadELF()` in `src/luasystem.cpp` to keep the `extra_args > 0` path identical (still calls `LoadELFFromFileExecPS2` to preserve POPSTARTER selector behavior) and to call `LoadELFFromFileRebootIOP(...)` when `extra_args == 0` and `reboot_iop` is non-zero; also removed the debug `printf` lines from this function.
- All changes are localized to the BOOT.ELF launch call site, the ELF loader (small helper), and the Lua-to-C branching logic to minimize blast radius and retain existing behavior elsewhere.

### Testing
- Attempted an automated full build with `make -j4`, which failed in this environment due to a missing PS2SDK make fragment (`/samples/Makefile.eeglobal`), so a local cross-build could not be completed here (build failure unrelated to the change in logic).
- Verified diffs and file updates (`ui.lua`, `src/luasystem.cpp`, `src/elf_loader/include/elf-loader.h`, `src/elf_loader/src/elf.c`) via repository inspection; no automated unit tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4df2f968c83218655d2e5e61e112c)