### PR TITLE
Reduce footer button bar icon scale by 10% globally

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -280,7 +280,7 @@ UI = {
       PREVIEW_H = 240;
 	      -- Match BETA-5 carousel/menu vertical placement.
       CAROUSEL_Y_OFFSET = 36;
-      FOOTER_ICON_SCALE = 0.70;
+      FOOTER_ICON_SCALE = 0.63;
       FOOTER_LABEL_W = 140;
       FOOTER_ICON_Y_OFFSET = 24;
       FOOTER_LABEL_Y_OFFSET = 10;


### PR DESCRIPTION
### Motivation
- Reduce footer (button bar) icon size uniformly across the UI by 10% via a single global constant so all scenes using `UI.Footer.Draw` inherit the change.

### Description
- Updated `UI.LAYOUT.FOOTER_ICON_SCALE` in `bin/POPSLDR/ui.lua` from `0.70` to `0.63` and made no other edits.

### Testing
- Ran `rg -n "FOOTER_ICON_SCALE" bin/POPSLDR/ui.lua`, `git diff --stat`, `git diff -- bin/POPSLDR/ui.lua`, `git status --short`, and committed the change which confirmed a single-file, one-line modification (`bin/POPSLDR/ui.lua | 2 +-`, `1 file changed, 1 insertion(+), 1 deletion(-)`), and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a907ecae6083218e2dc9df0f03e78c)