### PR TITLE
FAT32: delete only mc0:/POPSTARTER/usbd.irx and usbhdfsd.irx

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1215,8 +1215,8 @@ function PLDR.ApplyBdmaMode(mode_key)
   end
 
   if selected == "FAT32" then
-    DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbd.irx")
-    DeleteIfExists(POPSTARTER_PACK_ROOT.."/usbhdfsd.irx")
+    DeleteIfExists("mc0:/POPSTARTER/usbd.irx")
+    DeleteIfExists("mc0:/POPSTARTER/usbhdfsd.irx")
     WriteBdmaModeMarker(selected)
     return true
   end


### PR DESCRIPTION
### Motivation
- Ensure applying the FAT32 BDMA mode removes only the two specific `mc0:/POPSTARTER` IRX files and succeeds silently if they are absent, without touching any other files or changing other BDMA modes.

### Description
- In `PLDR.ApplyBdmaMode(mode_key)` the FAT32 branch now calls `DeleteIfExists("mc0:/POPSTARTER/usbd.irx")` and `DeleteIfExists("mc0:/POPSTARTER/usbhdfsd.irx")`, preserving the subsequent `WriteBdmaModeMarker("FAT32")` and `return true` behavior and leaving all other branches unchanged.

### Testing
- Confirmed the source change via `git diff --stat`, which reports: `bin/POPSLDR/system.lua | 4 ++--` and `1 file changed, 2 insertions(+), 2 deletions(-)`.
- Inspected the modified `FAT32` branch to verify the two explicit `DeleteIfExists` calls are present and no directory scanning or other deletions were introduced, and no automated runtime tests were available to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fa77d7248321af004f25fa982893)