### PR TITLE
ui: run bounded double-attempt MX4SIO entry on one press

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1371,6 +1371,22 @@ UI = {
         UI.MainMenu._draw_only = false
       end;
       Play = function ()
+        local function TryEnterMX4SIO()
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+
+          local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4sio_root == nil then
+            return false
+          end
+
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4sio_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+
+          return true
+        end
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
 	        -- Pages are no longer presented as "locked" in the UI.
@@ -1571,18 +1587,19 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
+            -- Attempt #1 (same behavior as today)
+            if TryEnterMX4SIO() then
               return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
             end
+
+            -- Attempt #2 (simulate the user pressing X a second time)
+            if TryEnterMX4SIO() then
+              return
+            end
+
+            -- Only notify if BOTH attempts fail
+            UI.Notif_queue.add("No MX4SIO device found")
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- MX4SIO entry required two manual X presses on hardware because the first entry attempt could fail while a second immediately succeeds.
- The intent is to make a single press perform two identical entry attempts deterministically without introducing timing, loop, or device-detection changes.

### Description
- Added a local helper `TryEnterMX4SIO()` inside `UI.MainMenu.Play()` that mirrors the existing MX4SIO entry sequence (`CleanupGameList`, clear `PLDR.GAMEPATH`, `InitMX4SIOPopsRoot`, then on success `CleanupGameList`, `GetPS1GameLists`, `UI.setDeviceLock`, and `UI.SceneChange`).
- Replaced the `UI.MainMenu.OPT == 2` confirm branch to call `TryEnterMX4SIO()` twice in a bounded fashion, returning immediately on success and only showing `No MX4SIO device found` if both attempts fail.
- Change is strictly limited to `bin/POPSLDR/ui.lua` and preserves all detection, launching, and device-classification behavior for other branches.

### Testing
- Verified the file diff shows the helper and branch replacement with the expected insertion/deletion counts and that only `bin/POPSLDR/ui.lua` was modified (passed).
- Located `TryEnterMX4SIO` via a file search to confirm the helper was added (passed).
- Inspected the branch replacement to confirm two bounded attempts and unchanged failure notification semantics (passed).
- Confirmed the working tree is clean and the repository reflects only the intended file change (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a870787f208321b3fe9edb448a5176)