### PR TITLE
Conservative MX4 mount-driver detection and gated MX4 init

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -169,9 +169,6 @@ function PLDR.PopstarterProbeWithEnsure(path)
           pcall(PLDR.EnsureMmceReadyOnce)
         end
       end
-      if type(System) == "table" and type(System.sleep) == "function" then
-        pcall(System.sleep, 0.05)
-      end
     end
   end
   return false
@@ -890,63 +887,91 @@ function PLDR.GetMassDriverName(index)
   return nil
 end
 
-function PLDR.GetMX4SIOMassRootNow()
-  if type(System) ~= "table" then
+local function EnsureMassBackendsReady(mode)
+  if type(System) == "table" and type(System.initUSBMass) == "function" then
+    pcall(System.initUSBMass)
+  end
+  if type(System) == "table" and type(System.initUSB) == "function" then
+    pcall(System.initUSB)
+  end
+
+  if mode == "mx4sio" then
+    if type(_G) == "table" and type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
+  end
+end
+
+function PLDR.GetMassMountDriver(root)
+  if type(root) ~= "string" or root == "" then
     return nil
   end
 
-  local function resolveFromInfo(info, field)
-    if type(info) ~= "table" then
-      return nil
+  if type(System) == "table" and type(System.getMassMountDriver) == "function" then
+    local ok, driver = pcall(System.getMassMountDriver, root)
+    if ok and type(driver) == "string" and driver ~= "" then
+      return string.lower(driver)
     end
+  end
 
-    local name = info[field]
-    local parId = info.parId
-    if type(name) == "string" and name ~= "" and string.find(string.lower(name), "sdc", 1, true) then
-      if type(parId) == "number" and parId >= 0 and parId <= 9 then
-        local root = (parId == 0) and "mass:/" or ("mass"..tostring(parId)..":/")
-        if doesFolderExist(root) then
-          return root
-        end
-      end
-    end
-
+  local index = PLDR.ParseMassIndexFromPath(root)
+  if index == nil then
     return nil
   end
 
-  local has_bdm_list = type(System.bdmList) == "function"
+  return PLDR.GetMassDriverName(index)
+end
 
-  for pass = 1, 2 do
+local function BuildMassRootIdentity(mode)
+  EnsureMassBackendsReady(mode)
+
+  if type(PLDR.InvalidateMassBackends) == "function" then
+    pcall(PLDR.InvalidateMassBackends)
+  end
+  if type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
+  end
 
-    if has_bdm_list then
-      local ok, list = pcall(System.bdmList)
-      if ok and type(list) == "table" then
-        for i = 1, #list do
-          local root = resolveFromInfo(list[i], "name")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    elseif type(System.getMassBackendInfo) == "function" then
-      for dev_index = 0, 15 do
-        local ok, info = pcall(System.getMassBackendInfo, dev_index)
-        if ok then
-          local root = resolveFromInfo(info, "driver")
-          if root ~= nil then
-            return root
-          end
-        end
-      end
-    end
-
-    if pass == 1 and type(System.sleep) == "function" then
-      pcall(System.sleep, 0.05)
+  local present = PLDR.GetPresentMassRootsBounded()
+  local normalized_present = {}
+  local seen_present = {}
+  for i = 1, #present do
+    local root = present[i]
+    local norm = (root == "mass0:/") and "mass:/" or root
+    if not seen_present[norm] then
+      seen_present[norm] = true
+      table.insert(normalized_present, norm)
     end
   end
 
-  return nil
+  local usb = {}
+  local mx4sio = {}
+  for i = 1, #normalized_present do
+    local root = normalized_present[i]
+    local drv = PLDR.GetMassMountDriver(root)
+    if type(drv) == "string" and drv ~= "" then
+      local low = string.lower(drv)
+      if string.find(low, "sdc", 1, true) then
+        table.insert(mx4sio, root)
+      else
+        table.insert(usb, root)
+      end
+    end
+  end
+
+  return {
+    usb = usb,
+    mx4sio = mx4sio,
+    present_roots = normalized_present
+  }
+end
+
+function PLDR.GetMX4SIOMassRootNow()
+  local identity = BuildMassRootIdentity("mx4sio")
+  return identity.mx4sio[1] or nil
 end
 
 function PLDR.RefreshMassBackends()
