### PR TITLE
Fix USB/MX4SIO separation via backend → parId → mount-root classification

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -894,6 +894,8 @@ function PLDR.GetMassDriverName(index)
 end
 
 local BuildMassRootIdentity
+local BuildMassSlotDriverMap
+
 
 function PLDR.GetMX4SIOMassRootNow()
   local identity = BuildMassRootIdentity()
@@ -938,7 +940,12 @@ function PLDR.InvalidateMassBackends()
 end
 
 function PLDR.RefreshMassStateSnapshot()
-  return {}
+  local identity = BuildMassRootIdentity()
+  return {
+    mx4_roots = identity.mx4sio,
+    usb_roots = identity.usb,
+    mx4_root = identity.mx4sio[1]
+  }
 end
 
 function PLDR.GetPresentMassRootsBounded()
@@ -952,16 +959,7 @@ function PLDR.GetPresentMassRootsBounded()
   return roots
 end
 
-BuildMassRootIdentity = function()
-  if type(PLDR.InvalidateMassBackends) == "function" then
-    pcall(PLDR.InvalidateMassBackends)
-  end
-  if type(PLDR.RefreshMassBackends) == "function" then
-    pcall(PLDR.RefreshMassBackends)
-  end
-
-  local present = PLDR.GetPresentMassRootsBounded()
-
+BuildMassSlotDriverMap = function()
   local slot_driver = {}
   if type(System) == "table" and type(System.getMassBackendInfo) == "function" then
     for backend = 0, 15 do
@@ -980,6 +978,20 @@ BuildMassRootIdentity = function()
       end
     end
   end
+  return slot_driver
+end
+
+BuildMassRootIdentity = function()
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
+
+  local present = PLDR.GetPresentMassRootsBounded()
+
+  local slot_driver = BuildMassSlotDriverMap()
 
   local identity = { usb = {}, mx4sio = {} }
   for i = 1, #present do
@@ -1035,12 +1047,31 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") then
-    local mx4_root_now = PLDR.GetMX4SIOMassRootNow()
-    local is_mx4_mass_path = false
-    if mx4_root_now ~= nil then
-      is_mx4_mass_path = string.sub(path, 1, string.len(mx4_root_now)) == mx4_root_now
+    local present = PLDR.GetPresentMassRootsBounded()
+    local matched_root = nil
+    for i = 1, #present do
+      local root = present[i]
+      if string.sub(path, 1, string.len(root)) == root then
+        matched_root = root
+        break
+      end
     end
-    if is_mx4_mass_path then
+
+    local class = nil
+    if matched_root ~= nil then
+      local slot = PLDR.ParseMassIndexFromPath(matched_root)
+      if slot ~= nil then
+        local slot_driver = BuildMassSlotDriverMap()
+        local drv = slot_driver[slot]
+        if drv ~= nil and string.find(drv, "sdc", 1, true) then
+          class = "mx4sio"
+        elseif drv ~= nil then
+          class = "usb"
+        end
+      end
+    end
+
+    if class == "mx4sio" then
       if type(_G.ensureMx4sioInit) == "function" then
         local ok = pcall(_G.ensureMx4sioInit)
         if ok then return true end
@@ -1049,7 +1080,7 @@ function PLDR.EnsureBackendForAppDir()
         local ok = pcall(System.initMX4SIO)
         if ok then return true end
       end
-    else
+    elseif class == "usb" then
       if type(System) == "table" and type(System.initUSB) == "function" then
         local ok = pcall(System.initUSB)
         if ok then return true end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -862,25 +862,31 @@ function PLDR.GetMassDriverName(index)
   if index == nil then return nil end
   local cached = PLDR.MASS.CACHE[index]
   if cached ~= nil and cached.driver ~= nil then
-    return cached.driver
+    if type(cached.driver) == "string" and cached.driver ~= "" then
+      return string.lower(cached.driver)
+    end
+    return nil
   end
   if type(System) == "table" then
