### PR TITLE
Prevent BOOT.ELF missing crash by aliasing `UI.Notify` to notification queue

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -372,6 +372,9 @@ UI = {
       end;
       msg = {};
     };
+    Notify = function (msg, _ms)
+      UI.Notif_queue.add(msg)
+    end;
     Footer = {
       order = {"triangle", "circle", "cross", "square"};
       order_with_r2 = {"triangle", "circle", "cross", "square"};


### PR DESCRIPTION
### Motivation
- A nil `UI.Notify` call during the BOOT.ELF missing path caused a crash; the intent is to post the same user-visible notification used elsewhere and return to UI without changing any ELF launch semantics.

### Description
- Add a minimal `UI.Notify` wrapper in `bin/POPSLDR/ui.lua` that forwards to `UI.Notif_queue.add(msg)` immediately after the `Notif_queue` definition, and make no other changes to BOOT/DKWDRV launch calls or parameters.

### Testing
- Verified the change and locations with `git show --stat --oneline HEAD`, `git diff`, `rg`, and `nl`/`sed` to confirm `UI.Notify` is present and that `LaunchBootElf` still uses `System.loadELFRebootIOP` while the DKWDRV flow still uses `System.loadELF`, and those inspections succeeded.
- Runtime acceptance tests that exercise removing `BOOT.ELF`/`DKWDRV.ELF` on a PS2/Enceladus target could not be executed in this container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5032124848321ad037ad55d9396c3)