### PR TITLE
MX4 UX: double-attempt MX4 entry on confirm (no timers)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1022,47 +1022,8 @@ local function BuildMassRootIdentity(mode)
   return identity
 end
 
-local mx4_retry_pending = false
-local mx4_retry_used = false
-local mx4_present_sig = nil
-
-local function MassRootsSignature()
-  local roots = PLDR.GetPresentMassRootsBounded()
-  return table.concat(roots, "|")
-end
-
-local function BuildMX4IdentityDeferred()
-  local sig = MassRootsSignature()
-  if sig ~= mx4_present_sig then
-    mx4_present_sig = sig
-    mx4_retry_pending = false
-    mx4_retry_used = false
-  end
-
-  local identity = BuildMassRootIdentity("mx4sio")
-  local empty = (type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0)
-  if not empty then
-    mx4_retry_pending = false
-    mx4_retry_used = false
-    return identity
-  end
-
-  if mx4_retry_used then
-    return identity
-  end
-
-  if not mx4_retry_pending then
-    mx4_retry_pending = true
-    return identity
-  end
-
-  mx4_retry_pending = false
-  mx4_retry_used = true
-  return identity
-end
-
 function PLDR.GetMX4SIOMassRootNow()
-  local identity = BuildMX4IdentityDeferred()
+  local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
     return identity.mx4sio[1] or nil
   end
@@ -1072,7 +1033,7 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
-    local identity = BuildMX4IdentityDeferred()
+    local identity = BuildMassRootIdentity("mx4sio")
     return identity.mx4sio
   end
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1545,6 +1545,21 @@ UI = {
           UI.Modal.OpenExit()
           return
         end
+        local function TryEnterMX4SIO(show_notif)
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4_root == nil then
+            if show_notif then UI.Notif_queue.add("No MX4SIO device found") end
+            return false
+          else
+            PLDR.CleanupGameList()
+            PLDR.GetPS1GameLists(mx4_root, true)
+            UI.setDeviceLock(DEVLOCK.MX4SIO)
+            UI.SceneChange(UI.SCENES.GMX4SIO)
+            return true
+          end
+        end
         if UI.Pad.Events.CONFIRM then
           if UI.MainMenu.OPT == 1 then
             if type(System) == "table" and type(System.initMMCE) == "function" then
@@ -1571,18 +1586,10 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
-              return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
-            end
+            if TryEnterMX4SIO(false) then return end
+            if TryEnterMX4SIO(false) then return end
+            UI.Notif_queue.add("No MX4SIO device found")
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- Users experience a transient MX4SIO first-entry failure that is reliably worked around by pressing X immediately again, so the UX should replicate two back-to-back entry attempts inside the same confirm press without adding timers or deferred state.
- The fix must be minimal and UI-local so it does not change identity logic, C-side behavior, USB handling, or POPStarter routing.

### Description
- Added a local helper `TryEnterMX4SIO(show_notif)` inside `UI.MainMenu.Play()` that encapsulates the existing MX4 entry pipeline (`PLDR.CleanupGameList()` → `PLDR.GAMEPATH = ""` → `PLDR.InitMX4SIOPopsRoot()` → load lists / `UI.setDeviceLock(DEVLOCK.MX4SIO)` → `UI.SceneChange(UI.SCENES.GMX4SIO)`), and it returns `true` on success and `false` on failure while optionally showing the notification.
- Replaced the `OPT == 2` confirm handler with a bounded two-attempt flow that calls `TryEnterMX4SIO(false)` twice back-to-back and only shows `UI.Notif_queue.add("No MX4SIO device found")` if both attempts fail.
- Removed leftover MX4 retry experiment code from `bin/POPSLDR/system.lua` (the `BuildMX4IdentityDeferred`, `MassRootsSignature`, and `mx4_retry_*` state and logic) and restored direct calls to `BuildMassRootIdentity("mx4sio")` for MX4 root resolution.
- Did not touch any C code or unrelated behaviors; no timers, no deferred retry state, and no extra notifications were introduced.

### Testing
- Ran `git diff --stat` and `git diff` to inspect changes, which show only `bin/POPSLDR/ui.lua` and `bin/POPSLDR/system.lua` were modified and the intended lines were added/removed. (succeeded)
- Ran `rg -n "mx4_autoretry|TryEnterMX4SIO|retrying|at_ms|Timer\.getTime\(|BuildMX4IdentityDeferred|MassRootsSignature|mx4_retry_pending|mx4_entry_primed" bin/POPSLDR/ui.lua bin/POPSLDR/system.lua` to verify no autoretry identifiers remain and `TryEnterMX4SIO` exists in `ui.lua`. (succeeded)
- Ran `git status --short` to confirm the working tree is clean after committing the single commit named `MX4 UX: double-attempt MX4 entry on confirm (no timers)`. (succeeded)
- Attempted to `lua -e "assert(loadfile('bin/POPSLDR/ui.lua')); assert(loadfile('bin/POPSLDR/system.lua'))"` to syntax-check the Lua files but the environment lacks a `lua` interpreter so this check could not run here. (not executed due to missing `lua`)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7bddfa2e48321ac3d5926a205506f)