### PR TITLE
Deterministic MX4SIO/USB detection: add getMassMountDriver and init-before-enumerate

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -975,14 +975,6 @@ function PLDR.EnsureUsbMassReadyOnce()
     return true
   end
 
-  if type(System) == "table" and type(System.ensureUsbMass) == "function" then
-    pcall(System.ensureUsbMass)
-  elseif type(System) == "table" and type(System.initUSBMass) == "function" then
-    pcall(System.initUSBMass)
-  end
-  if type(System) == "table" and type(System.initUSB) == "function" then
-    pcall(System.initUSB)
-  end
   if type(PLDR.RefreshMassStateSnapshot) == "function" then
     pcall(PLDR.RefreshMassStateSnapshot)
   elseif type(PLDR.RefreshMassBackends) == "function" then
@@ -1045,14 +1037,6 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mx4sio%d*:/") then
-    if type(_G.ensureMx4sioInit) == "function" then
-      local ok = pcall(_G.ensureMx4sioInit)
-      if ok then return true end
-    end
-    if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      local ok = pcall(System.initMX4SIO)
-      return ok
-    end
     return true
   end
   if string.match(path, "^mass%d*:/") then
@@ -1073,19 +1057,9 @@ function PLDR.EnsureBackendForAppDir()
     end
 
     if type(drv) == "string" and string.find(drv, "sdc", 1, true) then
-      if type(_G.ensureMx4sioInit) == "function" then
-        local ok = pcall(_G.ensureMx4sioInit)
-        if ok then return true end
-      end
-      if type(System) == "table" and type(System.initMX4SIO) == "function" then
-        local ok = pcall(System.initMX4SIO)
-        if ok then return true end
-      end
+      return true
     elseif drv ~= nil then
-      if type(System) == "table" and type(System.initUSB) == "function" then
-        local ok = pcall(System.initUSB)
-        if ok then return true end
-      end
+      return true
     end
     return true
   end
@@ -1517,13 +1491,6 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.ROOT = nil
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
-
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
-  end
 
   local root = PLDR.GetMX4SIOMassRootNow()
   if root ~= nil then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -905,7 +905,25 @@ local function NormalizeMassRoot(root)
   return root
 end
 
+local function EnsureMassBackendsReady()
+  if type(System) == "table" and type(System.initUSBMass) == "function" then
+    pcall(System.initUSBMass)
+  end
+  if type(System) == "table" and type(System.initUSB) == "function" then
+    pcall(System.initUSB)
+  end
+
+  if type(_G) == "table" and type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+end
+
 local function BuildMassRootIdentity()
+  EnsureMassBackendsReady()
+
   if type(PLDR.InvalidateMassBackends) == "function" then
     pcall(PLDR.InvalidateMassBackends)
   end
@@ -940,9 +958,6 @@ local function BuildMassRootIdentity()
 end
 
 function PLDR.GetMX4SIOMassRootNow()
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
-  end
   local identity = BuildMassRootIdentity()
   return identity.mx4sio[1]
 end
@@ -1006,19 +1021,6 @@ end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
-
-  if wanted == "mx4sio" then
-    if type(System) == "table" and type(System.initMX4SIO) == "function" then
-      pcall(System.initMX4SIO)
-    end
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-  elseif wanted == "usb" then
-    if type(System) == "table" and type(System.initUSB) == "function" then
-      pcall(System.initUSB)
-    end
-  end
 
   local identity = BuildMassRootIdentity()
   if wanted == "mx4sio" then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -169,9 +169,6 @@ function PLDR.PopstarterProbeWithEnsure(path)
           pcall(PLDR.EnsureMmceReadyOnce)
         end
       end
-      if type(System) == "table" and type(System.sleep) == "function" then
-        pcall(System.sleep, 0.05)
-      end
     end
   end
   return false
@@ -890,63 +887,64 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
-function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
+function PLDR.GetMassMountDriver(root)
+  if type(System) ~= "table" or type(System.getMassMountDriver) ~= "function" then
     return nil
   end
-
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
-    end
-
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
+  local ok, drv = pcall(System.getMassMountDriver, root)
+  if not ok or type(drv) ~= "string" or drv == "" then
     return nil
   end
+  return string.lower(drv)
+end
 
-  local has_bdm_list = type(System.bdmList) == "function"
+local function NormalizeMassRoot(root)
+  if root == "mass0:/" then
+    return "mass:/"
+  end
+  return root
+end
 