-    if type(System.getMassDriverName) == "function" then
+    local has_driver_name = type(System.getMassDriverName) == "function"
+    local has_driver = type(System.getMassDriver) == "function"
+
+    if has_driver_name then
       local ok, driver = pcall(System.getMassDriverName, index)
       if ok and type(driver) == "string" and driver ~= "" then
         return string.lower(driver)
       end
     end
-    if type(System.getMassDriver) == "function" then
+    if has_driver then
       local ok, driver = pcall(System.getMassDriver, index)
       if ok and type(driver) == "string" and driver ~= "" then
         return string.lower(driver)
       end
     end
-    if type(System.getMassBackendInfo) == "function" then
+    if (not has_driver_name) and (not has_driver) and type(System.getMassBackendInfo) == "function" then
       local ok, info = pcall(System.getMassBackendInfo, index)
       if ok and type(info) == "table" then
-        local driver = info.driver
+        local driver = info.driver or info.name
         if type(driver) == "string" and driver ~= "" then
           return string.lower(driver)
         end
@@ -890,63 +896,11 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
+local BuildMassRootIdentity
+
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
-    return nil
-  end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
-    return nil
-  end
-
-  local has_bdm_list = type(System.bdmList) == "function"
-
-  for pass = 1, 2 do
-    pcall(PLDR.RefreshMassBackends)
-
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
-  end
-
-  return nil
+  local identity = BuildMassRootIdentity()
+  return identity.mx4sio[1] or nil
 end
 
 function PLDR.RefreshMassBackends()
@@ -1003,30 +957,69 @@ function PLDR.GetPresentMassRootsBounded()
   return roots
 end
 
-function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
-  local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+BuildMassRootIdentity = function()
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
-    end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
+  local present = PLDR.GetPresentMassRootsBounded()
+  local present_slots = {}
+  for i = 1, #present do
+    local slot = PLDR.ParseMassIndexFromPath(present[i])
+    if slot ~= nil then
+      present_slots[slot] = true
     end
   end
-  return roots
+
+  local slot_driver = {}
+  if type(System) == "table" and type(System.getMassBackendInfo) == "function" then
+    for backend = 0, 15 do
+      local ok, info = pcall(System.getMassBackendInfo, backend)
+      if ok and type(info) == "table" then
+        local parId = info.parId
+        local drv = info.driver or info.name
+        if type(drv) == "string" and drv ~= "" then
+          drv = string.lower(drv)
+        else
+          drv = nil
+        end
+        if type(parId) == "number" and parId >= 0 and parId <= 9 and drv ~= nil and slot_driver[parId] == nil then
+          slot_driver[parId] = drv
+        end
+      end
+    end
+  end
+
+  local identity = { usb = {}, mx4sio = {} }
+  for i = 1, #present do
+    local root = present[i]
+    local slot = PLDR.ParseMassIndexFromPath(root)
+    if slot ~= nil and present_slots[slot] then
+      local drv = slot_driver[slot]
+      if drv ~= nil and string.find(drv, "sdc", 1, true) then
+        table.insert(identity.mx4sio, root)
+      elseif drv ~= nil then
+        table.insert(identity.usb, root)
+      end
+    end
+  end
+
+  return identity
+end
+
+function PLDR.GetRootsByType(kind, mass_snapshot)
+  local wanted = string.lower(tostring(kind or ""))
+  local identity = BuildMassRootIdentity()
+  if wanted == "usb" then
+    return identity.usb
+  end
+  if wanted == "mx4sio" then
+    return identity.mx4sio
+  end
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -169,9 +169,6 @@ function PLDR.PopstarterProbeWithEnsure(path)
           pcall(PLDR.EnsureMmceReadyOnce)
         end
       end
-      if type(System) == "table" and type(System.sleep) == "function" then
-        pcall(System.sleep, 0.05)
-      end
     end
   end
   return false
