### PR TITLE
Fix MX4SIO first-entry reliability with bounded backend double-probe

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -127,6 +127,34 @@ static bool EnsureCDFS()
 	return true;
 }
 
+static bool EnsureMx4sioMass()
+{
+	bool ok = EnsureBDMFatFs();
+	if (ok && !mx4sio_irx_loaded) {
+		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
+		if (ok) {
+			mx4sio_irx_loaded = true;
+		}
+	}
+
+	if (ok) {
+		char root[16];
+		char mx4_root[16];
+		for (int pass = 0; pass < 2; ++pass) {
+			(void)RefreshMassBackendCache();
+			for (int slot = 0; slot <= 9; ++slot) {
+				BuildMassRootPath(slot, root, sizeof(root));
+				(void)ProbeDir(root, NULL);
+			}
+			if (pass == 1) {
+				(void)GetMassRootByBackendNameInternal("mx4sio", mx4_root, sizeof(mx4_root));
+			}
+		}
+	}
+
+	return ok;
+}
+
 static bool EnsureBdmQueryRpc()
 {
 	if (!bdm_rpc_loaded) {
@@ -1266,13 +1294,7 @@ static int lua_mx4sio_init(lua_State *L)
 		(void)luaL_checkstring(L, 1);
 	}
 
-	bool ok = EnsureBDMFatFs();
-	if (ok && !mx4sio_irx_loaded) {
-		ok = LoadIrxCheckedBuffer("mx4sio_bd.irx", mx4sio_bd_irx, size_mx4sio_bd_irx, NULL, NULL);
-		if (ok) {
-			mx4sio_irx_loaded = true;
-		}
-	}
+	bool ok = EnsureMx4sioMass();
 
 	lua_pushboolean(L, ok);
 	lua_pushnil(L);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -37,6 +37,9 @@ extern unsigned int size_cdfs_irx;
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
+static bool RefreshMassBackendCache();
+static bool GetMassRootByBackendNameInternal(const char *backend_name, char *out_root, size_t out_sz);
+static bool ProbeDir(const char *path, int *out_ret);
 
 #ifndef USBMASS_IOCTL_GET_DRIVERNAME
 #define USBMASS_IOCTL_GET_DRIVERNAME 0x0003


### PR DESCRIPTION
### Motivation
- MX4SIO devices often require a second backend probe to enumerate/mount, causing the frontend to appear to need two attempts; the goal is to make the first backend init emulate a deterministic double-poke without changing any identity/mount/UI rules.
- The fix must be backend-only, bounded, deterministic, and minimal so behavior for all other devices remains unchanged.

### Description
- Added a backend helper `EnsureMx4sioMass()` in `src/luasystem.cpp` that preserves existing init semantics (`EnsureBDMFatFs()` and one-time `mx4sio_bd.irx` load guarded by `mx4sio_irx_loaded`).
- After successful init/load the helper performs a bounded two-pass poke: each pass calls `RefreshMassBackendCache()` and probes slots `0..9` by building roots with `BuildMassRootPath()` and calling `ProbeDir()`, and the second pass also calls `GetMassRootByBackendNameInternal("mx4sio", ...)` to exercise backend detection.
- Replaced the body of `lua_mx4sio_init(lua_State *L)` to call `EnsureMx4sioMass()` while preserving the exact Lua return contract and the `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c0735d7083219ddf2b8349459860)