### PR TITLE
Fix MX4SIO first-entry by bounded backend double probe

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -115,6 +115,44 @@ static bool EnsureUsbMass()
 	return true;
 }
 
+static bool EnsureMx4sioMass()
+{
+	if (!EnsureBDMFatFs()) {
+		return false;
+	}
+
+	if (!mx4sio_irx_loaded) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+			return false;
+		}
+		mx4sio_irx_loaded = true;
+	}
+
+	for (int pass = 0; pass < 2; ++pass) {
+		(void)RefreshMassBackendCache();
+
+		int probe_ret = -1;
+		(void)ProbeDir("mass:/", &probe_ret);
+
+		for (int slot = 0; slot <= 9; ++slot) {
+			char root[16];
+			BuildMassRootPath(slot, root, sizeof(root));
+			(void)ProbeDir(root, &probe_ret);
+		}
+
+		(void)RefreshMassBackendCache();
+
+		for (int slot = 0; slot <= 9; ++slot) {
+			const char *driver = GetMassMountDriverNameBySlot(slot);
+			if (driver != NULL) {
+				(void)ClassifyMassBackend(driver);
+			}
+		}
+	}
+
+	return true;
+}
+
 static bool EnsureCDFS()
 {
 	if (cdfs_irx_loaded) {
@@ -1266,13 +1304,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation

- On real PS2 hardware the MX4SIO page required two manual presses because the backend probe/refresh/detect sequence needed to run twice to discover MX4SIO as a mounted mass device.  
- The intent is to make a single UI press perform the same bounded two-pass backend work that a manual double-press triggers, without changing UI, Lua API contract, detection rules, or adding delays/logging.

### Description

- Added `EnsureMx4sioMass()` to `src/luasystem.cpp` which performs one-time IRX gating (`EnsureBDMFatFs()` and conditional load of `mx4sio_bd.irx`) and then runs exactly two passes of the existing backend probe/refresh sequence.  
- Each pass calls `RefreshMassBackendCache()`, probes `mass:/` and `mass0:/`..`mass9:/` via `ProbeDir()`/`BuildMassRootPath()`, refreshes again, and re-checks slot drivers with `GetMassMountDriverNameBySlot()` followed by `ClassifyMassBackend()`.  
- Replaced the previous single-pass initialization in the Lua binding by changing `lua_mx4sio_init` to call `EnsureMx4sioMass()` and preserved the original Lua return values and argument handling.  
- Only `src/luasystem.cpp` was modified; there are no sleeps, no logging, no IRX double-loads, no UI or Lua-level retry logic, and the probing is strictly bounded to two passes and slots `0..9`.

### Testing

- Verified file changes with `git status --short` and `git diff --stat` which reported only `src/luasystem.cpp` modified and the expected line changes.  
- Confirmed the source diff for `src/luasystem.cpp` with `git diff -- src/luasystem.cpp` and validated the new `EnsureMx4sioMass()` insertion and the `lua_mx4sio_init` call update.  
- Searched for symbols with `rg -n "EnsureMx4sioMass|lua_mx4sio_init|initMX4SIO" src/luasystem.cpp` to confirm correct wiring, and all checks succeeded.  
- Created a single commit containing the change with `git add`/`git commit` and validated the repository state and latest commit message successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85dbbbc9483219793ad5e81bbde0f)