### PR TITLE
Fix MX4SIO detection and prevent USB hotplug leakage

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -891,23 +891,51 @@ function PLDR.GetMassDriverName(index)
 end
 
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" or type(System.getMassBackendInfo) ~= "function" then
+  if type(System) ~= "table" then
     return nil
   end
 
+  local function resolveFromInfo(info, field)
+    if type(info) ~= "table" then
+      return nil
+    end
+
+    local name = info[field]
+    local parId = info.parId
+    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
+      if type(parId) == "number" and parId >= 0 and parId <= 9 then
+        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
+        if doesFolderExist(root) then
+          return root
+        end
+      end
+    end
+
+    return nil
+  end
+
+  local has_bdm_list = type(System.bdmList) == "function"
+
   for pass = 1, 2 do
     pcall(PLDR.RefreshMassBackends)
-    for dev_index = 0, 15 do
-      local ok, info = pcall(System.getMassBackendInfo, dev_index)
-      if ok and type(info) == "table" then
-        local drv = info.driver
-        local parId = info.parId
-        if type(drv) == "string" and drv ~= "" and string.find(string.lower(drv), "sdc", 1, true) then
-          if type(parId) == "number" and parId >= 0 and parId <= 9 then
-            if parId == 0 then
-              return "mass:/"
-            end
-            return "mass"..tostring(parId)..":/"
+
+    if has_bdm_list then
+      local ok, list = pcall(System.bdmList)
+      if ok and type(list) == "table" then
+        for i = 1, #list do
+          local root = resolveFromInfo(list[i], "name")
+          if root ~= nil then
+            return root
+          end
+        end
+      end
+    elseif type(System.getMassBackendInfo) == "function" then
+      for dev_index = 0, 15 do
+        local ok, info = pcall(System.getMassBackendInfo, dev_index)
+        if ok then
+          local root = resolveFromInfo(info, "driver")
+          if root ~= nil then
+            return root
           end
         end
       end
@@ -982,6 +1010,9 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
 
   if wanted == "usb" then
     local mx4_root = state.mx4_root
+    if mx4_root == nil then
+      mx4_root = PLDR.GetMX4SIOMassRootNow()
+    end
     local present = PLDR.GetPresentMassRootsBounded()
     for i = 1, #present do
       local root = present[i]


### PR DESCRIPTION
### Motivation
- MX4SIO detection could fail because the previous implementation scanned `System.getMassBackendInfo(index)` by fixed indexes (0..15), which breaks when backend `devNr` is non-contiguous after hotplug.
- After unplug/replug the MX4SIO device, its mass mount could be mis-identified and then appear on the USB page (leakage) because USB roots were not dynamically excluding the current sdc-backed mass root.
- The change should dynamically resolve which `mass:/` or `massN:/` corresponds to the MX4SIO (driver string containing `sdc`) on each page rebuild without touching unrelated flows.

### Description
- Rewrote `PLDR.GetMX4SIOMassRootNow()` to prefer `System.bdmList()` when available, iterating the returned entries and checking `info.name` for a case-insensitive literal `"sdc"` match, mapping `parId` into `mass:/` or `massN:/`, and verifying existence with `doesFolderExist` before returning a root.
- Added a small `resolveFromInfo` helper used for both `bdmList` entries (`name`) and legacy `getMassBackendInfo` (`driver`) to centralize detection and validation logic.
- Preserved bounded two-pass behavior with `PLDR.RefreshMassBackends` and a ~0.05s sleep between passes, and kept a safe fallback path that scans `System.getMassBackendInfo` only when `System.bdmList` is unavailable.
- Updated `PLDR.GetRootsByType("usb")` so that when `state.mx4_root` is nil it calls `PLDR.GetMX4SIOMassRootNow()` and excludes the resolved MX4 root from the returned USB roots, preventing hotplug leakage.

### Testing
- Applied the patch and validated the modified file diff and contents programmatically (patch tool succeeded and file updated as intended).
- Attempted a Lua syntax/load test using `lua -e 'assert(loadfile("bin/POPSLDR/system.lua"))'` / `luac -p`, but the environment lacks Lua/luac so the syntax check could not be executed here (tooling unavailable).
- No repository unit tests were present for these flows; recommend running device hotplug/manual smoke tests on target hardware to confirm MX4SIO page detects mounted device and that `PLDR.GetRootsByType("usb")` never includes the active sdc-backed mass root after hotplug.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dfa0ab488321b9b78e70be2516f9)