### PR TITLE
Harden BOOT.ELF launch handling in UI modal

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -44,6 +44,30 @@ local function SafeDoesFileExist(path)
   end
   return false
 end
+local function ResolveFirstExistingElf(candidates)
+  if type(candidates) ~= "table" then return nil end
+  for i = 1, #candidates do
+    local path = candidates[i]
+    if path ~= nil and path ~= "" then
+      local exists = false
+      if type(doesFileExist) == "function" then
+        local ok_exists, res = pcall(doesFileExist, path)
+        exists = ok_exists and res == true
+      elseif type(System) == "table" and type(System.openFile) == "function" and type(System.closeFile) == "function" then
+        local mode = FREAD or O_RDONLY
+        local ok_open, fd = pcall(System.openFile, path, mode)
+        if ok_open and type(fd) == "number" and fd >= 0 then
+          pcall(System.closeFile, fd)
+          exists = true
+        end
+      end
+      if exists then
+        return path
+      end
+    end
+  end
+  return nil
+end
 local function ExtractGameRelPath(entry)
   if entry == nil then return nil end
   local relpath = string.match(entry, "^[^|]+|(.+)$")
@@ -861,10 +885,25 @@ UI = {
         System.exitToBrowser()
       end;
       LaunchBootElf = function ()
-        local elf_path = "mc0:/BOOT/BOOT.ELF"
+        local elf_path = ResolveFirstExistingElf({
+          "mc0:/BOOT/BOOT2.ELF",
+          "mc0:/BOOT/BOOT.ELF",
+          "mc1:/BOOT/BOOT2.ELF",
+          "mc1:/BOOT/BOOT.ELF"
+        })
+        if elf_path == nil then
+          UI.LAUNCHING = false
+          UI.Notif_queue.add("mc?:/BOOT/BOOT2.ELF or BOOT.ELF not found")
+          return
+        end
         UI.LAUNCHING = true
-        System.loadELF(elf_path, 1, elf_path)
-        return
+        UI.Modal.Close()
+        local ok, rc = pcall(System.loadELF, elf_path, 1, elf_path)
+        if (not ok) or (type(rc) == "number" and rc < 0) then
+          UI.LAUNCHING = false
+          UI.Notif_queue.add("Failed to launch: "..elf_path)
+          return
+        end
       end;
       HandleInput = function ()
         if not UI.Modal.active then return end


### PR DESCRIPTION
### Motivation
- Fix a reported black-screen hang when selecting Exit -> BOOT.ELF caused by `UI.LAUNCHING` remaining true and `System.loadELF` being called without error/rc handling.
- Ensure the UI remains responsive when no BOOT ELF exists or when `System.loadELF` fails, matching the robustness from the known-good reference.

### Description
- Add a small file-local helper `ResolveFirstExistingElf(candidates)` that probes candidate ELF paths (using `doesFileExist` if available, otherwise `System.openFile`/`System.closeFile`) and returns the first existing path or `nil`.
- Update `UI.Modal.LaunchBootElf()` to resolve candidates in order: `mc0:/BOOT/BOOT2.ELF`, `mc0:/BOOT/BOOT.ELF`, `mc1:/BOOT/BOOT2.ELF`, `mc1:/BOOT/BOOT.ELF` before attempting to launch.
- If no candidate is found, clear `UI.LAUNCHING`, enqueue a notification (`mc?:/BOOT/BOOT2.ELF or BOOT.ELF not found`), and return without closing the UI.
- When an ELF is found, close the modal, set `UI.LAUNCHING = true`, call `System.loadELF` wrapped in `pcall`, and on `pcall` failure or negative numeric return reset `UI.LAUNCHING` and enqueue a `Failed to launch: <path>` notification.

### Testing
- Ran `git show --stat --oneline HEAD` which succeeded and shows the single-file change to `bin/POPSLDR/ui.lua`.
- Ran `git show -- bin/POPSLDR/ui.lua` and `git diff -- bin/POPSLDR/ui.lua` which succeeded and confirmed the intended minimal Lua-only edits.
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/ui.lua` but `luac` is not installed in this environment, so syntax was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e53a78608321b35170ae8ec26b17)