### PR TITLE
Add BOOT-only IOP-reboot chainload path and simplify BOOT resolver

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -44,6 +44,16 @@ local function SafeDoesFileExist(path)
   end
   return false
 end
+local function ResolveFirstExistingElf(candidates)
+  if candidates == nil then return nil end
+  for i = 1, #candidates do
+    local path = candidates[i]
+    if SafeDoesFileExist(path) then
+      return path
+    end
+  end
+  return nil
+end
 local function ExtractGameRelPath(entry)
   if entry == nil then return nil end
   local relpath = string.match(entry, "^[^|]+|(.+)$")
@@ -861,9 +871,19 @@ UI = {
         System.exitToBrowser()
       end;
       LaunchBootElf = function ()
-        local elf_path = "mc0:/BOOT/BOOT.ELF"
+        local elf_path = ResolveFirstExistingElf({
+          "mc0:/BOOT/BOOT2.ELF",
+          "mc0:/BOOT/BOOT.ELF",
+          "mc1:/BOOT/BOOT2.ELF",
+          "mc1:/BOOT/BOOT.ELF"
+        })
+        if elf_path == nil then
+          UI.Notify("BOOT.ELF not found", 120)
+          return
+        end
         UI.LAUNCHING = true
-        System.loadELF(elf_path, 1, elf_path)
+        UI.Modal.Close()
+        System.loadELFRebootIOP(elf_path, elf_path)
         return
       end;
       HandleInput = function ()

--- a/src/elf_loader/include/elf-loader.h
+++ b/src/elf_loader/include/elf-loader.h
@@ -23,6 +23,7 @@ extern "C" {
 // Before call this method be sure that you have previously called sbv_patch_disable_prefix_check();
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[]);
 
 /** Modify argv[0] when partition info should be kept
  *

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <kernel.h>
 #include <loadfile.h>
+#include <iopcontrol.h>
 #include <sys/stat.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -231,6 +232,47 @@ int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[])
 	if (ret != 0 || elfdata.epc == 0) {
 		return -2;
 	}
+
+	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
+	return -1;
+}
+
+
+int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[])
+{
+	t_ExecData elfdata;
+	char resolved_path[256];
+	int ret;
+
+	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {
+		return -1;
+	}
+
+	SifInitRpc(0);
+	SifLoadFileInit();
+	ret = SifLoadElf(resolved_path, &elfdata);
+	SifLoadFileExit();
+
+	if (ret != 0 || elfdata.epc == 0) {
+		return -2;
+	}
+
+	FlushCache(0);
+	while (!SifIopReset(NULL, 0)) {
+	}
+	while (!SifIopSync()) {
+	}
+
+	SifInitRpc(0);
+	SifLoadFileInit();
+	SifLoadModule("rom0:SIO2MAN", 0, NULL);
+	SifLoadModule("rom0:MCMAN", 0, NULL);
+	SifLoadModule("rom0:MCSERV", 0, NULL);
+	SifLoadFileExit();
+	SifExitRpc();
+
+	FlushCache(0);
+	FlushCache(2);
 
 	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc, argv);
 	return -1;

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -943,6 +943,7 @@ static int lua_checkexist(lua_State *L){
 extern "C" {
 int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
+int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[]);
 }
 static int lua_loadELF(lua_State *L)
 {
@@ -968,6 +969,26 @@ static int lua_loadELF(lua_State *L)
 	printf("# Loading ELF argv0 default (argc=0)\n");
 	int rc = LoadELFFromFile(elftoload, 0, NULL);
 	lua_pushinteger(L, rc);
+	return 1;
+}
+
+
+static int lua_loadELFRebootIOP(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc < 1) return luaL_error(L, "%s(path, argv0): not enough args", __FUNCTION__);
+	const char *elftoload = luaL_checkstring(L, 1);
+	if (argc >= 2 && !lua_isnil(L, 2)) {
+		static char argv0_buf[256];
+		static char *argv_static[2];
+		const char *argv0 = luaL_checkstring(L, 2);
+		snprintf(argv0_buf, sizeof(argv0_buf), "%s", argv0 ? argv0 : "");
+		argv_static[0] = argv0_buf;
+		argv_static[1] = NULL;
+		lua_pushinteger(L, LoadELFFromFileExecPS2RebootIOP(elftoload, 1, argv_static));
+		return 1;
+	}
+	lua_pushinteger(L, LoadELFFromFileExecPS2RebootIOP(elftoload, 0, NULL));
 	return 1;
 }
 
@@ -1273,6 +1294,7 @@ static const luaL_Reg System_functions[] = {
 	{"exitToBrowser",                  lua_exit},
 	{"getMCInfo",                 lua_getmcinfo},
 	{"loadELF",                 	lua_loadELF},
+	{"loadELFRebootIOP",        	lua_loadELFRebootIOP},
 	{"checkValidDisc",       lua_checkValidDisc},
 	{"getDiscType",             lua_getDiscType},
 	{"checkDiscTray",         lua_checkDiscTray},


### PR DESCRIPTION
### Motivation
- BETA-8 was black-screening when chainloading BOOT.ELF and the existing Lua-only probing was insufficient, so a BOOT-only path that reboots the IOP before ExecPS2 is required. 
- The BOOT path resolver contained duplicated probing logic and mode guessing, so it was simplified to a single, safe existence primitive.
- Changes must be minimal and localized while preserving DKWDRV and POPSTARTER behavior.

### Description
- Added `ResolveFirstExistingElf(candidates)` to `bin/POPSLDR/ui.lua` which iterates candidates and calls only `SafeDoesFileExist(path)` to pick the first existing BOOT ELF. 
- Updated `UI.Modal.LaunchBootElf()` in `bin/POPSLDR/ui.lua` to probe BOOTs in the order `mc0:/BOOT/BOOT2.ELF`, `mc0:/BOOT/BOOT.ELF`, `mc1:/BOOT/BOOT2.ELF`, `mc1:/BOOT/BOOT.ELF`, notify-and-return if none found, set `UI.LAUNCHING`, close the modal, and call the new `System.loadELFRebootIOP(boot_path, boot_path)` API. 
- Added `int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[])` declaration to `src/elf_loader/include/elf-loader.h`. 
- Implemented `LoadELFFromFileExecPS2RebootIOP` in `src/elf_loader/src/elf.c` to resolve the path, `SifInitRpc`/`SifLoadElf` the ELF, verify `epc`, `FlushCache(0)`, loop `SifIopReset`/`SifIopSync`, re-init RPC and reload `rom0:SIO2MAN`, `rom0:MCMAN`, `rom0:MCSERV`, `SifExitRpc`, flush caches, then `ExecPS2` (matching the proven loader sequence); it returns negative codes on error and does not add any logging. 
- Exposed a new Lua binding `System.loadELFRebootIOP(path, argv0?)` in `src/luasystem.cpp` which supports the BOOT use case exactly (argc=1 with argv0, or argc=0 with argv=NULL) and calls the new C API, leaving existing `System.loadELF()` unchanged and registering the new function in the `System` table. 
- All edits are localized to the four files: `bin/POPSLDR/ui.lua`, `src/luasystem.cpp`, `src/elf_loader/include/elf-loader.h`, and `src/elf_loader/src/elf.c`, and DKWDRV behavior and POPSTARTER launch paths were not modified.

### Testing
- Repository-level verification commands were executed to show the modified files and diffs, and those checks completed successfully. 
- No runtime or hardware automated tests were executed in this patch; the change implements the requested IOP-reset + ExecPS2 sequence mirroring the proven loader implementation and exposes a Lua API for the BOOT-only path. 
- A commit containing the changes was created successfully and the four target files were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e983de1c832183d979390d10f238)