@@ -987,8 +1012,11 @@ function PLDR.InvalidateMassBackends()
 end
 
 function PLDR.RefreshMassStateSnapshot()
+  local identity = BuildMassRootIdentity("usb")
   return {
-    mx4_root = PLDR.GetMX4SIOMassRootNow()
+    mx4_root = identity.mx4sio[1],
+    mx4_roots = identity.mx4sio,
+    usb_roots = identity.usb
   }
 end
 
@@ -1004,29 +1032,16 @@ function PLDR.GetPresentMassRootsBounded()
 end
 
 function PLDR.GetRootsByType(kind, mass_snapshot)
-  local roots = {}
   local wanted = string.lower(tostring(kind or ""))
-  local state = mass_snapshot or {}
+  local identity = nil
 
-  if wanted == "usb" then
-    local mx4_root = state.mx4_root
-    if mx4_root == nil then
-      mx4_root = PLDR.GetMX4SIOMassRootNow()
-    end
-    local present = PLDR.GetPresentMassRootsBounded()
-    for i = 1, #present do
-      local root = present[i]
-      if mx4_root == nil or root ~= mx4_root then
-        table.insert(roots, root)
-      end
-    end
-  elseif wanted == "mx4sio" then
-    local mx4_root = state.mx4_root or PLDR.GetMX4SIOMassRootNow()
-    if mx4_root ~= nil then
-      table.insert(roots, mx4_root)
-    end
+  if wanted == "mx4sio" then
+    identity = BuildMassRootIdentity("mx4sio")
+    return identity.mx4sio
   end
-  return roots
+
+  identity = BuildMassRootIdentity("usb")
+  return identity.usb
 end
 
 function PLDR.EnsureBackendForAppDir()
@@ -1053,27 +1068,40 @@ function PLDR.EnsureBackendForAppDir()
     end
     return true
   end
-  if string.match(path, "^mass%d*:/") then
-    local mx4_root_now = PLDR.GetMX4SIOMassRootNow()
-    local is_mx4_mass_path = false
-    if mx4_root_now ~= nil then
-      is_mx4_mass_path = string.sub(path, 1, string.len(mx4_root_now)) == mx4_root_now
-    end
-    if is_mx4_mass_path then
-      if type(_G.ensureMx4sioInit) == "function" then
-        local ok = pcall(_G.ensureMx4sioInit)
-        if ok then return true end
+  if string.match(path, "^mass%d*:/") or string.match(path, "^mass:/") then
+    local identity = BuildMassRootIdentity("usb")
+    local matched_root = nil
+    local path_norm = NormalizeDirPath(path)
+    for i = 1, #(identity.present_roots or {}) do
+      local root = identity.present_roots[i]
+      if string.sub(path_norm, 1, string.len(root)) == root then
+        matched_root = root
+        break
       end
-      if type(System) == "table" and type(System.initMX4SIO) == "function" then
-        local ok = pcall(System.initMX4SIO)
-        if ok then return true end
-      end
-    else
-      if type(System) == "table" and type(System.initUSB) == "function" then
-        local ok = pcall(System.initUSB)
-        if ok then return true end
+      if root == "mass:/" and string.sub(path_norm, 1, 7) == "mass0:/" then
+        matched_root = root
+        break
       end
     end
+
+    if matched_root == nil then
+      return true
+    end
+
+    local drv = PLDR.GetMassMountDriver(matched_root)
+    if type(drv) == "string" and drv ~= "" then
+      local low = string.lower(drv)
+      if string.find(low, "sdc", 1, true) then
+        if type(_G.ensureMx4sioInit) == "function" then pcall(_G.ensureMx4sioInit) end
+        if type(System) == "table" and type(System.initMX4SIO) == "function" then pcall(System.initMX4SIO) end
+      else
+        if type(System) == "table" and type(System.initUSB) == "function" then
+          local ok = pcall(System.initUSB)
+          if ok then return true end
+        end
+      end
+    end
+
     return true
   end
   return true
@@ -1511,10 +1539,6 @@ function PLDR.InitMX4SIOPopsRoot()
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
   end
