### PR TITLE
MX4 UX: auto second attempt after not-detected (one-shot)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1351,6 +1351,8 @@ UI = {
     };
     MainMenu = {
       OPT = 1;
+      mx4_autoretry_pending = false;
+      mx4_autoretry_at_ms = 0;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
@@ -1373,6 +1375,21 @@ UI = {
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
+	      local function TryEnterMX4SIO(show_notif)
+	        PLDR.CleanupGameList()
+	        PLDR.GAMEPATH = ""
+	        local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+	        if mx4sio_root == nil then
+	          if show_notif then UI.Notif_queue.add("No MX4SIO device found") end
+	          return false
+	        else
+	          PLDR.CleanupGameList()
+	          PLDR.GetPS1GameLists(mx4sio_root, true)
+	          UI.setDeviceLock(DEVLOCK.MX4SIO)
+	          UI.SceneChange(UI.SCENES.GMX4SIO)
+	          return true
+	        end
+	      end
 	        -- Pages are no longer presented as "locked" in the UI.
         local icon_map = {
           ["MMCE"] = "MMCE",
@@ -1526,6 +1543,7 @@ UI = {
         if UI.HandleGlobalInput(false) then return end
         if not carousel.animActive then
           if UI.Pad.Events.NAV_RIGHT then
+            UI.MainMenu.mx4_autoretry_pending = false
             carousel.targetIndex = WrapIndex(carousel.currentIndex + 1, profcnt)
             carousel.animDir = 1
             carousel.animActive = true
@@ -1533,6 +1551,7 @@ UI = {
             carousel.slide = 0
           end
           if UI.Pad.Events.NAV_LEFT then
+            UI.MainMenu.mx4_autoretry_pending = false
             carousel.targetIndex = WrapIndex(carousel.currentIndex - 1, profcnt)
             carousel.animDir = -1
             carousel.animActive = true
@@ -1540,8 +1559,12 @@ UI = {
             carousel.slide = 0
           end
         end
-        if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
+        if UI.Pad.Events.EXIT then
+          UI.MainMenu.mx4_autoretry_pending = false
+          UI.SceneChange(UI.SCENES.CREDITS)
+        end
         if UI.Pad.Events.BACK then
+          UI.MainMenu.mx4_autoretry_pending = false
           UI.Modal.OpenExit()
           return
         end
@@ -1571,18 +1594,11 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
-              return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
-            end
+            UI.MainMenu.mx4_autoretry_pending = false
+            if TryEnterMX4SIO(true) then return end
+            UI.MainMenu.mx4_autoretry_pending = true
+            UI.MainMenu.mx4_autoretry_at_ms = Timer.getTime(UI.Pad.Timer) + 250
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then
@@ -1628,6 +1644,10 @@ UI = {
             end
             UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
+        end
+        if UI.MainMenu.mx4_autoretry_pending and UI.MainMenu.OPT == 2 and Timer.getTime(UI.Pad.Timer) >= UI.MainMenu.mx4_autoretry_at_ms then
+          UI.MainMenu.mx4_autoretry_pending = false
+          TryEnterMX4SIO(false)
         end
       end
     };

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1597,7 +1597,7 @@ UI = {
             UI.MainMenu.mx4_autoretry_pending = false
             if TryEnterMX4SIO(true) then return end
             UI.MainMenu.mx4_autoretry_pending = true
-            UI.MainMenu.mx4_autoretry_at_ms = Timer.getTime(UI.Pad.Timer) + 250
+            UI.MainMenu.mx4_autoretry_at_ms = Timer.getTime(carousel.timer) + 250
             return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
@@ -1645,7 +1645,7 @@ UI = {
             UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
         end
-        if UI.MainMenu.mx4_autoretry_pending and UI.MainMenu.OPT == 2 and Timer.getTime(UI.Pad.Timer) >= UI.MainMenu.mx4_autoretry_at_ms then
+        if UI.MainMenu.mx4_autoretry_pending and UI.MainMenu.OPT == 2 and Timer.getTime(carousel.timer) >= UI.MainMenu.mx4_autoretry_at_ms then
           UI.MainMenu.mx4_autoretry_pending = false
           TryEnterMX4SIO(false)
         end


### PR DESCRIPTION
### Motivation

- The MX4SIO entry occasionally fails on the first attempt at cold boot but succeeds on an immediate user retry, so add a single automatic second attempt to improve UX without changing device code.
- The fix must be minimal, UI-only, bounded to exactly one automatic retry per user confirm, and avoid changing strings, scene IDs, or C/C++ code.

### Description

- Added a local helper `TryEnterMX4SIO(show_notif)` inside `UI.MainMenu.Play()` that encapsulates the existing MX4SIO entry path (`PLDR.CleanupGameList()`, `PLDR.GAMEPATH = ""`, `PLDR.InitMX4SIOPopsRoot()`, `PLDR.GetPS1GameLists(...)`, `UI.setDeviceLock(DEVLOCK.MX4SIO)`, `UI.SceneChange(UI.SCENES.GMX4SIO)`) and preserves the original failure notification when `show_notif` is true.
- Introduced bounded one-shot retry state on `UI.MainMenu` via `mx4_autoretry_pending` and `mx4_autoretry_at_ms`, with the confirm flow cleared of stale retries, first attempt performed immediately (with notification), and a single delayed retry armed at `Timer.getTime(UI.Pad.Timer) + 250` ms if the first attempt fails.
- Added guards to cancel the pending retry when the user navigates away, presses BACK/EXIT, or changes selection, and execute the delayed retry in the main menu tick with the pending flag cleared before invoking the helper to ensure exactly one retry and no loops.
- Scope limited to `bin/POPSLDR/ui.lua` only and no changes to strings, scene ids, `system.lua`, or native code were made.

### Testing

- Verified the working diff summary to confirm only `bin/POPSLDR/ui.lua` was modified using a repository diff/stat check (succeeded).
- Inspected the file diff for `bin/POPSLDR/ui.lua` to confirm insertion of `TryEnterMX4SIO`, the retry state, confirm-path changes, per-frame retry execution, and navigation/exit cancellation (succeeded).
- Searched the updated file for `TryEnterMX4SIO`, `mx4_autoretry`, `autoretry`, and `InitMX4SIOPopsRoot()` to confirm correct wiring (succeeded).
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/ui.lua` but `luac` is not available in this environment (syntax check not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a09180608321b7ce3fe63c388fce)