### PR TITLE
ui: auto-run one-shot MX4SIO retry next frame

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1352,6 +1352,9 @@ UI = {
     MainMenu = {
       OPT = 1;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
+      mx4_autoretry_pending = false;
+      mx4_autoretry_index = nil;
+      mx4_autoretry_wait_release = false;
       Carousel = {
         currentIndex = 1,
         targetIndex = 1,
@@ -1373,6 +1376,19 @@ UI = {
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
+
+        local function TryEnterMX4SIO()
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4sio_root == nil then return false end
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4sio_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+          return true
+        end
+
 	        -- Pages are no longer presented as "locked" in the UI.
         local icon_map = {
           ["MMCE"] = "MMCE",
@@ -1524,6 +1540,32 @@ UI = {
         if UI.MainMenu._draw_only then return end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
+        if UI.MainMenu.mx4_autoretry_pending then
+          if carousel.animActive then return end
+          if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
+            UI.MainMenu.mx4_autoretry_pending = false
+            UI.MainMenu.mx4_autoretry_index = nil
+            UI.MainMenu.mx4_autoretry_wait_release = false
+            return
+          end
+          if UI.MainMenu.mx4_autoretry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_autoretry_index then
+            UI.MainMenu.mx4_autoretry_pending = false
+            UI.MainMenu.mx4_autoretry_index = nil
+            UI.MainMenu.mx4_autoretry_wait_release = false
+            return
+          end
+          if UI.MainMenu.mx4_autoretry_wait_release then
+            if UI.Pad.Events.CONFIRM then return end
+            UI.MainMenu.mx4_autoretry_wait_release = false
+          end
+          UI.MainMenu.mx4_autoretry_pending = false
+          UI.MainMenu.mx4_autoretry_index = nil
+          UI.MainMenu.mx4_autoretry_wait_release = false
+          if not TryEnterMX4SIO() then
+            UI.Notif_queue.add("No MX4SIO device found")
+          end
+          return
+        end
         if not carousel.animActive then
           if UI.Pad.Events.NAV_RIGHT then
             carousel.targetIndex = WrapIndex(carousel.currentIndex + 1, profcnt)
@@ -1571,18 +1613,11 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
-              return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
-            end
+            if TryEnterMX4SIO() then return end
+            UI.MainMenu.mx4_autoretry_pending = true
+            UI.MainMenu.mx4_autoretry_index = carousel.currentIndex
+            UI.MainMenu.mx4_autoretry_wait_release = true
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- Make MX4SIO enter on the first user press by automatically emulating the user pressing confirm twice (performing a single automatic retry on the next frame) while preserving all existing detection, mount, slot, and probing logic.

### Description
- Added three `UI.MainMenu` fields: `mx4_autoretry_pending`, `mx4_autoretry_index`, and `mx4_autoretry_wait_release` to track a one-shot next-frame retry state in `bin/POPSLDR/ui.lua`.
- Factored the existing MX4SIO entry sequence into a local helper `TryEnterMX4SIO()` inside `UI.MainMenu.Play()` that duplicates the previous call order (`PLDR.CleanupGameList`, `PLDR.GAMEPATH = ""`, `PLDR.InitMX4SIOPopsRoot`, `PLDR.GetPS1GameLists`, `UI.setDeviceLock`, `UI.SceneChange`) and returns `true/false` with no other side effects.
- Added a pending auto-retry execution block immediately after `Input_GetEvent()` and `UI.HandleGlobalInput(false)` that waits one frame (skips while `carousel.animActive`), cancels on navigation/back/exit or index change, respects confirm-button release (`mx4_autoretry_wait_release`), and then runs the single automatic retry and only shows the "No MX4SIO device found" notification if that retry fails.
- Replaced the inline MX4SIO confirm handler for `OPT == 2` to call `TryEnterMX4SIO()` first and, on its failure, schedule the bounded auto-retry state instead of immediately notifying; all original MX4SIO calls, order and behavior are preserved when an attempt succeeds.

### Testing
- Verified the edit summary and scope with `git diff --stat` which shows only `bin/POPSLDR/ui.lua` changed.
- Inspected the exact source edits with `git diff -- bin/POPSLDR/ui.lua` and confirmed the new fields, `TryEnterMX4SIO()` helper, retry block, and modified `OPT == 2` branch are present.
- Confirmed symbol occurrences with `rg -n "mx4_autoretry_pending|TryEnterMX4SIO|mx4_autoretry_wait_release" bin/POPSLDR/ui.lua` and validated the code locations.
- Checked the working tree with `git status --short` to ensure only the intended file was modified before committing; automatic patch application and the repository commit were performed after validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86e148f048321ad0bd4db43102936)