-  for pass = 1, 2 do
+local function BuildMassRootIdentity()
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
+  end
 
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
+  local identity = {
+    usb = {},
+    mx4sio = {},
+    present_roots = {}
+  }
+  local seen = {}
+  local present = PLDR.GetPresentMassRootsBounded()
+  for i = 1, #present do
+    local root = NormalizeMassRoot(present[i])
+    if type(root) == "string" and root ~= "" and not seen[root] then
+      seen[root] = true
+      table.insert(identity.present_roots, root)
+      local drv = PLDR.GetMassMountDriver(root)
+      if type(drv) == "string" and drv ~= "" then
+        if string.find(drv, "sdc", 1, true) then
+          table.insert(identity.mx4sio, root)
+        else
+          table.insert(identity.usb, root)
         end
       end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
     end
   end
 
-  return nil
+  return identity
+end
+
+function PLDR.GetMX4SIOMassRootNow()
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+  local identity = BuildMassRootIdentity()
+  return identity.mx4sio[1]
 end
 
 function PLDR.RefreshMassBackends()
@@ -987,8 +985,11 @@ function PLDR.InvalidateMassBackends()
 end
 
 function PLDR.RefreshMassStateSnapshot()
+  local identity = BuildMassRootIdentity()
   return {
-    mx4_root = PLDR.GetMX4SIOMassRootNow()
+    mx4_root = identity.mx4sio[1],
+    mx4_roots = identity.mx4sio,
+    usb_roots = identity.usb
   }
 end
 
@@ -1004,29 +1005,28 @@ function PLDR.GetPresentMassRootsBounded()
 end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
+  if wanted == "mx4sio" then
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
     end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
     end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
+  elseif wanted == "usb" then
+    if type(System) == "table" and type(System.initUSB) == "function" then
+      pcall(System.initUSB)
     end
   end
-  return roots
+
+  local identity = BuildMassRootIdentity()
+  if wanted == "mx4sio" then
+    return identity.mx4sio
+  elseif wanted == "usb" then
+    return identity.usb
+  end
+  return {}
 end
 
 function PLDR.EnsureBackendForAppDir()
@@ -1054,12 +1054,23 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") then
-    local mx4_root_now = PLDR.GetMX4SIOMassRootNow()
-    local is_mx4_mass_path = false
-    if mx4_root_now ~= nil then
-      is_mx4_mass_path = string.sub(path, 1, string.len(mx4_root_now)) == mx4_root_now
+    local norm_path = NormalizeDirPath(path)
+    local identity = BuildMassRootIdentity()
+    local matched_root = nil
+    for i = 1, #identity.present_roots do
+      local root = NormalizeMassRoot(identity.present_roots[i])
+      if string.sub(norm_path, 1, string.len(root)) == root then
+        matched_root = root
+        break
+      end
     end
-    if is_mx4_mass_path then
+
+    local drv = nil
+    if matched_root ~= nil then
+      drv = PLDR.GetMassMountDriver(matched_root)
+    end
+
+    if type(drv) == "string" and string.find(drv, "sdc", 1, true) then
       if type(_G.ensureMx4sioInit) == "function" then
         local ok = pcall(_G.ensureMx4sioInit)
         if ok then return true end
@@ -1068,7 +1079,7 @@ function PLDR.EnsureBackendForAppDir()
         local ok = pcall(System.initMX4SIO)
         if ok then return true end
       end
-    else
+    elseif drv ~= nil then
       if type(System) == "table" and type(System.initUSB) == "function" then
         local ok = pcall(System.initUSB)
         if ok then return true end
@@ -1510,9 +1521,6 @@ function PLDR.InitMX4SIOPopsRoot()
   end
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
-  end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
   end
 
   local root = PLDR.GetMX4SIOMassRootNow()

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sifrpc.h>
 #include <string.h>
+#include <ctype.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
@@ -196,6 +197,27 @@ static bool EnsureMassBackendCache()
 		return true;
 	}
 	return RefreshMassBackendCache();
