### PR TITLE
Classify mass roots by slot and exclude unknown drivers to prevent USB/MX4 bleed

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1518,11 +1518,10 @@ function PLDR.InitMX4SIOPopsRoot()
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
   end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
-  end
 
-  for pass = 1, 2 do
+  for attempt = 1, 2 do
+    pcall(PLDR.RefreshMassBackends)
+
     local _, mx4_roots = PLDR.GetMassRootsByMountDriverIdentity()
     local candidate_root = mx4_roots[1]
     if candidate_root ~= nil then
@@ -1531,9 +1530,6 @@ function PLDR.InitMX4SIOPopsRoot()
         PLDR.SetMX4SIORoot(candidate_root)
         return pops
       end
-    end
-    if pass == 1 and type(System) == "table" and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
     end
   end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1004,6 +1004,10 @@ function PLDR.GetPresentMassRootsBounded()
 end
 
 function PLDR.GetMassRootsByMountDriverIdentity()
+  if type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
+
   local usb_roots = {}
   local mx4_roots = {}
 
@@ -1530,6 +1534,10 @@ function PLDR.InitMX4SIOPopsRoot()
         PLDR.SetMX4SIORoot(candidate_root)
         return pops
       end
+    end
+
+    if attempt == 1 and type(System.sleep) == "function" then
+      pcall(System.sleep, 0.05)
     end
   end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1003,30 +1003,37 @@ function PLDR.GetPresentMassRootsBounded()
   return roots
 end
 
-function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
-  local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+function PLDR.GetMassRootsByMountDriverIdentity()
+  local usb_roots = {}
+  local mx4_roots = {}
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
+  for parId = 0, 9 do
+    local root = (parId == 0) and "mass:/" or ("mass"..parId..":/")
+    if doesFolderExist(root) then
+      local driver = PLDR.GetMassDriverName(parId)
+      if type(driver) == "string" and driver ~= "" then
+        if string.find(driver, "sdc", 1, true) ~= nil then
+          table.insert(mx4_roots, root)
+        else
+          table.insert(usb_roots, root)
+        end
       end
     end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
-    end
   end
-  return roots
+
+  return usb_roots, mx4_roots
+end
+
+function PLDR.GetRootsByType(kind, mass_snapshot)
+  local wanted = string.lower(tostring(kind or ""))
+  local usb_roots, mx4_roots = PLDR.GetMassRootsByMountDriverIdentity()
+
+  if wanted == "usb" then
+    return usb_roots
+  elseif wanted == "mx4sio" then
+    return mx4_roots
+  end
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()
@@ -1515,12 +1522,18 @@ function PLDR.InitMX4SIOPopsRoot()
     pcall(System.sleep, 0.05)
   end
 
-  local root = PLDR.GetMX4SIOMassRootNow()
-  if root ~= nil then
-    local pops = root.."POPS/"
-    if doesFolderExist(pops) then
-      PLDR.SetMX4SIORoot(root)
-      return pops
+  for pass = 1, 2 do
+    local _, mx4_roots = PLDR.GetMassRootsByMountDriverIdentity()
+    local candidate_root = mx4_roots[1]
+    if candidate_root ~= nil then
+      local pops = candidate_root.."POPS/"
+      if doesFolderExist(pops) then
+        PLDR.SetMX4SIORoot(candidate_root)
+        return pops
+      end
+    end
+    if pass == 1 and type(System) == "table" and type(System.sleep) == "function" then
+      pcall(System.sleep, 0.05)
     end
   end
 


### PR DESCRIPTION
### Motivation
- Hotplug churn can make per-slot driver identity queries return nil/empty and those were implicitly treated as USB, causing MX4 content to appear on the USB page (and vice versa). 
- The goal is to deterministically classify present `mass:/`..`mass9:/` roots by slot-index driver identity and exclude unknown drivers so pages don't cross-contaminate.

### Description
- Added `PLDR.GetMassRootsByMountDriverIdentity()` which scans `parId` 0..9, builds device roots (`mass:/` or `massN:/`), queries `PLDR.GetMassDriverName(parId)`, and places roots into `mx4_roots` only if the driver string contains `"sdc"`, into `usb_roots` for known non-`sdc` drivers, and excludes roots when the driver is nil/empty/unknown. 
- Replaced `PLDR.GetRootsByType(kind, ...)` to return the lists from the new helper directly (`usb` -> USB roots, `mx4sio` -> MX4SIO roots) and return empty for other kinds. 
- Updated `PLDR.InitMX4SIOPopsRoot()` to keep the existing bounded 2-pass readiness probe but recompute MX4 roots each pass, use `mx4_roots[1]` as the candidate, validate `POPS/` existence, and set the MX4 root only on success (no unbounded retries added). 
- Only `bin/POPSLDR/system.lua` was modified.

### Testing
- Attempted to validate the file via `lua -e 'assert(loadfile("bin/POPSLDR/system.lua"))'`, but it failed due to the `lua` executable not being available in the environment (test could not run). 
- Verified repository state and patch contents with `git status --short`, `git show --stat --oneline HEAD`, and `git show -- bin/POPSLDR/system.lua`, all of which completed successfully and confirm the single-file change. 
- No additional automated unit tests are present for these code paths in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6bbabb9e8832182a3d474bef4e0bb)