### PR TITLE
MX4: perform bounded double probe in EnsureMx4sioMass to mask second-press hardware quirk

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -36,7 +36,11 @@ extern unsigned int size_cdfs_irx;
 
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
+static bool ProbeDir(const char *path, int *out_ret);
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
+static bool RefreshMassBackendCache();
+static const char *ClassifyMassBackend(const char *driver);
+static const char *GetMassMountDriverNameBySlot(int slot);
 
 #ifndef USBMASS_IOCTL_GET_DRIVERNAME
 #define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
@@ -113,6 +117,52 @@ static bool EnsureUsbMass()
 	}
 	usbmass_irx_loaded = true;
 	return true;
+}
+
+static bool EnsureMx4sioMass()
+{
+	if (!EnsureBDMFatFs()) {
+		return false;
+	}
+
+	if (!mx4sio_irx_loaded) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+			return false;
+		}
+		mx4sio_irx_loaded = true;
+	}
+
+	for (int pass = 0; pass < 2; ++pass) {
+		char root[16];
+		for (int slot = 0; slot <= 9; ++slot) {
+			BuildMassRootPath(slot, root, sizeof(root));
+			ProbeDir(root, NULL);
+		}
+
+		mass_backend_cache_valid = false;
+		bool cache_ok = RefreshMassBackendCache();
+
+		if (pass == 0) {
+			continue;
+		}
+
+		if (cache_ok) {
+			for (u32 i = 0; i < mass_backend_cache.count; ++i) {
+				if (strcmp(ClassifyMassBackend(mass_backend_cache.devs[i].name), "mx4sio") == 0) {
+					return true;
+				}
+			}
+		}
+
+		for (int slot = 0; slot <= 9; ++slot) {
+			const char *driver = GetMassMountDriverNameBySlot(slot);
+			if (driver != NULL && strcmp(ClassifyMassBackend(driver), "mx4sio") == 0) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 static bool EnsureCDFS()
@@ -1266,13 +1316,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation
- MX4SIO devices become visible only after an initial backend poke, forcing users to press the MX4 entry twice; the goal is to mask this hardware quirk so the first attempt succeeds. 
- Detection logic is correct and must not be redesigned; the fix must be bounded, avoid USB/driver changes, logging, or timers, and be implemented entirely in the backend helper. 

### Description
- Added a new helper `EnsureMx4sioMass()` in `src/luasystem.cpp` that ensures `BDM/FATFS`, loads `mx4sio_bd.irx` if needed, and then executes the exact existing probe path twice (bounded two-pass): pass 0 performs the probe/poke and always proceeds, pass 1 repeats the probe and evaluates detection results. 
- The two-pass logic reuses existing functions: `BuildMassRootPath`, `ProbeDir`, `RefreshMassBackendCache`, `ClassifyMassBackend`, and `GetMassMountDriverNameBySlot`, and preserves existing slot ranges and classification heuristics. 
- Updated `System.initMX4SIO` (`lua_mx4sio_init`) to call `EnsureMx4sioMass()` instead of only loading the IRX, and added minimal forward declarations required by the new helper. 
- Change is confined to a single file (`src/luasystem.cpp`) and one commit, and it does not alter Lua logic, USB code paths, logging, sleeps, or detection rules. 

### Testing
- Ran repository checks and diffs to validate the change: `git diff --stat`, `git diff`, `rg -n "EnsureMx4sioMass" src/luasystem.cpp`, and `git status --short`, all executed successfully. 
- Committed the change in one commit with message `MX4: perform bounded double probe in EnsureMx4sioMass to mask second-press hardware quirk`, and verified via `git show --stat --oneline HEAD` which succeeded. 
- No automated build/unit tests were run in this rollout; only source-level verification and repository operations were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a822c04cf883219d100551a70127c7)