### PR TITLE
ui: MX4SIO one-press entry via bounded deferred retry

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1351,6 +1351,10 @@ UI = {
     };
     MainMenu = {
       OPT = 1;
+      mx4_retry_pending = false;
+      mx4_retry_index = nil;
+      mx4_retry_wait_release = false;
+      mx4_retry_frames = 0;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
       Carousel = {
         currentIndex = 1,
@@ -1371,6 +1375,25 @@ UI = {
         UI.MainMenu._draw_only = false
       end;
       Play = function ()
+        local function TryEnterMX4SIO()
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4sio_root == nil then
+            return false
+          end
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4sio_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+          return true
+        end
+        local function ClearMX4RetryState()
+          UI.MainMenu.mx4_retry_pending = false
+          UI.MainMenu.mx4_retry_index = nil
+          UI.MainMenu.mx4_retry_wait_release = false
+          UI.MainMenu.mx4_retry_frames = 0
+        end
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
 	        -- Pages are no longer presented as "locked" in the UI.
@@ -1524,6 +1547,30 @@ UI = {
         if UI.MainMenu._draw_only then return end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
+        if UI.MainMenu.mx4_retry_pending then
+          if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
+            ClearMX4RetryState()
+          elseif UI.MainMenu.mx4_retry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_retry_index then
+            ClearMX4RetryState()
+          elseif carousel.animActive then
+            return
+          elseif UI.MainMenu.mx4_retry_wait_release then
+            if UI.Pad.Events.CONFIRM then
+              return
+            end
+            UI.MainMenu.mx4_retry_wait_release = false
+          else
+            UI.MainMenu.mx4_retry_frames = UI.MainMenu.mx4_retry_frames - 1
+            if UI.MainMenu.mx4_retry_frames <= 0 then
+              ClearMX4RetryState()
+              if not TryEnterMX4SIO() then
+                UI.Notif_queue.add("No MX4SIO device found")
+              end
+              return
+            end
+            return
+          end
+        end
         if not carousel.animActive then
           if UI.Pad.Events.NAV_RIGHT then
             carousel.targetIndex = WrapIndex(carousel.currentIndex + 1, profcnt)
@@ -1571,17 +1618,12 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
+            if not TryEnterMX4SIO() then
+              UI.MainMenu.mx4_retry_pending = true
+              UI.MainMenu.mx4_retry_index = carousel.currentIndex
+              UI.MainMenu.mx4_retry_wait_release = true
+              UI.MainMenu.mx4_retry_frames = 12
               return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
             end
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1550,8 +1550,10 @@ UI = {
         if UI.MainMenu.mx4_retry_pending then
           if UI.Pad.Events.NAV_LEFT or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.BACK or UI.Pad.Events.EXIT then
             ClearMX4RetryState()
+            return
           elseif UI.MainMenu.mx4_retry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_retry_index then
             ClearMX4RetryState()
+            return
           elseif carousel.animActive then
             return
           elseif UI.MainMenu.mx4_retry_wait_release then
@@ -1559,6 +1561,7 @@ UI = {
               return
             end
             UI.MainMenu.mx4_retry_wait_release = false
+            return
           else
             UI.MainMenu.mx4_retry_frames = UI.MainMenu.mx4_retry_frames - 1
             if UI.MainMenu.mx4_retry_frames <= 0 then


### PR DESCRIPTION
### Motivation
- Users needed a single X press to act like a quick double-press for MX4SIO by giving the backend a short deterministic window to appear, without adding unbounded delays, extra logging, new device logic, or touching non-UI code.

### Description
- Added a one-shot bounded deferred-retry state to `UI.MainMenu` (`mx4_retry_pending`, `mx4_retry_index`, `mx4_retry_wait_release`, `mx4_retry_frames`) and kept all changes localized to `bin/POPSLDR/ui.lua`.
- Implemented a local helper `TryEnterMX4SIO()` inside `UI.MainMenu.Play()` that performs the exact existing MX4SIO entry sequence (`PLDR.CleanupGameList()`, `PLDR.GAMEPATH = ""`, `PLDR.InitMX4SIOPopsRoot()`, `PLDR.GetPS1GameLists()`, `UI.setDeviceLock(DEVLOCK.MX4SIO)`, `UI.SceneChange(UI.SCENES.GMX4SIO)`).
- Replaced the MX4SIO confirm branch to attempt immediate entry and, on first failure, arm the deferred one-shot retry with `mx4_retry_frames = 12` and `mx4_retry_wait_release = true` (no immediate notification on first failure).
- Added a pending-retry runner immediately after `Input_GetEvent()`/`UI.HandleGlobalInput(false)` that waits for confirm release, pauses during carousel animation, cancels on nav/back/exit or index change, decrements the frame countdown, fires `TryEnterMX4SIO()` once when expired, and only then shows the "No MX4SIO device found" notification if it still fails.

### Testing
- Searched the updated source to confirm new symbols and helper presence with `rg -n "TryEnterMX4SIO|mx4_retry_pending|mx4_retry_frames|mx4_retry_wait_release" bin/POPSLDR/ui.lua`, which returned the expected hits and locations.
- Verified the patch is limited to `bin/POPSLDR/ui.lua` using `git diff --stat` and inspected the file diff with `git diff -- bin/POPSLDR/ui.lua`, both of which showed only the intended changes.
- Confirmed working-tree state with `git status --short` to ensure no other files were modified, and recorded the change as a single revision with a descriptive message; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a875ed989c8321b7d86269b1835bd3)