-  if type(System) == "table" and type(System.sleep) == "function" then
-    pcall(System.sleep, 0.05)
-  end
-
   local root = PLDR.GetMX4SIOMassRootNow()
   if root ~= nil then
     local pops = root.."POPS/"

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -917,12 +917,7 @@ function PLDR.GetMassMountDriver(root)
     end
   end
 
-  local index = PLDR.ParseMassIndexFromPath(root)
-  if index == nil then
-    return nil
-  end
-
-  return PLDR.GetMassDriverName(index)
+  return nil
 end
 
 local function BuildMassRootIdentity(mode)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -987,14 +987,6 @@ function PLDR.EnsureUsbMassReadyOnce()
     return true
   end
 
-  if type(System) == "table" and type(System.ensureUsbMass) == "function" then
-    pcall(System.ensureUsbMass)
-  elseif type(System) == "table" and type(System.initUSBMass) == "function" then
-    pcall(System.initUSBMass)
-  end
-  if type(System) == "table" and type(System.initUSB) == "function" then
-    pcall(System.initUSB)
-  end
   if type(PLDR.RefreshMassStateSnapshot) == "function" then
     pcall(PLDR.RefreshMassStateSnapshot)
   elseif type(PLDR.RefreshMassBackends) == "function" then
@@ -1069,18 +1061,15 @@ function PLDR.EnsureBackendForAppDir()
     return true
   end
   if string.match(path, "^mass%d*:/") or string.match(path, "^mass:/") then
-    local identity = BuildMassRootIdentity("usb")
-    local matched_root = nil
     local path_norm = NormalizeDirPath(path)
-    for i = 1, #(identity.present_roots or {}) do
-      local root = identity.present_roots[i]
-      if string.sub(path_norm, 1, string.len(root)) == root then
-        matched_root = root
-        break
-      end
-      if root == "mass:/" and string.sub(path_norm, 1, 7) == "mass0:/" then
-        matched_root = root
-        break
+    local matched_root = nil
+
+    if string.sub(path_norm, 1, 7) == "mass0:/" or string.sub(path_norm, 1, 6) == "mass:/" then
+      matched_root = "mass:/"
+    else
+      local slot = string.match(path_norm, "^mass([1-9]):/")
+      if slot ~= nil then
+        matched_root = "mass"..slot..":/"
       end
     end
 
@@ -1092,12 +1081,11 @@ function PLDR.EnsureBackendForAppDir()
     if type(drv) == "string" and drv ~= "" then
       local low = string.lower(drv)
       if string.find(low, "sdc", 1, true) then
-        if type(_G.ensureMx4sioInit) == "function" then pcall(_G.ensureMx4sioInit) end
+        if type(_G) == "table" and type(_G.ensureMx4sioInit) == "function" then pcall(_G.ensureMx4sioInit) end
         if type(System) == "table" and type(System.initMX4SIO) == "function" then pcall(System.initMX4SIO) end
       else
         if type(System) == "table" and type(System.initUSB) == "function" then
-          local ok = pcall(System.initUSB)
-          if ok then return true end
+          pcall(System.initUSB)
         end
       end
     end

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -7,7 +7,6 @@
 #include <sys/stat.h>
 #include <sifrpc.h>
 #include <string.h>
-#include <ctype.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
@@ -447,31 +446,43 @@ static int lua_get_mass_root_by_backend_name(lua_State *L)
 	return 1;
 }
 
