### PR TITLE
ui: MX4SIO one-press entry via next-frame retry

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1352,6 +1352,8 @@ UI = {
     MainMenu = {
       OPT = 1;
       opts = {"MMCE", "MX4SIO", "HDD (exFAT)", "HDD (PFS)", "USB", "SMB (v1)", "Disc (DKWDRV)"};
+      mx4_retry_pending = false;
+      mx4_retry_index = nil;
       Carousel = {
         currentIndex = 1,
         targetIndex = 1,
@@ -1373,6 +1375,19 @@ UI = {
       Play = function ()
         local layout = UI.LAYOUT
         local profcnt = #UI.MainMenu.opts
+        local function TryEnterMX4SIO()
+          PLDR.CleanupGameList()
+          PLDR.GAMEPATH = ""
+          local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
+          if mx4sio_root == nil then
+            return false
+          end
+          PLDR.CleanupGameList()
+          PLDR.GetPS1GameLists(mx4sio_root, true)
+          UI.setDeviceLock(DEVLOCK.MX4SIO)
+          UI.SceneChange(UI.SCENES.GMX4SIO)
+          return true
+        end
 	        -- Pages are no longer presented as "locked" in the UI.
         local icon_map = {
           ["MMCE"] = "MMCE",
@@ -1524,6 +1539,24 @@ UI = {
         if UI.MainMenu._draw_only then return end
         Input_GetEvent()
         if UI.HandleGlobalInput(false) then return end
+        if UI.MainMenu.mx4_retry_pending then
+          if carousel.animActive then
+            return
+          end
+          if UI.MainMenu.mx4_retry_index ~= nil and carousel.currentIndex ~= UI.MainMenu.mx4_retry_index then
+            UI.MainMenu.mx4_retry_pending = false
+            UI.MainMenu.mx4_retry_index = nil
+            return
+          end
+          local saved_index = UI.MainMenu.mx4_retry_index
+          UI.MainMenu.mx4_retry_pending = false
+          UI.MainMenu.mx4_retry_index = nil
+          if TryEnterMX4SIO() then
+            return
+          end
+          UI.Notif_queue.add("No MX4SIO device found")
+          return
+        end
         if not carousel.animActive then
           if UI.Pad.Events.NAV_RIGHT then
             carousel.targetIndex = WrapIndex(carousel.currentIndex + 1, profcnt)
@@ -1571,18 +1604,12 @@ UI = {
               UI.SceneChange(UI.SCENES.GSMB)
             end
           elseif UI.MainMenu.OPT == 2 then
-            PLDR.CleanupGameList()
-            PLDR.GAMEPATH = ""
-            local mx4sio_root = PLDR.InitMX4SIOPopsRoot()
-            if mx4sio_root == nil then
-              UI.Notif_queue.add("No MX4SIO device found")
+            if TryEnterMX4SIO() then
               return
-            else
-              PLDR.CleanupGameList()
-              PLDR.GetPS1GameLists(mx4sio_root, true)
-              UI.setDeviceLock(DEVLOCK.MX4SIO)
-              UI.SceneChange(UI.SCENES.GMX4SIO)
             end
+            UI.MainMenu.mx4_retry_pending = true
+            UI.MainMenu.mx4_retry_index = carousel.currentIndex
+            return
           elseif UI.MainMenu.OPT == 3 then
             UI.Notif_queue.add("Not Implemented Yet")
           elseif UI.MainMenu.OPT == 4 then


### PR DESCRIPTION
### Motivation
- Physical MX4SIO entry requires two presses across frames; this change simulates that by performing an immediate attempt and a single automatic retry on the next frame to match hardware timing.

### Description
- Added two persistent fields on `UI.MainMenu`: `mx4_retry_pending` (bool) and `mx4_retry_index` (index capture) to track a scheduled next-frame retry.
- Introduced a local helper `TryEnterMX4SIO()` inside `UI.MainMenu.Play()` that performs the exact existing MX4SIO enter sequence and returns success/failure.
- Implemented a retry-runner immediately after `Input_GetEvent()` and `UI.HandleGlobalInput(false)` and before normal navigation/confirm handling that runs the deferred second attempt exactly once, defers while carousel animation is active, cancels if selection changed, clears pending before attempting, and only shows a notification on deferred failure.
- Replaced the `OPT == 2` confirm branch so one press does an immediate `TryEnterMX4SIO()` attempt and, on failure, schedules the single next-frame retry without immediate notification.

### Testing
- Ran `rg -n` checks for `mx4_retry_pending`, `mx4_retry_index`, `TryEnterMX4SIO`, the retry-runner block, and the modified `OPT == 2` branch and all patterns were found (success).
- Generated and inspected the diff summary with `git diff --stat` and full `git diff -- bin/POPSLDR/ui.lua` to verify only `bin/POPSLDR/ui.lua` was changed (success).
- Verified working tree was clean after creating the commit with `git status --short` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87d6e01e88321bfd99405c367a6f4)