### PR TITLE
Canonicalize MX4 mount driver to "sdc"

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -169,9 +169,6 @@ function PLDR.PopstarterProbeWithEnsure(path)
           pcall(PLDR.EnsureMmceReadyOnce)
         end
       end
-      if type(System) == "table" and type(System.sleep) == "function" then
-        pcall(System.sleep, 0.05)
-      end
     end
   end
   return false
@@ -891,61 +888,10 @@ function PLDR.GetMassDriverName(index)
 end
 
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
-    return nil
+  local identity = PLDR.BuildMassRootIdentity()
+  if type(identity) == "table" and type(identity.mx4sio) == "table" then
+    return identity.mx4sio[1]
   end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
-    return nil
-  end
-
-  local has_bdm_list = type(System.bdmList) == "function"
-
-  for pass = 1, 2 do
-    pcall(PLDR.RefreshMassBackends)
-
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
-    end
-  end
-
   return nil
 end
 
@@ -1003,30 +949,76 @@ function PLDR.GetPresentMassRootsBounded()
   return roots
 end
 
-function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
-  local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+local function NormalizeMassRoot(root)
+  if type(root) ~= "string" then
+    return nil
+  end
+  local low = string.lower(root)
+  if low == "mass0:/" then
+    return "mass:/"
+  end
+  if low == "mass:/" or string.match(low, "^mass[1-9]:/$") then
+    return low
+  end
+  return nil
+end
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
-    end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
+function PLDR.GetMassMountDriver(root)
+  if type(System) == "table" and type(System.getMassMountDriver) == "function" then
+    local ok, drv = pcall(System.getMassMountDriver, root)
+    if ok and type(drv) == "string" and drv ~= "" then
+      return string.lower(drv)
     end
   end
-  return roots
+  return nil
+end
+
+function PLDR.BuildMassRootIdentity()
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
+
+  local present = PLDR.GetPresentMassRootsBounded()
+  local normalized_present = {}
+  local seen_present = {}
+  local usb = {}
+  local mx4sio = {}
+
+  for i = 1, #present do
+    local root = NormalizeMassRoot(present[i])
+    if root ~= nil and not seen_present[root] then
+      seen_present[root] = true
+      table.insert(normalized_present, root)
+      local drv = PLDR.GetMassMountDriver(root)
+      if type(drv) == "string" then
+        if string.find(drv, "sdc", 1, true) then
+          table.insert(mx4sio, root)
+        else
+          table.insert(usb, root)
+        end
+      end
+    end
+  end
+
+  return {
+    usb = usb,
+    mx4sio = mx4sio,
+    present_roots = normalized_present
+  }
+end
+
+function PLDR.GetRootsByType(kind, mass_snapshot)
+  local wanted = string.lower(tostring(kind or ""))
+  local identity = PLDR.BuildMassRootIdentity()
+  if wanted == "usb" then
+    return identity.usb or {}
+  elseif wanted == "mx4sio" then
+    return identity.mx4sio or {}
+  end
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()
@@ -1054,12 +1046,23 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") then
-    local mx4_root_now = PLDR.GetMX4SIOMassRootNow()
-    local is_mx4_mass_path = false
-    if mx4_root_now ~= nil then
-      is_mx4_mass_path = string.sub(path, 1, string.len(mx4_root_now)) == mx4_root_now
+    local identity = PLDR.BuildMassRootIdentity()
+    local present_roots = identity.present_roots or {}
+    local matched_root = nil
+    local norm_path = string.lower(path)
+    norm_path = string.gsub(norm_path, "^mass0:/", "mass:/")
+    for i = 1, #present_roots do
+      local root = present_roots[i]
+      if string.sub(norm_path, 1, string.len(root)) == root then
+        matched_root = root
+        break
+      end
     end
-    if is_mx4_mass_path then
+    local drv = nil
+    if matched_root ~= nil then
+      drv = PLDR.GetMassMountDriver(matched_root)
+    end
+    if type(drv) == "string" and string.find(drv, "sdc", 1, true) then
       if type(_G.ensureMx4sioInit) == "function" then
         local ok = pcall(_G.ensureMx4sioInit)
         if ok then return true end
@@ -1068,7 +1071,7 @@ function PLDR.EnsureBackendForAppDir()
         local ok = pcall(System.initMX4SIO)
         if ok then return true end
       end
-    else
+    elseif drv ~= nil then
       if type(System) == "table" and type(System.initUSB) == "function" then
         local ok = pcall(System.initUSB)
         if ok then return true end
@@ -1510,9 +1513,6 @@ function PLDR.InitMX4SIOPopsRoot()
   end
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
-  end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
   end
 
   local root = PLDR.GetMX4SIOMassRootNow()

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sifrpc.h>
 #include <string.h>
+#include <ctype.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
@@ -196,6 +197,24 @@ static bool EnsureMassBackendCache()
 		return true;
 	}
 	return RefreshMassBackendCache();
