### PR TITLE
system: MX4SIO one-press entry via bounded 2-attempt init

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1022,8 +1022,6 @@ local function BuildMassRootIdentity(mode)
   return identity
 end
 
-local mx4_retry_pending = false
-local mx4_retry_used = false
 local mx4_present_sig = nil
 
 local function MassRootsSignature()
@@ -1031,38 +1029,13 @@ local function MassRootsSignature()
   return table.concat(roots, "|")
 end
 
-local function BuildMX4IdentityDeferred()
+function PLDR.GetMX4SIOMassRootNow()
   local sig = MassRootsSignature()
   if sig ~= mx4_present_sig then
     mx4_present_sig = sig
-    mx4_retry_pending = false
-    mx4_retry_used = false
   end
 
   local identity = BuildMassRootIdentity("mx4sio")
-  local empty = (type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0)
-  if not empty then
-    mx4_retry_pending = false
-    mx4_retry_used = false
-    return identity
-  end
-
-  if mx4_retry_used then
-    return identity
-  end
-
-  if not mx4_retry_pending then
-    mx4_retry_pending = true
-    return identity
-  end
-
-  mx4_retry_pending = false
-  mx4_retry_used = true
-  return identity
-end
-
-function PLDR.GetMX4SIOMassRootNow()
-  local identity = BuildMX4IdentityDeferred()
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
     return identity.mx4sio[1] or nil
   end
@@ -1072,7 +1045,7 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
-    local identity = BuildMX4IdentityDeferred()
+    local identity = BuildMassRootIdentity("mx4sio")
     return identity.mx4sio
   end
 
@@ -1565,20 +1538,54 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
 
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
+  local function AttemptOnce()
+    PLDR.MX4SIO.READY = false
+    PLDR.MX4SIO.ROOT = nil
+    PLDR.MX4SIO.MASSINDX = nil
+    PLDR.MX4SIO.IS_MASS_ALIAS = false
+
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
+
+    local root = PLDR.GetMX4SIOMassRootNow()
+    if root ~= nil then
+      local pops = root.."POPS/"
+      if doesFolderExist(pops) then
+        PLDR.SetMX4SIORoot(root)
+        return pops
+      end
+    end
+    return nil
   end
 
-  local root = PLDR.GetMX4SIOMassRootNow()
-  if root ~= nil then
-    local pops = root.."POPS/"
-    if doesFolderExist(pops) then
-      PLDR.SetMX4SIORoot(root)
-      return pops
+  local function YieldOnce()
+    if type(System) == "table" and type(System.yield) == "function" then
+      pcall(System.yield)
+      return
     end
+    if type(coroutine) == "table" and type(coroutine.yield) == "function" then
+      pcall(coroutine.yield)
+      return
+    end
+    if type(System) == "table" and type(System.sleep) == "function" then
+      pcall(System.sleep, 1)
+    end
+  end
+
+  local pops = AttemptOnce()
+  if pops ~= nil then
+    return pops
+  end
+
+  YieldOnce()
+
+  pops = AttemptOnce()
+  if pops ~= nil then
+    return pops
   end
 
   return nil


### PR DESCRIPTION
### Motivation
- The MX4SIO flow required the user to press X twice because a deferred identity gate in `system.lua` suppressed early identity results and forced multi-frame behavior outside the init path.
- Move the bounded two-press semantics into a single deterministic init routine so a single X behaves like "press now, then press again next frame" without global retry state or unbounded retries.

### Description
- Removed the deferred MX4 identity retry state by deleting `BuildMX4IdentityDeferred` and the `mx4_retry_pending` / `mx4_retry_used` state variables and kept `mx4_present_sig` for snapshot tracking.
- Changed `PLDR.GetMX4SIOMassRootNow()` to compute identity directly with `BuildMassRootIdentity("mx4sio")` and preserved existing classification rules (sdc => mx4sio; unknown => excluded).
- Updated `PLDR.GetRootsByType("mx4sio")` to use `BuildMassRootIdentity("mx4sio")` directly instead of the deferred helper.
- Reworked `PLDR.InitMX4SIOPopsRoot()` to implement exactly two bounded attempts with local `AttemptOnce()` and `YieldOnce()` helpers (reset MX4SIO state, call optional `_G.ensureMx4sioInit` and `System.initMX4SIO`, check `root.."POPS/"`, yield once between attempts using `System.yield` / `coroutine.yield` / `System.sleep(1)` fallback), and return `nil` after two failed attempts; no new globals, no extra logging, only `bin/POPSLDR/system.lua` changed.

### Testing
- Verified repository changes with `git diff --stat` which reports `bin/POPSLDR/system.lua | 87 +47 -40` and a single file modified, and `git commit` succeeded using the message `system: MX4SIO one-press entry via bounded 2-attempt init`.
- Confirmed the expected symbols and removals via `rg -n` yielding `GetMX4SIOMassRootNow`, `InitMX4SIOPopsRoot`, `AttemptOnce`, `YieldOnce` and absence of `BuildMX4IdentityDeferred`, `mx4_retry_pending`, and `mx4_retry_used` in `bin/POPSLDR/system.lua`.
- Displayed the implemented diff with `git diff -- bin/POPSLDR/system.lua` and validated the new two-attempt flow and direct identity calls; these checks completed successfully.
- Created PR metadata via `make_pr` with matching title/body and recorded the single commit in the repo history.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a879b286408321b35621601529eb0f)