### PR TITLE
Fix MX4SIO first-entry detection with bounded double backend probe

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1270,6 +1270,8 @@ static bool EnsureMx4sioMass()
 	}
 
 	for (int pass = 0; pass < 2; ++pass) {
+		ProbeDir("mass:/", NULL);
+
 		for (int slot = 0; slot <= 9; ++slot) {
 			char root[16];
 			BuildMassRootPath(slot, root, sizeof(root));
@@ -1281,8 +1283,11 @@ static bool EnsureMx4sioMass()
 		}
 
 		if (RefreshMassBackendCache()) {
-			for (u32 i = 0; i < mass_backend_cache.count; ++i) {
-				(void)ClassifyMassBackend(mass_backend_cache.devs[i].name);
+			for (int slot = 0; slot <= 9; ++slot) {
+				const char *driver = GetMassMountDriverNameBySlot(slot);
+				if (driver != NULL) {
+					(void)ClassifyMassBackend(driver);
+				}
 			}
 		}
 	}

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1256,6 +1256,40 @@ static int lua_ensure_cdfs(lua_State *L)
 	return 1;
 }
 
+static bool EnsureMx4sioMass()
+{
+	if (!EnsureBDMFatFs()) {
+		return false;
+	}
+
+	if (!mx4sio_irx_loaded) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+			return false;
+		}
+		mx4sio_irx_loaded = true;
+	}
+
+	for (int pass = 0; pass < 2; ++pass) {
+		for (int slot = 0; slot <= 9; ++slot) {
+			char root[16];
+			BuildMassRootPath(slot, root, sizeof(root));
+			ProbeDir(root, NULL);
+			const char *driver = GetMassMountDriverNameBySlot(slot);
+			if (driver != NULL) {
+				(void)ClassifyMassBackend(driver);
+			}
+		}
+
+		if (RefreshMassBackendCache()) {
+			for (u32 i = 0; i < mass_backend_cache.count; ++i) {
+				(void)ClassifyMassBackend(mass_backend_cache.devs[i].name);
+			}
+		}
+	}
+
+	return true;
+}
+
 static int lua_mx4sio_init(lua_State *L)
 {
 	int argc = lua_gettop(L);
@@ -1266,13 +1300,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation
- MX4SIO devices often require a manual second press because the backend/device probe/refresh/detect sequence must be exercised twice to discover the mass mount, not a UI retry; the change implements that backend behavior.
- The fix must be backend-only, bounded (exactly two passes), and must not change detection rules, Lua/UI files, IRX load semantics, logging, or introduce delays.

### Description
- Added `EnsureMx4sioMass()` in `src/luasystem.cpp` which performs required IRX loads once and then runs a bounded two-pass probe/refresh/detect flow using existing helpers (`BuildMassRootPath`, `ProbeDir`, `GetMassMountDriverNameBySlot`, `ClassifyMassBackend`, `RefreshMassBackendCache`).
- Updated `lua_mx4sio_init` (System.initMX4SIO binding) to call `EnsureMx4sioMass()` and preserved the original return contract and behavior.
- Only `src/luasystem.cpp` was modified and no Lua files, logging, sleeps, unbounded loops, IRX double-loads, or detection/classification rules were changed.

### Testing
- Ran repository checks and diffs which all succeeded: `git status --short` (showed only `src/luasystem.cpp` modified), `git diff --stat` (1 file changed, 35 insertions, 7 deletions), `git diff -- src/luasystem.cpp` (shows the new `EnsureMx4sioMass()` and the wiring), and `rg -n "EnsureMx4sioMass|lua_mx4sio_init|initMX4SIO" src/luasystem.cpp` (confirmed symbols present); all commands completed successfully.
- Committed the change as a single commit (`Fix MX4SIO first-entry detection with bounded double backend probe`).
- No automated unit tests were present for this area; no runtime regression tests were run here in CI as part of this change (manual hardware test plan provided separately).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84ae1251c8321942b6871013dc93e)