### PR TITLE
Fix USB/MX4SIO separation via mount driver identity

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -864,25 +864,39 @@ function PLDR.GetMassDriverName(index)
   if cached ~= nil and cached.driver ~= nil then
     return cached.driver
   end
+  local function normalizeDriver(driver)
+    if type(driver) ~= "string" or driver == "" then
+      return nil
+    end
+    return string.lower(driver)
+  end
   if type(System) == "table" then
-    if type(System.getMassDriverName) == "function" then
+    local has_get_driver_name = type(System.getMassDriverName) == "function"
+    local has_get_driver = type(System.getMassDriver) == "function"
+    if has_get_driver_name then
       local ok, driver = pcall(System.getMassDriverName, index)
-      if ok and type(driver) == "string" and driver ~= "" then
-        return string.lower(driver)
+      if ok then
+        local normalized = normalizeDriver(driver)
+        if normalized ~= nil then
+          return normalized
+        end
       end
     end
-    if type(System.getMassDriver) == "function" then
+    if has_get_driver then
       local ok, driver = pcall(System.getMassDriver, index)
-      if ok and type(driver) == "string" and driver ~= "" then
-        return string.lower(driver)
+      if ok then
+        local normalized = normalizeDriver(driver)
+        if normalized ~= nil then
+          return normalized
+        end
       end
     end
-    if type(System.getMassBackendInfo) == "function" then
+    if (not has_get_driver_name) and (not has_get_driver) and type(System.getMassBackendInfo) == "function" then
       local ok, info = pcall(System.getMassBackendInfo, index)
       if ok and type(info) == "table" then
-        local driver = info.driver
-        if type(driver) == "string" and driver ~= "" then
-          return string.lower(driver)
+        local normalized = normalizeDriver(info.driver)
+        if normalized ~= nil then
+          return normalized
         end
       end
     end
@@ -890,63 +904,35 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
-function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
-    return nil
+local function BuildMassRootIdentity()
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
   end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
-    return nil
-  end
-
-  local has_bdm_list = type(System.bdmList) == "function"
-
-  for pass = 1, 2 do
+  if type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
-
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
   end
 
-  return nil
+  local identity = {
+    usb = {},
+    mx4sio = {}
+  }
+  local present = PLDR.GetPresentMassRootsBounded()
+  for i = 1, #present do
+    local root = present[i]
+    local idx = PLDR.ParseMassIndexFromPath(root)
+    local driver = PLDR.GetMassDriverName(idx)
+    if driver ~= nil and driver:find("sdc", 1, true) then
+      table.insert(identity.mx4sio, root)
+    elseif driver ~= nil then
+      table.insert(identity.usb, root)
+    end
+  end
+  return identity
+end
+
+function PLDR.GetMX4SIOMassRootNow()
+  local identity = BuildMassRootIdentity()
+  return identity.mx4sio[1] or nil
 end
 
 function PLDR.RefreshMassBackends()
@@ -1004,29 +990,15 @@ function PLDR.GetPresentMassRootsBounded()
 end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+  local identity = BuildMassRootIdentity()
 
   if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
-    end
+    return identity.usb
   elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
-    end
+    return identity.mx4sio
   end
-  return roots
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -916,17 +916,45 @@ local function BuildMassRootIdentity()
     usb = {},
     mx4sio = {}
   }
+
   local present = PLDR.GetPresentMassRootsBounded()
+  local order = {}
+  local roots_by_index = {}
+
   for i = 1, #present do
     local root = present[i]
     local idx = PLDR.ParseMassIndexFromPath(root)
-    local driver = PLDR.GetMassDriverName(idx)
-    if driver ~= nil and driver:find("sdc", 1, true) then
-      table.insert(identity.mx4sio, root)
-    elseif driver ~= nil then
-      table.insert(identity.usb, root)
+    if idx ~= nil and idx >= 0 and idx <= 9 then
+      local canonical = (idx == 0) and "mass:/" or ("mass"..tostring(idx)..":/")
+      local current = roots_by_index[idx]
+      if current == nil then
+        roots_by_index[idx] = canonical
+        table.insert(order, idx)
+      elseif idx == 0 and canonical == "mass:/" then
+        roots_by_index[idx] = "mass:/"
+      end
     end
   end
+
+  local seen_usb = {}
+  local seen_mx4 = {}
+  for i = 1, #order do
+    local idx = order[i]
+    local root = roots_by_index[idx]
+    local driver = PLDR.GetMassDriverName(idx)
+    if driver ~= nil and driver:find("sdc", 1, true) then
+      if root ~= nil and not seen_mx4[root] then
+        seen_mx4[root] = true
+        table.insert(identity.mx4sio, root)
+      end
+    elseif driver ~= nil then
+      if root ~= nil and not seen_usb[root] then
+        seen_usb[root] = true
+        table.insert(identity.usb, root)
+      end
+    end
+  end
+
   return identity
 end
 


### PR DESCRIPTION
### Motivation

- Resolve incorrect mixing of USB and MX4SIO page roots by deriving identity from mounted root → mount-slot index → driver string on every rebuild. 
- Avoid using stale cached driver strings in BETA-8 by forcing a single invalidate/refresh cycle at the start of each identity rebuild. 
- Ensure unknown/nil/empty driver roots are excluded from both USB and MX4SIO pages and remove sleep/wait logic from detection paths. 

### Description

- Tightened `PLDR.GetMassDriverName(index)` to normalize driver results (non-string/empty → `nil`, otherwise lowercase) and to only use `System.getMassBackendInfo` as a strict last resort when neither `System.getMassDriverName` nor `System.getMassDriver` exist. 
- Added a local `BuildMassRootIdentity()` that calls `PLDR.InvalidateMassBackends` and `PLDR.RefreshMassBackends` exactly once each, enumerates bounded present mass roots (`PLDR.GetPresentMassRootsBounded()`), derives index with `PLDR.ParseMassIndexFromPath()`, reads the normalized driver, and classifies roots: include in `mx4sio` only if driver contains the literal substring `"sdc"` (case-insensitive), include in `usb` for any other non-empty driver, and exclude unknown drivers. 
- Rewrote `PLDR.GetMX4SIOMassRootNow()` to return the first entry from `BuildMassRootIdentity().mx4sio` and removed previous backend-scanning and sleep logic. 
- Replaced `PLDR.GetRootsByType(kind, mass_snapshot)` separation with identity-driven returns so USB and MX4SIO lists come directly from `BuildMassRootIdentity()` (no present-minus-mx4 logic and unknown drivers are excluded). 
- All changes limited to `bin/POPSLDR/system.lua`, no logging added, no sleeps/yields introduced, and loops remain bounded. 

### Testing

- Ran `git diff --stat` to verify file changes, which showed `bin/POPSLDR/system.lua | 130 +... -...` and one file changed. 
- Ran `git diff -- bin/POPSLDR/system.lua` to inspect the applied patch and confirmed the intended modifications to driver normalization, identity builder, and root-selection functions. 
- Ran `rg -n "GetRootsByType|BuildMassRootIdentity|GetMX4SIOMassRootNow|getMassBackendInfo|bdmList|getMassDriverName|getMassDriver|sleep|sdc|InvalidateMassBackends|RefreshMassBackends" bin/POPSLDR/system.lua` to validate occurrences and confirm the new helper and updated call sites are present. 
- Ran `git status` to confirm the working tree is clean after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c9da3fcc8321a2060cb172b4261e)