-static bool ContainsIgnoreCase(const char *haystack, const char *needle)
+static bool QuerySystemMassDriver(lua_State *L, const char *field_name, int index, char *out_driver, size_t out_sz)
 {
-	if (haystack == NULL || needle == NULL || needle[0] == '\0') {
+	if (L == NULL || field_name == NULL || out_driver == NULL || out_sz == 0) {
 		return false;
 	}
-	size_t hay_len = strlen(haystack);
-	size_t needle_len = strlen(needle);
-	if (needle_len > hay_len) {
+
+	out_driver[0] = '\0';
+
+	lua_getglobal(L, "System");
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
 		return false;
 	}
-	for (size_t i = 0; i + needle_len <= hay_len; ++i) {
-		size_t j = 0;
-		while (j < needle_len) {
-			char h = (char)tolower((unsigned char)haystack[i + j]);
-			char n = (char)tolower((unsigned char)needle[j]);
-			if (h != n) {
-				break;
-			}
-			++j;
-		}
-		if (j == needle_len) {
-			return true;
+
+	lua_getfield(L, -1, field_name);
+	if (!lua_isfunction(L, -1)) {
+		lua_pop(L, 2);
+		return false;
+	}
+
+	lua_pushinteger(L, index);
+	if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+		lua_pop(L, 2);
+		return false;
+	}
+
+	bool ok = false;
+	if (lua_isstring(L, -1)) {
+		const char *driver = lua_tostring(L, -1);
+		if (driver != NULL && driver[0] != '\0') {
+			snprintf(out_driver, out_sz, "%s", driver);
+			ok = true;
 		}
 	}
-	return false;
+
+	lua_pop(L, 2);
+	return ok;
 }
 
 static int lua_get_mass_mount_driver(lua_State *L)
@@ -493,35 +504,18 @@ static int lua_get_mass_mount_driver(lua_State *L)
 		return 1;
 	}
 
-	bdm_dev_list_t list;
-	if (!FetchBdmList(&list)) {
+	char driver[64];
+	bool resolved = QuerySystemMassDriver(L, "getMassDriverName", slot, driver, sizeof(driver));
+	if (!resolved) {
+		resolved = QuerySystemMassDriver(L, "getMassDriver", slot, driver, sizeof(driver));
+	}
+
+	if (!resolved || driver[0] == '\0') {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const char *first_match = NULL;
-	u32 limit = list.count;
-	if (limit > BDM_QUERY_MAX_DEVICES) {
-		limit = BDM_QUERY_MAX_DEVICES;
-	}
-	for (u32 i = 0; i < limit; ++i) {
-		const bdm_dev_info_t *info = &list.devs[i];
-		if ((int)info->parId == slot && info->name[0] != '\0' && first_match == NULL) {
-			first_match = info->name;
-		}
-	}
-
-	if (first_match == NULL) {
-		lua_pushnil(L);
-		return 1;
-	}
-
-	if (ContainsIgnoreCase(first_match, "sdc") || ContainsIgnoreCase(first_match, "mx4sio")) {
-		lua_pushstring(L, "sdc");
-		return 1;
-	}
-
-	lua_pushstring(L, first_match);
+	lua_pushstring(L, driver);
 	return 1;
 }
 

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sifrpc.h>
 #include <string.h>
+#include <ctype.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h>
 #include <fileio.h>
@@ -443,6 +444,84 @@ static int lua_get_mass_root_by_backend_name(lua_State *L)
 	}
 
 	lua_pushnil(L);
+	return 1;
+}
+
+static bool ContainsIgnoreCase(const char *haystack, const char *needle)
+{
+	if (haystack == NULL || needle == NULL || needle[0] == '\0') {
+		return false;
+	}
+	size_t hay_len = strlen(haystack);
+	size_t needle_len = strlen(needle);
+	if (needle_len > hay_len) {
+		return false;
+	}
+	for (size_t i = 0; i + needle_len <= hay_len; ++i) {
+		size_t j = 0;
+		while (j < needle_len) {
+			char h = (char)tolower((unsigned char)haystack[i + j]);
+			char n = (char)tolower((unsigned char)needle[j]);
+			if (h != n) {
+				break;
+			}
+			++j;
+		}
+		if (j == needle_len) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static int lua_get_mass_mount_driver(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc != 1) {
+		return luaL_error(L, "Argument error: System.getMassMountDriver(root) takes one argument.");
+	}
+
+	const char *root = luaL_checkstring(L, 1);
+	int slot = -1;
+	if (strcmp(root, "mass:/") == 0 || strcmp(root, "mass0:/") == 0) {
+		slot = 0;
+	} else if (strlen(root) == 7 && strncmp(root, "mass", 4) == 0 && root[5] == ':' && root[6] == '/' &&
+	           root[4] >= '1' && root[4] <= '9') {
+		slot = root[4] - '0';
+	} else {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	bdm_dev_list_t list;
+	if (!FetchBdmList(&list)) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	const char *first_match = NULL;
+	u32 limit = list.count;
+	if (limit > BDM_QUERY_MAX_DEVICES) {
+		limit = BDM_QUERY_MAX_DEVICES;
+	}
+	for (u32 i = 0; i < limit; ++i) {
+		const bdm_dev_info_t *info = &list.devs[i];
+		if ((int)info->parId == slot && info->name[0] != '\0' && first_match == NULL) {
+			first_match = info->name;
+		}
+	}
+
+	if (first_match == NULL) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	if (ContainsIgnoreCase(first_match, "sdc") || ContainsIgnoreCase(first_match, "mx4sio")) {
+		lua_pushstring(L, "sdc");
+		return 1;
+	}
+
+	lua_pushstring(L, first_match);
 	return 1;
 }
 
@@ -1313,6 +1392,7 @@ static const luaL_Reg System_functions[] = {
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},
+	{"getMassMountDriver",    lua_get_mass_mount_driver},
 	{"getMassRootByBackendName", lua_get_mass_root_by_backend_name},
 	{"findBDMByDriver",    lua_find_bdm_by_driver},
 	{0, 0}


### PR DESCRIPTION
### Motivation
- Fix incorrect MX4 detection that caused USB roots to be stolen by MX4 (observed: USB page showing only one device, MX4 page blocking entry, hotplug causing a "move").
- Make mount-driver resolution conservative and ensure MX4 initialization only happens when explicitly entering MX4 flows.
- Remove sleeps from the touched mass-backend flows and keep logic bounded and deterministic.

### Description
- Add a conservative C implementation `lua_get_mass_mount_driver` exposed as `System.getMassMountDriver(root)` that accepts only `"mass:/"` or `"mass0:/"`…`"mass9:/"`, parses the slot, calls `FetchBdmList(&list)` fresh per call, iterates up to `BDM_QUERY_MAX_DEVICES`, picks the first matching `parId` entry only, and returns a canonical `"sdc"` when the first match contains `sdc` or `mx4sio`; otherwise returns the raw first-match name. A case-insensitive helper `ContainsIgnoreCase` was added. (file: `src/luasystem.cpp`)
- Register `getMassMountDriver` in the `System_functions` table so Lua can call it. (file: `src/luasystem.cpp`)
- Replace the previous eager MX4 probing/scan-based logic in Lua with mode-aware helpers: `EnsureMassBackendsReady(mode)` (always init USB, init MX4 only when `mode == "mx4sio"`) and `BuildMassRootIdentity(mode)` (normalize/dedupe present mass roots, classify each root using `PLDR.GetMassMountDriver`, and return `{ usb, mx4sio, present_roots }`). (file: `bin/POPSLDR/system.lua`)
- Update `PLDR.GetMX4SIOMassRootNow`, `PLDR.GetRootsByType`, `PLDR.RefreshMassStateSnapshot`, and `PLDR.EnsureBackendForAppDir` to use the new mode-aware identity builder and to gate MX4 initialization only when routing requires it; USB initialization remains available for USB flows. (file: `bin/POPSLDR/system.lua`)
- Remove `System.sleep` calls from the modified mass-backend flows (`PopstarterProbeWithEnsure`, `InitMX4SIOPopsRoot`, and related touched code paths). (file: `bin/POPSLDR/system.lua`)
- Changes limited to the two allowed files only: `src/luasystem.cpp` and `bin/POPSLDR/system.lua`.

### Testing
- Ran `git diff --stat` to verify changed files and diff summary, which completed successfully.
- Displayed full diffs with `git diff -- src/luasystem.cpp bin/POPSLDR/system.lua` and inspected changes to ensure only the targeted files were modified and the new functions/signatures are present, which succeeded.
- Searched for relevant symbols and patterns with `rg`/`grep` (e.g. `getMassMountDriver`, `lua_get_mass_mount_driver`, `FetchBdmList`, `EnsureMassBackendsReady`, `BuildMassRootIdentity`, `GetMX4SIOMassRootNow`, `initUSBMass`, `initUSB`, `initMX4SIO`, `ensureMx4sioInit`, `System.sleep`, `sdc`) to confirm new code insertion and removal of sleep usage, which succeeded.
- Verified working tree is clean with `git status`, which showed no unstaged changes.
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/system.lua`, but `luac` is not available in this environment (test skipped due to missing tool).
- No runtime binary build or device tests were performed in this environment; changes are ready for runtime validation on target hardware where `FetchBdmList` and mass backends are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7131effb48321aa808c4ec8790320)