### PR TITLE
MX4: auto second attempt on first entry (bounded, no sleeps)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1025,6 +1025,9 @@ end
 function PLDR.GetMX4SIOMassRootNow()
   local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
     identity = BuildMassRootIdentity("mx4sio")
   end
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
@@ -1038,6 +1041,9 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
   if wanted == "mx4sio" then
     local identity = BuildMassRootIdentity("mx4sio")
     if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
+      if type(_G.ensureMx4sioInit) == "function" then
+        pcall(_G.ensureMx4sioInit)
+      end
       identity = BuildMassRootIdentity("mx4sio")
     end
     return identity.mx4sio

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1023,10 +1023,17 @@ local function BuildMassRootIdentity(mode)
 end
 
 function PLDR.GetMX4SIOMassRootNow()
+  if type(_G.ensureMx4sioInit) == "function" then
+    pcall(_G.ensureMx4sioInit)
+  end
+  if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
+    pcall(PLDR.RefreshMassBackends)
+  end
+
   local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
+    if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
+      pcall(PLDR.RefreshMassBackends)
     end
     identity = BuildMassRootIdentity("mx4sio")
   end
@@ -1039,10 +1046,17 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
+      pcall(PLDR.RefreshMassBackends)
+    end
+
     local identity = BuildMassRootIdentity("mx4sio")
     if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
-      if type(_G.ensureMx4sioInit) == "function" then
-        pcall(_G.ensureMx4sioInit)
+      if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
+        pcall(PLDR.RefreshMassBackends)
       end
       identity = BuildMassRootIdentity("mx4sio")
     end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1022,13 +1022,24 @@ local function BuildMassRootIdentity(mode)
   return identity
 end
 
-function PLDR.GetMX4SIOMassRootNow()
+local mx4_entry_primed = false
+
+local function PrimeMX4Once()
+  if mx4_entry_primed then
+    return
+  end
+  mx4_entry_primed = true
+
   if type(_G.ensureMx4sioInit) == "function" then
     pcall(_G.ensureMx4sioInit)
   end
   if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
     pcall(PLDR.RefreshMassBackends)
   end
+end
+
+function PLDR.GetMX4SIOMassRootNow()
+  PrimeMX4Once()
 
   local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
@@ -1046,12 +1057,7 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
-    if type(_G.ensureMx4sioInit) == "function" then
-      pcall(_G.ensureMx4sioInit)
-    end
-    if type(PLDR) == "table" and type(PLDR.RefreshMassBackends) == "function" then
-      pcall(PLDR.RefreshMassBackends)
-    end
+    PrimeMX4Once()
 
     local identity = BuildMassRootIdentity("mx4sio")
     if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1024,6 +1024,9 @@ end
 
 function PLDR.GetMX4SIOMassRootNow()
   local identity = BuildMassRootIdentity("mx4sio")
+  if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
+    identity = BuildMassRootIdentity("mx4sio")
+  end
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
     return identity.mx4sio[1]
   end
@@ -1034,6 +1037,9 @@ function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
     local identity = BuildMassRootIdentity("mx4sio")
+    if type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0 then
+      identity = BuildMassRootIdentity("mx4sio")
+    end
     return identity.mx4sio
   end
 


### PR DESCRIPTION
### Motivation
- Fix a UX issue where the MX4SIO page sometimes required the user to press entry twice on cold boot by automatically performing exactly one additional MX4 identity attempt when the first yields empty roots.
- Maintain existing USB vs MX4 separation and identity rules without changing UI, logging, waits, or backend scanning behavior.
- Keep change minimal and localized to the MX4 entry accessor level as a bounded, deterministic retry (exactly one extra attempt). 

### Description
- Updated `PLDR.GetMX4SIOMassRootNow()` in `bin/POPSLDR/system.lua` to call `BuildMassRootIdentity("mx4sio")` once and, if the result meets the strict empty predicate (`type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0`), immediately call `BuildMassRootIdentity("mx4sio")` exactly one more time before returning the first root or `nil`.
- Updated the `wanted == "mx4sio"` branch in `PLDR.GetRootsByType(kind, mass_snapshot)` to apply the same single additional attempt behavior and return `identity.mx4sio` from the final identity.
- No changes were made to USB logic, no sleeps/waits/yields were introduced, no retry loops added, and no global state or backend enumeration was added.

### Testing
- Verified the patch diff summary with `git diff --stat` and confirmed `bin/POPSLDR/system.lua | 6 ++++++` succeeded.
- Inspected the file diff with `git diff -- bin/POPSLDR/system.lua` and confirmed the two bounded retry insertions into the MX4 code paths succeeded.
- Scanned the modified file with `rg -n "mx4|BuildMassRootIdentity\(|EnsureMassBackendsReady\(|System\.sleep|yield|bdmList|getMassBackendInfo" bin/POPSLDR/system.lua` to ensure no forbidden calls or extra backend enumeration were introduced and the check succeeded.
- Confirmed the working tree status with `git status` and found the repository clean after applying the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a78d756d08832195ee4617d21f0ab4)