### PR TITLE
Fix USB/MX4SIO separation via mount driver identity

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -900,8 +900,26 @@ local function BuildMassRootIdentity()
     mx4sio = {}
   }
   local present = PLDR.GetPresentMassRootsBounded()
+  local unique = {}
+  local seen = {}
   for i = 1, #present do
     local root = present[i]
+    local key = root
+    if root == "mass0:/" then
+      key = "mass:/"
+    end
+
+    local at = seen[key]
+    if at == nil then
+      table.insert(unique, root)
+      seen[key] = #unique
+    elseif key == "mass:/" and root == "mass:/" and unique[at] == "mass0:/" then
+      unique[at] = "mass:/"
+    end
+  end
+
+  for i = 1, #unique do
+    local root = unique[i]
     local index = PLDR.ParseMassIndexFromPath(root)
     local driver = PLDR.GetMassDriverName(index)
     if type(driver) ~= "string" or driver == "" then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -877,7 +877,7 @@ function PLDR.GetMassDriverName(index)
         return string.lower(driver)
       end
     end
-    if type(System.getMassBackendInfo) == "function" then
+    if type(System.getMassDriverName) ~= "function" and type(System.getMassDriver) ~= "function" and type(System.getMassBackendInfo) == "function" then
       local ok, info = pcall(System.getMassBackendInfo, index)
       if ok and type(info) == "table" then
         local driver = info.driver
@@ -890,63 +890,39 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
-function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
-    return nil
-  end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
-    return nil
-  end
-
-  local has_bdm_list = type(System.bdmList) == "function"
-
-  for pass = 1, 2 do
+local function BuildMassRootIdentity()
+  if type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
+  end
 
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
+  local identity = {
+    usb = {},
+    mx4sio = {}
+  }
+  local present = PLDR.GetPresentMassRootsBounded()
+  for i = 1, #present do
+    local root = present[i]
+    local index = PLDR.ParseMassIndexFromPath(root)
+    local driver = PLDR.GetMassDriverName(index)
+    if type(driver) ~= "string" or driver == "" then
+      driver = nil
+    else
+      driver = string.lower(driver)
     end
 
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
+    if driver ~= nil and string.find(driver, "sdc", 1, true) then
+      table.insert(identity.mx4sio, root)
+    elseif driver ~= nil then
+      table.insert(identity.usb, root)
     end
   end
 
-  return nil
+  return identity
+end
+
+function PLDR.GetMX4SIOMassRootNow()
+  local identity = BuildMassRootIdentity()
+  return identity.mx4sio[1]
 end
 
 function PLDR.RefreshMassBackends()
@@ -1006,24 +982,15 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local roots = {}
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+  local identity = BuildMassRootIdentity()
 
   if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
+    for i = 1, #identity.usb do
+      table.insert(roots, identity.usb[i])
     end
   elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
+    for i = 1, #identity.mx4sio do
+      table.insert(roots, identity.mx4sio[i])
     end
   end
   return roots


### PR DESCRIPTION
### Motivation
- Ensure USB vs MX4SIO page separation and first-entry MX4 detection are derived from the actual mounted roots (`mass:/`, `massN:/`) and their mount-level driver identity instead of guessed slot assumptions.
- Recompute identity on every page entry and strictly exclude unknown drivers from both pages per the non-negotiable identity rule.

### Description
- Limit backend fallback inside `PLDR.GetMassDriverName(index)` so `System.getMassBackendInfo` is used only when neither `System.getMassDriverName` nor `System.getMassDriver` exist, and normalize unknown/empty results to `nil`.
- Add `BuildMassRootIdentity()` which calls `PLDR.RefreshMassBackends` exactly once, enumerates present mass roots bounded 0..9 via `PLDR.GetPresentMassRootsBounded()`, parses each root's index, queries mount-level driver (`PLDR.GetMassDriverName`) and classifies roots as MX4SIO if driver contains "sdc" (case-insensitive), USB if driver is known non-empty and does not contain "sdc", and excludes unknown drivers.
- Make `PLDR.GetMX4SIOMassRootNow()` return the first MX4SIO-classified root from the live identity and change `PLDR.GetRootsByType()` to rebuild identity on each call and return roots strictly from the classification lists (`usb` and `mx4sio`).
- Keep external call surfaces stable and follow the required bounded, deterministic logic without introducing caching that could go stale.

### Testing
- Ran `git diff --stat` and it completed successfully showing `bin/POPSLDR/system.lua` modified. (succeeded)
- Ran `git diff -- bin/POPSLDR/system.lua` and inspected the exact changes. (succeeded)
- Ran `rg -n "GetRootsByType|GetMX4SIOMassRootNow|getMassBackendInfo|bdmList|getMassDriverName|getMassDriver|sdc" bin/POPSLDR/system.lua` to verify updated references. (succeeded)
- Ran `git status` to confirm working tree state. (succeeded)
- Committed the single change with message `Fix USB/MX4SIO separation via mount driver identity`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c5a5afc48321a5031a0d7d83ab16)