### PR TITLE
Fix USB/MX4SIO separation via mount driver identity

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -864,20 +864,23 @@ function PLDR.GetMassDriverName(index)
   if cached ~= nil and cached.driver ~= nil then
     return cached.driver
   end
+  local has_driver_apis = false
   if type(System) == "table" then
     if type(System.getMassDriverName) == "function" then
+      has_driver_apis = true
       local ok, driver = pcall(System.getMassDriverName, index)
       if ok and type(driver) == "string" and driver ~= "" then
         return string.lower(driver)
       end
     end
     if type(System.getMassDriver) == "function" then
+      has_driver_apis = true
       local ok, driver = pcall(System.getMassDriver, index)
       if ok and type(driver) == "string" and driver ~= "" then
         return string.lower(driver)
       end
     end
-    if type(System.getMassBackendInfo) == "function" then
+    if not has_driver_apis and type(System.getMassBackendInfo) == "function" then
       local ok, info = pcall(System.getMassBackendInfo, index)
       if ok and type(info) == "table" then
         local driver = info.driver
@@ -891,61 +894,10 @@ function PLDR.GetMassDriverName(index)
 end
 
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
-    return nil
+  local roots = PLDR.GetRootsByType("mx4sio")
+  if #roots > 0 then
+    return roots[1]
   end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
-    return nil
-  end
-
-  local has_bdm_list = type(System.bdmList) == "function"
-
-  for pass = 1, 2 do
-    pcall(PLDR.RefreshMassBackends)
-
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
-  end
-
   return nil
 end
 
@@ -1006,24 +958,39 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local roots = {}
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+  local state = mass_snapshot
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
+  if state == nil or type(state.identity) ~= "table" then
+    if type(PLDR.RefreshMassBackends) == "function" then
+      pcall(PLDR.RefreshMassBackends)
     end
+    state = { identity = {} }
     local present = PLDR.GetPresentMassRootsBounded()
     for i = 1, #present do
       local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
+      local index = PLDR.ParseMassIndexFromPath(root)
+      local driver = PLDR.GetMassDriverName(index)
+      if type(driver) ~= "string" or driver == "" then
+        driver = nil
+      else
+        driver = string.lower(driver)
+      end
+
+      if driver ~= nil and string.find(driver, "sdc", 1, true) ~= nil then
+        state.identity[root] = "mx4sio"
+      elseif driver ~= nil then
+        state.identity[root] = "usb"
       end
     end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
+  end
+
+  if wanted == "usb" or wanted == "mx4sio" then
+    local present = PLDR.GetPresentMassRootsBounded()
+    for i = 1, #present do
+      local root = present[i]
+      if state.identity[root] == wanted then
+        table.insert(roots, root)
+      end
     end
   end
   return roots


### PR DESCRIPTION
### Motivation
- USB vs MX4SIO page separation was unreliable because identity was inferred from backend scans instead of the actual mounted mass roots' driver strings. 
- The intent is to deterministically classify each present `mass*:/` root on every page entry using the mount-level driver string so hotplug/order changes cannot cause cross-bleed. 
- Classification must be strict: driver containing `sdc` ⇒ MX4SIO, known non-`sdc` driver ⇒ USB, unknown/empty driver ⇒ excluded from both pages.

### Description
- Modified a single file: `bin/POPSLDR/system.lua` to implement the mount-root → driver → identity pipeline and kept changes minimal and deterministic. 
- Reworked `PLDR.GetRootsByType(kind, mass_snapshot)` to rebuild identity per call by enumerating bounded present roots via `PLDR.GetPresentMassRootsBounded()`, doing one one-shot `PLDR.RefreshMassBackends()` (if available), parsing each root's index with `PLDR.ParseMassIndexFromPath()`, querying the mount-level driver with `PLDR.GetMassDriverName(index)`, and classifying roots with the exact rules required. 
- Adjusted `PLDR.GetMassDriverName(index)` to prefer `System.getMassDriverName` / `System.getMassDriver` and only use `System.getMassBackendInfo` as a strict fallback when direct driver APIs are not present. 
- Rewrote `PLDR.GetMX4SIOMassRootNow()` to derive its result from the new classifier (`GetRootsByType("mx4sio")`) rather than scanning backend lists; iteration remains bounded and no unbounded waits/loops were added. 

### Testing
- Ran repository and code inspections: `rg -n "GetRootsByType|GetMX4SIOMassRootNow|getMassBackendInfo|bdmList|getMassDriverName|getMassDriver|sdc" bin/POPSLDR/system.lua` to verify updated call sites and pattern placements, which returned the expected locations. 
- Inspected the modified file regions with `sed`/`nl` to confirm the new identity pipeline and driver-fallback logic were applied as intended. 
- Verified repository state and change summary (diff/stat) and ensured the working tree is clean after the change; all automated checks executed succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c4590da083219a3fcbd54664283a)