### PR TITLE
Adjust intro splash and credits hold timings for boot sync

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -759,8 +759,10 @@ UI = {
 
         -- Start boot sound once; explicit holds must not be lengthened by audio duration.
         TryBootSound()
-        local SPLASH_HOLD_MS = 3000
-        local CREDITS_HOLD_MS = 4000
+        local SPLASH_HOLD_SEC = 4.0
+        local CREDITS_HOLD_SEC = 3.0
+        local SPLASH_HOLD_MS = SPLASH_HOLD_SEC * 1000
+        local CREDITS_HOLD_MS = CREDITS_HOLD_SEC * 1000
 
         StepFade(DrawSplash, 128, 0, FADE_IN_MS)
         StepHold(DrawSplash, SPLASH_HOLD_MS)


### PR DESCRIPTION
### Motivation
- Align the visual intro timing with the boot audio so the splash remains visible for 4.0s and the credits for 3.0s, without altering any existing fade/transition durations or other scene logic.

### Description
- In `UI.WelcomeDraw.Play` (file `bin/POPSLDR/ui.lua`) added `SPLASH_HOLD_SEC = 4.0` and `CREDITS_HOLD_SEC = 3.0`, converted them to milliseconds and used the existing `StepHold(...)` calls to enforce the holds, leaving `FADE_IN_MS`/`FADE_OUT_MS` and the transition flow unchanged; no other files or systems were modified.

### Testing
- Verified the change via `git show --stat --oneline HEAD` and `git show -- bin/POPSLDR/ui.lua` to confirm the commit and diff succeeded; attempted a Lua syntax check with `luac -p bin/POPSLDR/ui.lua` but `luac` is not installed in this environment (no runtime unit tests were available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f6c9abcc83218f2e4d182d7a1f94)