### PR TITLE
MainMenu: add MX4SIO auto-retry and TryEnterMX4SIO helper

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1353,6 +1353,7 @@ UI = {
       OPT = 1;
       mx4_autoretry_pending = false;
       mx4_autoretry_index = nil;
+      mx4_autoretry_wait_release = false;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
@@ -1546,15 +1547,24 @@ UI = {
           if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
             UI.MainMenu.mx4_autoretry_pending = false
             UI.MainMenu.mx4_autoretry_index = nil
+            UI.MainMenu.mx4_autoretry_wait_release = false
             return
           end
           if UI.MainMenu.mx4_autoretry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_autoretry_index then
             UI.MainMenu.mx4_autoretry_pending = false
             UI.MainMenu.mx4_autoretry_index = nil
+            UI.MainMenu.mx4_autoretry_wait_release = false
             return
+          end
+          if UI.MainMenu.mx4_autoretry_wait_release then
+            if UI.Pad.Events.CONFIRM then
+              return
+            end
+            UI.MainMenu.mx4_autoretry_wait_release = false
           end
           UI.MainMenu.mx4_autoretry_pending = false
           UI.MainMenu.mx4_autoretry_index = nil
+          UI.MainMenu.mx4_autoretry_wait_release = false
           if not TryEnterMX4SIO() then
             UI.Notif_queue.add("No MX4SIO device found")
           end
@@ -1611,6 +1621,7 @@ UI = {
               if not TryEnterMX4SIO() then
                 UI.MainMenu.mx4_autoretry_pending = true
                 UI.MainMenu.mx4_autoretry_index = carousel.currentIndex
+                UI.MainMenu.mx4_autoretry_wait_release = true
               end
               return
             end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1351,6 +1351,8 @@ UI = {
     };
     MainMenu = {
       OPT = 1;
+      mx4_autoretry_pending = false;
+      mx4_autoretry_index = nil;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
@@ -1371,6 +1373,19 @@ UI = {
         UI.MainMenu._draw_only = false
       end;
       Play = function ()
+        local function TryEnterMX4SIO()
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4sio_root == nil then
+            return false
+          end
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4sio_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+          return true
+        end
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
 	        -- Pages are no longer presented as "locked" in the UI.
@@ -1524,6 +1539,27 @@ UI = {
         if UI.MainMenu._draw_only then return end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
+        if UI.MainMenu.mx4_autoretry_pending then
+          if carousel.animActive then
+            return
+          end
+          if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
+            UI.MainMenu.mx4_autoretry_pending = false
+            UI.MainMenu.mx4_autoretry_index = nil
+            return
+          end
+          if UI.MainMenu.mx4_autoretry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_autoretry_index then
+            UI.MainMenu.mx4_autoretry_pending = false
+            UI.MainMenu.mx4_autoretry_index = nil
+            return
+          end
+          UI.MainMenu.mx4_autoretry_pending = false
+          UI.MainMenu.mx4_autoretry_index = nil
+          if not TryEnterMX4SIO() then
+            UI.Notif_queue.add("No MX4SIO device found")
+          end
+          return
+        end
         if not carousel.animActive then
           if UI.Pad.Events.NAV_RIGHT then
             carousel.targetIndex = WrapIndex(carousel.currentIndex + 1, profcnt)
@@ -1571,17 +1607,12 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
+            if not UI.MainMenu.mx4_autoretry_pending then
+              if not TryEnterMX4SIO() then
+                UI.MainMenu.mx4_autoretry_pending = true
+                UI.MainMenu.mx4_autoretry_index = carousel.currentIndex
+              end
               return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
             end
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1565,6 +1565,12 @@ UI = {
           UI.MainMenu.mx4_autoretry_pending = false
           UI.MainMenu.mx4_autoretry_index = nil
           UI.MainMenu.mx4_autoretry_wait_release = false
+          if type(UI)=="table" and type(UI.setDeviceLock)=="function" then
+            pcall(UI.setDeviceLock, DEVLOCK.NONE)
+          end
+          if type(_G.Input_GetEvent)=="function" then
+            pcall(_G.Input_GetEvent)
+          end
           if not TryEnterMX4SIO() then
             UI.Notif_queue.add("No MX4SIO device found")
           end

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -115,6 +115,21 @@ static bool EnsureUsbMass()
 	return true;
 }
 
+static bool EnsureMx4sioMass()
+{
+	bool ok = true;
+	for (int pass = 0; pass < 2 && ok; ++pass) {
+		ok = EnsureBDMFatFs();
+		if (ok && !mx4sio_irx_loaded) {
+			ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+			if (ok) {
+				mx4sio_irx_loaded = true;
+			}
+		}
+	}
+	return ok;
+}
+
 static bool EnsureCDFS()
 {
 	if (cdfs_irx_loaded) {
@@ -1266,13 +1281,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation
- Improve UX when selecting the MX4SIO option by allowing the UI to automatically retry initialization if the device is not present at first selection.
- Reduce repeated user actions by deferring immediate failure notifications and retrying when the carousel is left idle on the MX4SIO entry.

### Description
- Introduced a `TryEnterMX4SIO` helper that consolidates `PLDR` cleanup, `InitMX4SIOPopsRoot`, `GetPS1GameLists`, device lock with `UI.setDeviceLock(DEVLOCK.MX4SIO)`, and scene change to `UI.SCENES.GMX4SIO` when successful.
- Added `mx4_autoretry_pending` and `mx4_autoretry_index` state fields to `UI.MainMenu` to track a pending auto-retry attempt for MX4SIO.
- Changed the MX4SIO `CONFIRM` handler to set the pending autoretry state instead of immediately failing when `InitMX4SIOPopsRoot` returns nil, and to call `TryEnterMX4SIO` immediately on success.
- Implemented pending-retry processing at the top of `UI.MainMenu.Play` to cancel retries on user navigation or input mismatch and to attempt `TryEnterMX4SIO` once the menu is idle, showing a notification on final failure.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8434763d08321bed8e95ec7eca26a)