### PR TITLE
Restore MX4SIO detection via mount-slot sdc scan

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -877,38 +877,27 @@ function PLDR.GetMassDriverName(index)
         return string.lower(driver)
       end
     end
-    if type(System.getMassBackendInfo) == "function" then
-      local ok, info = pcall(System.getMassBackendInfo, index)
-      if ok and type(info) == "table" then
-        local driver = info.driver
-        if type(driver) == "string" and driver ~= "" then
-          return string.lower(driver)
-        end
-      end
-    end
   end
   return nil
 end
 
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" or type(System.getMassBackendInfo) ~= "function" then
+  if type(System) ~= "table" then
     return nil
   end
 
   for pass = 1, 2 do
     pcall(PLDR.RefreshMassBackends)
-    for dev_index = 0, 15 do
-      local ok, info = pcall(System.getMassBackendInfo, dev_index)
-      if ok and type(info) == "table" then
-        local drv = info.driver
-        local parId = info.parId
-        if type(drv) == "string" and drv ~= "" and string.find(string.lower(drv), "sdc", 1, true) then
-          if type(parId) == "number" and parId >= 0 and parId <= 9 then
-            if parId == 0 then
-              return "mass:/"
-            end
-            return "mass"..tostring(parId)..":/"
-          end
+    for slot = 0, 9 do
+      local root = (slot == 0) and "mass:/" or ("mass"..slot..":/")
+      local mounted = true
+      if type(doesFolderExist) == "function" then
+        mounted = doesFolderExist(root)
+      end
+      if mounted then
+        local drv = PLDR.GetMassDriverName(slot)
+        if type(drv) == "string" and string.find(drv, "sdc", 1, true) then
+          return root
         end
       end
     end


### PR DESCRIPTION
### Motivation
- MX4SIO detection regressed because `mx4_root` could be nil when code relied on backend-info `parId` mapping, causing MX4 devices to be classified as USB; the intent is to identify MX4SIO strictly from mount-level driver names containing "sdc" and avoid backend-index vs mount-slot mismatches.

### Description
- Modified `bin/POPSLDR/system.lua` and limited changes to the two requested functions only.
- `PLDR.GetMassDriverName(index)` now uses only `System.getMassDriverName` and `System.getMassDriver` (plus existing cache) and the fallback to `System.getMassBackendInfo` was removed.
- `PLDR.GetMX4SIOMassRootNow()` now performs a bounded 2-pass scan of mount slots `mass:/` through `mass9:/`, optionally checks mount presence via `doesFolderExist`, calls `PLDR.GetMassDriverName(slot)`, identifies MX4 when the driver string contains `sdc`, returns the matching mount root immediately, and uses exactly one optional `System.sleep(0.05)` between passes.
- The function no longer uses `System.getMassBackendInfo()` or `parId` and makes no other behavioral changes beyond the requested scope.

### Testing
- Validated the code change with local diffs and file content checks using `git diff -- bin/POPSLDR/system.lua`, `git diff HEAD~1..HEAD -- bin/POPSLDR/system.lua`, and `git show --stat --oneline -1`, which all completed successfully.
- Inspected the updated file with `git show -- bin/POPSLDR/system.lua` to confirm the exact edits to the two functions and that no other files were modified.
- Changes were committed locally and the repository state reflects the single-file update; no runtime unit tests were available to run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bd8d15f48321ac2e7a07b92e2810)