### PR TITLE
Ensure MX4SIO readiness with bounded two-pass backend probe

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -38,6 +38,13 @@ extern unsigned int size_cdfs_irx;
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
 
+// Forward declarations for MX4 probe helpers
+static bool EnsureBdmQueryRpc();
+static bool RefreshMassBackendCache();
+static bool ProbeDir(const char *path, int *out_ret);
+static const char *GetMassMountDriverNameBySlot(int slot);
+static const char *ClassifyMassBackend(const char *driver);
+
 #ifndef USBMASS_IOCTL_GET_DRIVERNAME
 #define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
 #endif

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -127,6 +127,54 @@ static bool EnsureCDFS()
 	return true;
 }
 
+static bool EnsureMx4sioMass()
+{
+	if (!EnsureBDMFatFs()) {
+		return false;
+	}
+	if (!EnsureBdmQueryRpc()) {
+		return false;
+	}
+	if (!mx4sio_irx_loaded) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+			return false;
+		}
+		mx4sio_irx_loaded = true;
+	}
+
+	for (int pass = 0; pass < 2; ++pass) {
+		if (!EnsureBdmQueryRpc()) {
+			return false;
+		}
+
+		mass_backend_cache_valid = false;
+		mass_backend_cache.count = 0;
+
+		RefreshMassBackendCache();
+
+		ProbeDir("mass:/", NULL);
+		for (int slot = 0; slot <= 9; ++slot) {
+			char root[16];
+			BuildMassRootPath(slot, root, sizeof(root));
+			ProbeDir(root, NULL);
+		}
+
+		if (!EnsureBdmQueryRpc()) {
+			return false;
+		}
+		RefreshMassBackendCache();
+
+		for (int slot = 0; slot <= 9; ++slot) {
+			const char *driver = GetMassMountDriverNameBySlot(slot);
+			if (driver != NULL) {
+				ClassifyMassBackend(driver);
+			}
+		}
+	}
+
+	return true;
+}
+
 static bool EnsureBdmQueryRpc()
 {
 	if (!bdm_rpc_loaded) {
@@ -1266,13 +1314,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation
- The MX4SIO path required two manual presses because the backend BDM query RPC or mass backend cache refresh could be unavailable on the first probe, so the init path must ensure RPC readiness and force a bounded double probe/refresh to surface the device on the first press.  

### Description
- Added `EnsureMx4sioMass()` in `src/luasystem.cpp` which enforces one-time prerequisites `EnsureBDMFatFs()`, a required-success `EnsureBdmQueryRpc()`, and a one-time load of `mx4sio_bd.irx`, and returns false if prerequisites fail.  
- Implemented a bounded two-pass probe loop (exactly two passes) that re-checks `EnsureBdmQueryRpc()` before refresh, invalidates the existing mass backend cache via existing fields (`mass_backend_cache_valid = false` and `mass_backend_cache.count = 0`), calls `RefreshMassBackendCache()`, probes `mass:/` and `mass0:/..mass9:/` via `ProbeDir`/`BuildMassRootPath`, then re-checks RPC and refreshes again and re-classifies drivers via `GetMassMountDriverNameBySlot`/`ClassifyMassBackend`.  
- Rewired `lua_mx4sio_init` to call `EnsureMx4sioMass()` while preserving argument validation and the original return contract `(bool, nil, errOrNil)`.  
- Only modified `src/luasystem.cpp`; no Lua changes, no logging, no sleeps/delays, no new detection rules or slot range changes, and no new public APIs.  

### Testing
- Ran `git diff --stat` to verify the single-file change and it succeeded.  
- Ran `git diff -- src/luasystem.cpp` to inspect the patch and it succeeded.  
- Ran `rg -n "EnsureMx4sioMass|EnsureBdmQueryRpc|RefreshMassBackendCache|ProbeDir|GetMassMountDriverNameBySlot|lua_mx4sio_init|initMX4SIO" src/luasystem.cpp` to confirm new symbols/wiring and it succeeded.  
- Ran `git status --short` and `git diff --check` to confirm a clean working tree and no whitespace errors; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85f17f738832186f509d0d9f1052b)