+}
+
+static bool ContainsIgnoreCase(const char *text, const char *needle)
+{
+	if (text == NULL || needle == NULL || needle[0] == '\0') {
+		return false;
+	}
+
+	for (const char *h = text; *h != '\0'; ++h) {
+		const char *h_cur = h;
+		const char *n_cur = needle;
+		while (*h_cur != '\0' && *n_cur != '\0' && tolower((unsigned char)*h_cur) == tolower((unsigned char)*n_cur)) {
+			++h_cur;
+			++n_cur;
+		}
+		if (*n_cur == '\0') {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 static bool GetMassRootByBackendNameInternal(const char *backend_name, char *out_root, size_t out_sz)
@@ -439,6 +461,64 @@ static int lua_get_mass_root_by_backend_name(lua_State *L)
 	char root[16];
 	if (GetMassRootByBackendNameInternal(backend_name, root, sizeof(root))) {
 		lua_pushstring(L, root);
+		return 1;
+	}
+
+	lua_pushnil(L);
+	return 1;
+}
+
+static int lua_get_mass_mount_driver(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1) {
+		return luaL_error(L, "Argument error: System.getMassMountDriver(root) takes one argument.");
+	}
+
+	const char *root = luaL_checkstring(L, 1);
+	int slot = -1;
+	if (strcmp(root, "mass:/") == 0 || strcmp(root, "mass0:/") == 0) {
+		slot = 0;
+	} else if (strncmp(root, "mass", 4) == 0 && root[4] >= '1' && root[4] <= '9' && strcmp(root + 5, ":/") == 0) {
+		slot = root[4] - '0';
+	} else {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	bdm_dev_list_t list;
+	if (!FetchBdmList(&list)) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	u32 limit = list.count;
+	if (limit > BDM_QUERY_MAX_DEVICES) {
+		limit = BDM_QUERY_MAX_DEVICES;
+	}
+
+	const char *first_candidate = NULL;
+	bool has_sdc_candidate = false;
+	for (u32 i = 0; i < limit; ++i) {
+		const bdm_dev_info_t *info = &list.devs[i];
+		if ((int)info->parId != slot || info->name[0] == '\0') {
+			continue;
+		}
+		if (first_candidate == NULL) {
+			first_candidate = info->name;
+		}
+		if (ContainsIgnoreCase(info->name, "sdc") || ContainsIgnoreCase(info->name, "mx4sio")) {
+			has_sdc_candidate = true;
+			break;
+		}
+	}
+
+	if (has_sdc_candidate) {
+		lua_pushstring(L, "sdc");
+		return 1;
+	}
+	if (first_candidate != NULL) {
+		lua_pushstring(L, first_candidate);
 		return 1;
 	}
 
@@ -1313,6 +1393,7 @@ static const luaL_Reg System_functions[] = {
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
+	{"getMassMountDriver",     lua_get_mass_mount_driver},
 	{"getMassRootByBackendName", lua_get_mass_root_by_backend_name},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}


### PR DESCRIPTION
### Motivation
- Intermittent failures where MX4SIO reports "No MX4SIO detected" and USB page shows only one device indicated the identity pipeline depended on timing/stale backend cache, so enumeration must be deterministic.
- Make identity decisions deterministic by forcing backend initialization once before folder existence checks and by using a fresh BDM list for driver resolution to avoid stale cache effects.

### Description
- C: added a new `System.getMassMountDriver(root)` Lua binding in `src/luasystem.cpp` that strictly validates `mass:/`, `mass0:/`, and `mass1:/..mass9:/`, maps to a slot, fetches a fresh `FetchBdmList` per call, picks a candidate bounded by `BDM_QUERY_MAX_DEVICES`, prefers `sdc`/`mx4sio` matches (returns canonical `"sdc"`) and otherwise returns the first non-empty driver name; also added a case-insensitive `ContainsIgnoreCase` helper and registered the function in `System_functions`.
- Lua: reworked `bin/POPSLDR/system.lua` to remove all `System.sleep` calls, added `PLDR.GetMassMountDriver(root)` wrapper, `NormalizeMassRoot`, and a new `BuildMassRootIdentity()` that invalidates/refreshes backends once, enumerates present mass roots bounded (0..9), normalizes/dedupes roots, and classifies them strictly by driver (`sdc` → MX4SIO, non-empty non-sdc → USB, unknown → excluded).
- Lua: changed timing so `PLDR.GetRootsByType(kind, ...)` calls the appropriate init function once before building identity (`initMX4SIO`/`ensureMx4sioInit` for mx4sio, `initUSB` for usb) and returns identity lists directly; simplified `PLDR.GetMX4SIOMassRootNow()` to init then read identity; updated `PLDR.RefreshMassStateSnapshot()` to return `mx4_root`, `mx4_roots`, and `usb_roots`; updated `PLDR.EnsureBackendForAppDir()` to route by matched root driver rather than mass-root prefix heuristics.
- Scope: only `src/luasystem.cpp` and `bin/POPSLDR/system.lua` were changed, no logging added, no sleeps/yields introduced, and logic remains bounded and deterministic.

### Testing
- Verified the expected symbols and code placements with `rg`/`grep` (presence of `getMassMountDriver`, `BuildMassRootIdentity`, `GetRootsByType`, `GetMX4SIOMassRootNow`, and removal of `System.sleep`) and the checks succeeded.
- Reviewed diffs with `git diff --stat` and `git diff -- src/luasystem.cpp bin/POPSLDR/system.lua` to confirm only the intended files/sections changed and those checks succeeded.
- Attempted Lua syntax check with `luac -p bin/POPSLDR/system.lua` but `luac` is unavailable in the environment, so that validation could not be performed.
- Ran `git status` to ensure the working tree is clean after the change and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a70bd147dc832188a31f9021141820)