### PR TITLE
MX4SIO: bounded init + re-resolve loop on page entry

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1505,22 +1505,29 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
 
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
-  end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
-  end
+  for pass = 1, 3 do
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
 
-  local root = PLDR.GetMX4SIOMassRootNow()
-  if root ~= nil then
-    local pops = root.."POPS/"
-    if doesFolderExist(pops) then
-      PLDR.SetMX4SIORoot(root)
-      return pops
+    if type(PLDR.RefreshMassBackends) == "function" then
+      pcall(PLDR.RefreshMassBackends)
+    end
+
+    local root = PLDR.GetMX4SIOMassRootNow()
+    if root ~= nil then
+      local pops = root.."POPS/"
+      if doesFolderExist(pops) then
+        PLDR.SetMX4SIORoot(root)
+        return pops
+      end
+    end
+
+    if pass < 3 and type(System) == "table" and type(System.sleep) == "function" then
+      pcall(System.sleep, 0.05 * pass)
     end
   end
 


### PR DESCRIPTION
### Motivation
- The MX4SIO page sometimes fails to detect the device on the first entry attempt because backend init/mount happens asynchronously, requiring a second entry to succeed; the change folds init and re-resolution into the same page-entry attempt to avoid that race. 
- The fix must be bounded, avoid UI/logging changes, and keep identity rules and unrelated flows intact.

### Description
- Reworked `PLDR.InitMX4SIOPopsRoot()` in `bin/POPSLDR/system.lua` to run a bounded loop of up to 3 passes that retries init+resolve within the same attempt. 
- Each pass calls the existing `_G.ensureMx4sioInit` and `System.initMX4SIO` where available, invokes `PLDR.RefreshMassBackends()` if present, then calls `PLDR.GetMX4SIOMassRootNow()` and returns success immediately when `POPS/` is found and `PLDR.SetMX4SIORoot()` is called. 
- Between failed passes a small backoff sleep is applied using `System.sleep` with `0.05 * pass`, and original failure behavior is preserved after three attempts. 
- Only `bin/POPSLDR/system.lua` was modified and USB/identity logic was left unchanged.

### Testing
- Verified the source diff for `bin/POPSLDR/system.lua` with `git diff` and inspected the edited region to confirm the loop and calls were inserted as intended. 
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/system.lua`, but `luac` is not available in this environment. 
- Confirmed the change was packaged as a single update to `bin/POPSLDR/system.lua` and recorded in the repo state for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e360b578832181787a9fbfd20555)