@@ -941,9 +938,7 @@ function PLDR.InvalidateMassBackends()
 end
 
 function PLDR.RefreshMassStateSnapshot()
-  return {
-    mx4_root = PLDR.GetMX4SIOMassRootNow()
-  }
+  return {}
 end
 
 function PLDR.GetPresentMassRootsBounded()
@@ -966,13 +961,6 @@ BuildMassRootIdentity = function()
   end
 
   local present = PLDR.GetPresentMassRootsBounded()
-  local present_slots = {}
-  for i = 1, #present do
-    local slot = PLDR.ParseMassIndexFromPath(present[i])
-    if slot ~= nil then
-      present_slots[slot] = true
-    end
-  end
 
   local slot_driver = {}
   if type(System) == "table" and type(System.getMassBackendInfo) == "function" then
@@ -997,7 +985,7 @@ BuildMassRootIdentity = function()
   for i = 1, #present do
     local root = present[i]
     local slot = PLDR.ParseMassIndexFromPath(root)
-    if slot ~= nil and present_slots[slot] then
+    if slot ~= nil then
       local drv = slot_driver[slot]
       if drv ~= nil and string.find(drv, "sdc", 1, true) then
         table.insert(identity.mx4sio, root)
@@ -1504,10 +1492,6 @@ function PLDR.InitMX4SIOPopsRoot()
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
   end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
-  end
-
   local root = PLDR.GetMX4SIOMassRootNow()
   if root ~= nil then
     local pops = root.."POPS/"


### PR DESCRIPTION
### Motivation
- The existing mass-driver classification assumed mount slot index == driver index, causing MX4/USB cross-bleed and missed devices.
- Classification must be deterministic and driven by backend metadata (backend 0..15 → parId 0..9 → mass root) and follow strict identity rules for "sdc" and non-empty drivers.
- Changes must be minimal, deterministic, avoid sleeps/yields in detection paths, and only touch `bin/POPSLDR/system.lua`.

### Description
- Tightened `PLDR.GetMassDriverName(index)` so `System.getMassBackendInfo` is used only if both `System.getMassDriverName` and `System.getMassDriver` are absent, and normalized cached/returned driver names to lowercase non-empty strings or `nil`.
- Added a single helper `BuildMassRootIdentity()` that refreshes backends once (bounded), enumerates present `mass:/` roots (bounded 0..9), scans `System.getMassBackendInfo` for backends 0..15 to map `parId -> driver` (first-seen wins), and classifies only present mounts into `{ usb = {...}, mx4sio = {...} }` using the exact identity rules (`driver` containing `sdc` → MX4SIO, known non-empty non-`sdc` → USB, nil/empty → excluded).
- Rewrote `PLDR.GetRootsByType(kind, mass_snapshot)` to return lists from `BuildMassRootIdentity()` directly (removed subtractive "present minus mx4_root" logic).
- Rewrote `PLDR.GetMX4SIOMassRootNow()` to return the first MX4SIO root from `BuildMassRootIdentity()` (removed `bdmList` scanning and sleep loops); detection paths contain no new sleeps.
- Only `bin/POPSLDR/system.lua` was modified and logic was kept bounded and deterministic.

### Testing
- Inspected changes with `git diff --stat` and `git diff -- bin/POPSLDR/system.lua` to validate the edits and confirmed the intended diffs were present.
- Searched the modified file with `rg -n "GetRootsByType|BuildMassRootIdentity|GetMX4SIOMassRootNow|getMassBackendInfo|bdmList|getMassDriverName|getMassDriver|sleep|sdc|InvalidateMassBackends|RefreshMassBackends|parId" bin/POPSLDR/system.lua` and confirmed the new helper and call-sites exist and the sleep calls were not reintroduced in detection paths.
- Ran `git status` to confirm the working tree was clean after changes.
- Attempted to run `luac -p bin/POPSLDR/system.lua` for a syntax check, but the `luac` tool is unavailable in the environment (failure due to missing binary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ce5748448321b680c8bd9407fb26)