### PR TITLE
system: MX4SIO one-press entry via bounded 2-attempt init

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1022,47 +1022,8 @@ local function BuildMassRootIdentity(mode)
   return identity
 end
 
-local mx4_retry_pending = false
-local mx4_retry_used = false
-local mx4_present_sig = nil
-
-local function MassRootsSignature()
-  local roots = PLDR.GetPresentMassRootsBounded()
-  return table.concat(roots, "|")
-end
-
-local function BuildMX4IdentityDeferred()
-  local sig = MassRootsSignature()
-  if sig ~= mx4_present_sig then
-    mx4_present_sig = sig
-    mx4_retry_pending = false
-    mx4_retry_used = false
-  end
-
-  local identity = BuildMassRootIdentity("mx4sio")
-  local empty = (type(identity) ~= "table" or type(identity.mx4sio) ~= "table" or #identity.mx4sio == 0)
-  if not empty then
-    mx4_retry_pending = false
-    mx4_retry_used = false
-    return identity
-  end
-
-  if mx4_retry_used then
-    return identity
-  end
-
-  if not mx4_retry_pending then
-    mx4_retry_pending = true
-    return identity
-  end
-
-  mx4_retry_pending = false
-  mx4_retry_used = true
-  return identity
-end
-
 function PLDR.GetMX4SIOMassRootNow()
-  local identity = BuildMX4IdentityDeferred()
+  local identity = BuildMassRootIdentity("mx4sio")
   if type(identity) == "table" and type(identity.mx4sio) == "table" then
     return identity.mx4sio[1] or nil
   end
@@ -1072,7 +1033,7 @@ end
 function PLDR.GetRootsByType(kind, mass_snapshot)
   local wanted = string.lower(tostring(kind or ""))
   if wanted == "mx4sio" then
-    local identity = BuildMX4IdentityDeferred()
+    local identity = BuildMassRootIdentity("mx4sio")
     return identity.mx4sio
   end
 
@@ -1565,20 +1526,56 @@ function PLDR.InitMX4SIOPopsRoot()
   PLDR.MX4SIO.MASSINDX = nil
   PLDR.MX4SIO.IS_MASS_ALIAS = false
 
-  if type(_G.ensureMx4sioInit) == "function" then
-    pcall(_G.ensureMx4sioInit)
-  end
-  if type(System) == "table" and type(System.initMX4SIO) == "function" then
-    pcall(System.initMX4SIO)
+  local function AttemptOnce()
+    PLDR.MX4SIO.READY = false
+    PLDR.MX4SIO.ROOT = nil
+    PLDR.MX4SIO.MASSINDX = nil
+    PLDR.MX4SIO.IS_MASS_ALIAS = false
+
+    if type(_G.ensureMx4sioInit) == "function" then
+      pcall(_G.ensureMx4sioInit)
+    end
+    if type(System) == "table" and type(System.initMX4SIO) == "function" then
+      pcall(System.initMX4SIO)
+    end
+
+    local root = PLDR.GetMX4SIOMassRootNow()
+    if root ~= nil then
+      local pops = root.."POPS/"
+      if doesFolderExist(pops) then
+        PLDR.SetMX4SIORoot(root)
+        return pops
+      end
+    end
+
+    return nil
   end
 
-  local root = PLDR.GetMX4SIOMassRootNow()
-  if root ~= nil then
-    local pops = root.."POPS/"
-    if doesFolderExist(pops) then
-      PLDR.SetMX4SIORoot(root)
-      return pops
+  local function YieldOnce()
+    if type(System) == "table" and type(System.yield) == "function" then
+      pcall(System.yield)
+      return
     end
+    if type(coroutine) == "table" and type(coroutine.yield) == "function" then
+      pcall(coroutine.yield)
+      return
+    end
+    if type(System) == "table" and type(System.sleep) == "function" then
+      pcall(System.sleep, 1)
+      return
+    end
+  end
+
+  local pops = AttemptOnce()
+  if pops ~= nil then
+    return pops
+  end
+
+  YieldOnce()
+
+  pops = AttemptOnce()
+  if pops ~= nil then
+    return pops
   end
 
   return nil


### PR DESCRIPTION
### Motivation
- Remove the deferred MX4 identity gate that attempted to hide a one-frame requirement and caused unreliable UI/C-side retry interactions and potential freezes. 
- Ensure that MX4SIO initialization behaves like a user pressing X once and then again on the next frame, while keeping the behavior strictly bounded to two attempts and scoped to `PLDR.InitMX4SIOPopsRoot()`.

### Description
- Removed deferred MX4 identity retry state and logic (`BuildMX4IdentityDeferred`, `mx4_retry_pending`, `mx4_retry_used`) and their signature helper. 
- Made `PLDR.GetMX4SIOMassRootNow()` compute identity directly every call via `BuildMassRootIdentity("mx4sio")` and return `identity.mx4sio[1]` or `nil`. 
- Made `PLDR.GetRootsByType("mx4sio", ...)` return `BuildMassRootIdentity("mx4sio").mx4sio` directly. 
- Implemented bounded two-attempt init inside `PLDR.InitMX4SIOPopsRoot()` with local helpers: `AttemptOnce()` which deterministically resets the 4 `PLDR.MX4SIO` fields, calls existing init hooks, probes `PLDR.GetMX4SIOMassRootNow()`, validates `POPS/` and returns `pops` or `nil`; and `YieldOnce()` which yields to the next frame via `System.yield`, `coroutine.yield`, or `System.sleep(1)` in that order; the function performs exactly `AttemptOnce()`, `YieldOnce()`, `AttemptOnce()` and then returns `nil` if not found. 
- No logging, no extra scan loops, no additional probes beyond the existing `ensureMx4sioInit`/`System.initMX4SIO` calls, and no changes to other files or flows.

### Testing
- Ran symbol and code checks (`rg -n`) to confirm presence of `GetMX4SIOMassRootNow`, `GetRootsByType`, `InitMX4SIOPopsRoot`, `AttemptOnce`, `YieldOnce` and absence of `BuildMX4IdentityDeferred`, `mx4_retry_pending`, and `mx4_retry_used`, which all succeeded. 
- Confirmed `git diff --stat` and `git diff` reflect only `bin/POPSLDR/system.lua` changes and show the expected deletions/insertions. 
- Verified repository state before commit showed `M bin/POPSLDR/system.lua` and after commit was clean, and created a single commit with message `system: MX4SIO one-press entry via bounded 2-attempt init`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87c00bbb88321b46909f35d648cb2)