### PR TITLE
luasystem: bounded double poke in initMX4SIO

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -37,6 +37,7 @@ extern unsigned int size_cdfs_irx;
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
+static bool ProbeDir(const char *path, int *out_ret);
 
 #ifndef USBMASS_IOCTL_GET_DRIVERNAME
 #define USBMASS_IOCTL_GET_DRIVERNAME 0x0003
@@ -124,6 +125,33 @@ static bool EnsureCDFS()
 		return false;
 	}
 	cdfs_irx_loaded = true;
+	return true;
+}
+
+static bool EnsureMx4sioMass()
+{
+	if (!EnsureBDMFatFs()) {
+		return false;
+	}
+
+	if (!mx4sio_irx_loaded) {
+		if (!LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL)) {
+			return false;
+		}
+		mx4sio_irx_loaded = true;
+	}
+
+	for (int pass = 0; pass < 2; ++pass) {
+		int probe_ret;
+		ProbeDir("mass:/", &probe_ret);
+
+		for (int slot = 0; slot <= 9; ++slot) {
+			char root[16];
+			BuildMassRootPath(slot, root, sizeof(root));
+			ProbeDir(root, &probe_ret);
+		}
+	}
+
 	return true;
 }
 
@@ -1266,13 +1294,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);


### PR DESCRIPTION
### Motivation
- Fix the MX4SIO “needs two presses” quirk by making the init path perform the exact, bounded double poke that a real second press triggers, without adding UI/Lua retry logic or any RPC/cache refresh work that could hang.

### Description
- Added a new helper `EnsureMx4sioMass()` in `src/luasystem.cpp` that ensures `EnsureBDMFatFs()` and loads `mx4sio_bd.irx` once, then performs exactly two passes of probing: `ProbeDir("mass:/", ...)` and `ProbeDir()` for `mass0:/`..`mass9:/` via `BuildMassRootPath`.
- Replaced the previous inline `EnsureBDMFatFs()` + IRX load in `lua_mx4sio_init` with a single call to `EnsureMx4sioMass()` while preserving argument validation and the return contract `(bool, nil, errOrNil)` with `"IRX_LOAD_FAIL"` on failure.
- Added a minimal forward declaration for `ProbeDir` to satisfy compile-order without moving existing function bodies, and limited all modifications to only `src/luasystem.cpp`.
- Ensured the helper performs no classification, driver querying, backend-cache refresh, sleeps, logging, or additional detection changes, and does not call `EnsureBdmQueryRpc()`, `RefreshMassBackendCache()`, or `FetchBdmList()` as part of init.

### Testing
- Ran automated repository inspections: `git diff --stat` and `git diff -- src/luasystem.cpp` to verify the exact source delta, and `rg -n "EnsureMx4sioMass|lua_mx4sio_init|initMX4SIO|ProbeDir(\"mass:/\"|BuildMassRootPath" src/luasystem.cpp` to confirm the new symbols and probe calls; these checks succeeded and show only `src/luasystem.cpp` changed.
- Verified working tree cleanliness with `git status --short` to confirm no other files were modified; this check succeeded.
- Performed a static review of `src/luasystem.cpp` to confirm the bounded two-pass probe and one-time IRX load semantics; no runtime tests were executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a861c635748321b9dacb5ca249f8fe)