+}
+
+static bool ContainsCaseInsensitive(const char *haystack, const char *needle)
+{
+	if (haystack == NULL || needle == NULL || needle[0] == '\0') {
+		return false;
+	}
+	for (size_t i = 0; haystack[i] != '\0'; ++i) {
+		size_t j = 0;
+		while (needle[j] != '\0' && haystack[i + j] != '\0' &&
+		       tolower((unsigned char)haystack[i + j]) == tolower((unsigned char)needle[j])) {
+			++j;
+		}
+		if (needle[j] == '\0') {
+			return true;
+		}
+	}
+	return false;
 }
 
 static bool GetMassRootByBackendNameInternal(const char *backend_name, char *out_root, size_t out_sz)
@@ -443,6 +462,67 @@ static int lua_get_mass_root_by_backend_name(lua_State *L)
 	}
 
 	lua_pushnil(L);
+	return 1;
+}
+
+static int lua_get_mass_mount_driver(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1) {
+		return luaL_error(L, "Argument error: System.getMassMountDriver(root) takes one argument.");
+	}
+
+	const char *root = luaL_checkstring(L, 1);
+	int slot = -1;
+
+	if (strcmp(root, "mass:/") == 0 || strcmp(root, "mass0:/") == 0) {
+		slot = 0;
+	} else if (strlen(root) == 7 && strncmp(root, "mass", 4) == 0 && root[4] >= '1' && root[4] <= '9' && root[5] == ':' && root[6] == '/') {
+		slot = root[4] - '0';
+	}
+
+	if (slot < 0) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (!EnsureMassBackendCache()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	bool mx4_found = false;
+	const char *first_match = NULL;
+	u32 limit = mass_backend_cache.count;
+	if (limit > BDM_QUERY_MAX_DEVICES) {
+		limit = BDM_QUERY_MAX_DEVICES;
+	}
+
+	for (u32 i = 0; i < limit; ++i) {
+		const bdm_dev_info_t *info = &mass_backend_cache.devs[i];
+		if ((int)info->parId != slot) {
+			continue;
+		}
+		const char *name = info->name;
+		if (name == NULL || name[0] == '\0') {
+			continue;
+		}
+		if (first_match == NULL) {
+			first_match = name;
+		}
+		if (ContainsCaseInsensitive(name, "sdc") || ContainsCaseInsensitive(name, "mx4sio")) {
+			mx4_found = true;
+		}
+	}
+
+	if (mx4_found) {
+		lua_pushstring(L, "sdc");
+	} else if (first_match != NULL) {
+		lua_pushstring(L, first_match);
+	} else {
+		lua_pushnil(L);
+	}
+
 	return 1;
 }
 
@@ -1313,6 +1393,7 @@ static const luaL_Reg System_functions[] = {
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
+	{"getMassMountDriver",     lua_get_mass_mount_driver},
 	{"getMassRootByBackendName", lua_get_mass_root_by_backend_name},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}


### PR DESCRIPTION
### Motivation
- Lua logic relies on an exact driver token `"sdc"` to identify MX4SIO devices, but backend names from BETA-8 can be non-literal (e.g. `"mx4sio"`), causing MX4 drives to be misclassified as USB and leak across pages.  
- Fixing classification at the C source-of-truth keeps Lua simple and strict while restoring correct MX4/USB separation.  

### Description
- Add a new C binding `System.getMassMountDriver(root)` in `src/luasystem.cpp` that validates only `mass:/`, `mass0:/`, and `mass1:/`..`mass9:/`, refreshes the backend cache, scans up to `BDM_QUERY_MAX_DEVICES`, and deterministically returns `"sdc"` if any backend name for the slot contains `sdc` or `mx4sio` (case-insensitive), otherwise returns the first non-empty matched backend name or `nil`.  
- Introduce `ContainsCaseInsensitive` helper and register the new binding in the `System_functions` table.  
- Rework Lua identity flow in `bin/POPSLDR/system.lua` by adding `PLDR.GetMassMountDriver`, `NormalizeMassRoot`, and `PLDR.BuildMassRootIdentity()` which normalizes/dedupes present mass roots and classifies them only via `GetMassMountDriver(root)` where `string.find(drv, "sdc")` determines MX4; update `PLDR.GetRootsByType` and `PLDR.GetMX4SIOMassRootNow` to use that identity.  
- Update `PLDR.EnsureBackendForAppDir()` to match mass paths against normalized present roots and pick MX4 vs USB init solely from the canonical driver token, and remove all `System.sleep` usages from `bin/POPSLDR/system.lua`.  

### Testing
- Ran `git diff --stat` and `git diff -- src/luasystem.cpp bin/POPSLDR/system.lua` to validate the change scope and diffs, which completed successfully.  
- Ran `grep -nE` for key symbols (`getMassMountDriver`, `lua_get_mass_mount_driver`, `mx4sio`, `sdc`, `BuildMassRootIdentity`, `GetRootsByType`, `GetMX4SIOMassRootNow`, `System.sleep`) across the two modified files and confirmed the intended symbols and removals.  
- Verified `rg -n "System\.sleep" bin/POPSLDR/system.lua` returns no matches and ran `git status` to confirm a clean working tree; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7083015788321b5a656ec517aaf8f)