### PR TITLE
MX4 UX: one-frame deferred second MX4 entry attempt (no timers)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1022,47 +1022,8 @@ local function BuildMassRootIdentity(mode)
   return identity
 end
 
-local mx4_retry_pending = false
-local mx4_retry_used = false
-local mx4_present_sig = nil
-
-local function MassRootsSignature()
-  local roots = PLDR.GetPresentMassRootsBounded()
-  return table.concat(roots, "|")
-end
-
-local function BuildMX4IdentityDeferred()
-  local sig = MassRootsSignature()
-  if sig ~= mx4_present_sig then
-    mx4_present_sig = sig
-    mx4_retry_pending = false
-    mx4_retry_used = false
-  end
-
-  local identity = BuildMassRootIdentity("mx4sio")
-  local empty = (type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0)
-  if not empty then
-    mx4_retry_pending = false
-    mx4_retry_used = false
-    return identity
-  end
-
-  if mx4_retry_used then
-    return identity
-  end
-
-  if not mx4_retry_pending then
-    mx4_retry_pending = true
-    return identity
-  end
-
-  mx4_retry_pending = false
-  mx4_retry_used = true
-  return identity
-end
-
 function PLDR.GetMX4SIOMassRootNow()
-  local identity = BuildMX4IdentityDeferred()
+  local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
     return identity.mx4sio[1] or nil
   end
@@ -1072,7 +1033,7 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
-    local identity = BuildMX4IdentityDeferred()
+    local identity = BuildMassRootIdentity("mx4sio")
     return identity.mx4sio
   end
 

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1351,6 +1351,7 @@ UI = {
     };
     MainMenu = {
       OPT = 1;
+      mx4_retry_pending = false;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
@@ -1373,6 +1374,24 @@ UI = {
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
+
+        local function TryEnterMX4SIO(show_notif)
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4_root == nil then
+            if show_notif then
+              UI.Notif_queue.add("No MX4SIO device found")
+            end
+            return false
+          end
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+          return true
+        end
+
 	        -- Pages are no longer presented as "locked" in the UI.
         local icon_map = {
           ["MMCE"] = "MMCE",
@@ -1542,8 +1561,12 @@ UI = {
         end
         if UI.Pad.Events.EXIT then UI.SceneChange(UI.SCENES.CREDITS) end
         if UI.Pad.Events.BACK then
+          UI.MainMenu.mx4_retry_pending = false
           UI.Modal.OpenExit()
           return
+        end
+        if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT then
+          UI.MainMenu.mx4_retry_pending = false
         end
         if UI.Pad.Events.CONFIRM then
           if UI.MainMenu.OPT == 1 then
@@ -1571,18 +1594,12 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
+            UI.MainMenu.mx4_retry_pending = false
+            if TryEnterMX4SIO(false) then
               return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
             end
+            UI.MainMenu.mx4_retry_pending = true
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then
@@ -1628,6 +1645,22 @@ UI = {
             end
             UI.Modal.OpenDKWDRV()
           end --because we still dont support SMB
+        end
+
+        local on_mx4 = (carousel.currentIndex == 2) or (carousel.targetIndex == 2)
+        if not on_mx4 then
+          UI.MainMenu.mx4_retry_pending = false
+        end
+        if UI.Pad.Events.EXIT then
+          UI.MainMenu.mx4_retry_pending = false
+        end
+        if UI.MainMenu.mx4_retry_pending and on_mx4 then
+          UI.MainMenu.mx4_retry_pending = false
+          if TryEnterMX4SIO(false) then
+            return
+          end
+          UI.Notif_queue.add("No MX4SIO device found")
+          return
         end
       end
     };


### PR DESCRIPTION
### Motivation
- Emulate the user behavior of pressing X twice for MX4SIO entry by performing an automatic single retry on the next UI frame so cold-boot false negatives are handled without requiring hotplug or a real second press.
- Preserve existing USB/MMCE/BDMA/launch behavior and avoid timers/sleeps/loops while bounding attempts to two per user press.
- Remove accidental/deferred identity retry artifacts in `system.lua` and ensure MX4 root lookup uses the baseline direct identity path.

### Description
- Added `mx4_retry_pending = false` to `UI.MainMenu` to track a one-frame deferred retry state.
- Implemented `TryEnterMX4SIO(show_notif)` as a local helper inside `UI.MainMenu.Play()` which centralizes the MX4 entry pipeline and handles optional notification on failure.
- Modified the MX4 `CONFIRM` handler so the first attempt is immediate and silent, and if it fails it arms `mx4_retry_pending` and returns (no notification); the retry will run on the next frame.
- At the end of `UI.MainMenu.Play()` added logic to clear pending retries when navigation/back/exit occur or when the carousel is no longer on the MX4 slot, and to consume the pending retry exactly once on the next frame, showing a single notification only if both attempts fail.
- Removed the deferred MX4 identity retry helpers (`BuildMX4IdentityDeferred`, `MassRootsSignature`, and related retry state) from `bin/POPSLDR/system.lua` and replaced calls to them with direct `BuildMassRootIdentity("mx4sio")` lookups to preserve baseline behavior.

### Testing
- Ran `git diff --stat` and `git diff` to validate file changes and patch content, which succeeded.
- Ran `rg -n` for the relevant symbols (`mx4_retry_pending`, `TryEnterMX4SIO`, `BuildMX4IdentityDeferred`, `MassRootsSignature`, `System.sleep`, etc.) across `bin/POPSLDR/ui.lua` and `bin/POPSLDR/system.lua` to verify new symbols and removal of deferred helpers, which succeeded.
- Verified repository state with `git status` and committed with the message `MX4 UX: one-frame deferred second MX4 entry attempt (no timers)`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c09ed0e88321850d37ff36d2f870)