### PR TITLE
docs: refresh STATE/ARCHITECTURE/RULES/PROMPTS/DECISIONS from repo truth

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,42 +2,41 @@ Last updated: 2026-03-05
 
 # ARCHITECTURE
 
-## Purpose
-High-level map of POPSLoader structure, flow, and boundaries.
+## Verified module boundaries
+- **Boot/runtime entry**
+  - `src/main.cpp`: initializes runtime/IOP services and executes `boot.lua`.
+  - `etc/boot.lua`: boot-path handling, font init, then `require("system")`.
+- **Lua orchestration and UI**
+  - `bin/POPSLDR/system.lua`: backend init, storage classification, game discovery, launch policy, settings load/save, BDMA apply.
+  - `bin/POPSLDR/ui.lua`: scene management, input handling, settings/profile interactions, labels and icon drawing.
+  - `bin/POPSLDR/images.lua`: image asset loading/registry used by UI.
+  - `bin/POPSLDR/pops_profiles.lua`: POPStarter profile definitions.
+- **Native backend/system bindings**
+  - `src/luasystem.cpp`: Lua `System.*` bindings, mass mount-driver query/classification support, module init wrappers.
+  - `iop/bdm_query/bdm_query.c`: backend driver query RPC support used by mass backend detection.
+- **Embedded assets/build packaging**
+  - `src/embed_assets.cpp` + generated `src/assets/*.c`: embedded Lua/assets used at runtime.
+  - `Makefile` and `.github/workflows/compilation.yml`: build and release artifact packaging.
 
-## Top-Level Components
-- [ ] `src/` EE core runtime (`main.cpp`, rendering/audio/input, Lua host bindings).
-- [ ] `bin/POPSLDR/` Lua orchestration and UI (`system.lua`, `ui.lua`, profiles, assets).
-- [ ] `iop/embed/` embedded IRX modules loaded at runtime.
-- [ ] `iop/bdm_query/` RPC module for querying block-device backend identity.
-- [ ] `modules/` optional controller modules (`ds34bt`, `ds34usb`, `pademu`).
-- [ ] `Makefile` + `.github/workflows/compilation.yml` build/embed/package pipeline.
+## High-level data flows
+1. **Boot -> load settings -> apply runtime defaults -> UI entry**
+   - `main.cpp` runs `boot.lua`.
+   - `boot.lua` requires `system.lua`.
+   - `system.lua` executes `PLDR.LoadSettingsNonFatal()` before entering the UI loop.
+2. **Settings edit -> adjust -> confirm/leave -> save -> reflected labels**
+   - UI profile/settings scene stages changes in memory (`UI.ProfileDirty`, `UI.BdmaDirty`).
+   - On exit/confirm, `queue_exit` writes settings with `PLDR.SaveSettingsAtomic()` and applies BDMA if changed.
+   - Initial UI BDMA selector index is derived from loaded `PLDR.BDMA_MODE_KEY`.
+3. **Device identity pipeline (USB vs MX4SIO)**
+   - Lua asks `System.getMassMountDriver(root)` (or fallback driver query paths).
+   - Classification uses mount-driver identity; `sdc` (`mx4sio` in native classifier) maps to MX4SIO.
+   - USB lists and MX4SIO lists are built from separated root sets.
 
-## Data / Control Flow
-- [ ] ELF startup (`src/main.cpp`) initializes IOP/runtime and executes boot Lua.
-- [ ] Boot script (`etc/boot.lua`) normalizes boot context and requires `system.lua`.
-- [ ] Runtime logic (`bin/POPSLDR/system.lua`) prepares devices, assets, and launch policies.
-- [ ] UI logic (`bin/POPSLDR/ui.lua`) handles scene navigation and user actions.
-- [ ] Device enumeration/classification uses mass roots + mount driver identity (`sdc` => MX4SIO path).
-- [ ] Game discovery scans device `POPS/` folders for `.vcd` files.
-- [ ] Launch path resolves POPStarter selector/device mode and transfers control.
+## Non-goals / guardrails
+- No unbounded loops or retries in backend/device probing.
+- Avoid debug/logging additions in production paths.
+- Do not guess device identity when mount driver is unknown.
 
-## Key Boundaries
-- [ ] Keep boot and launch pipeline behavior stable unless task explicitly targets startup/launch.
-- [ ] Keep device detection/classification logic stable and isolated (Lua + `luasystem.cpp` + `bdm_query`).
-- [ ] Keep UI scene code separate from low-level backend probing details.
-- [ ] Keep embedded assets/IRX packaging changes isolated to build+asset paths.
-
-## Where to Add New Features vs Fixes
-- [ ] UI/UX features: `bin/POPSLDR/ui.lua` and related image/text assets.
-- [ ] Device/backend behavior: `bin/POPSLDR/system.lua` plus `src/luasystem.cpp` if native hooks are required.
-- [ ] Low-level module behavior: `iop/` and `src/` only when Lua-level changes are insufficient.
-- [ ] Build/package changes: `Makefile` and CI workflow.
-- [ ] Bug fixes should land closest to defect source; avoid cross-layer rewrites.
-
-## Dependency Rules
-- [ ] Lua UI/runtime may depend on exposed `System.*` APIs; avoid bypassing through ad hoc globals.
-- [ ] EE core (`src/`) can embed/use Lua/assets and IRX blobs; embedded data must not depend on runtime state.
-- [ ] IOP modules remain isolated and communicate through explicit RPC/IOCTL boundaries.
-- [ ] Optional controller modules must not become hard runtime requirements for core boot/launch.
-- [ ] Runtime behavior must remain deterministic for the same inputs/device state.
+## Unknown (verify)
+- Exact on-device timing behavior for MX4SIO first-entry masking with explicit ~1s delay is not fully codified in `system.lua`; current retry state machine exists but may not match target UX timing.
+- ART pipeline integration boundaries are not implemented yet (verify when feature lands).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,44 +2,31 @@ Last updated: 2026-03-05
 
 # DECISIONS
 
-## Purpose
-Lightweight ADR log for architectural and process decisions.
+## Decision log format
+For each entry, record:
+- **Date** (`YYYY-MM-DD`)
+- **Decision**
+- **Rationale**
+- **Implications**
 
-## ADR Template
-```markdown
-ID: ADR-XXXX
-Date: YYYY-MM-DD
-Status: Proposed | Accepted | Superseded | Deprecated
+## Decision log
 
-Context:
-- <problem, constraints, and background>
+### 2026-03-05 — Settings persist on confirm/leave Settings/Profile
+- **Decision:** Stage settings edits in UI state, then persist on Settings/Profile exit/confirm via `SaveSettingsAtomic()`.
+- **Rationale:** Current UI flow marks changes dirty while navigating and commits in `queue_exit`, avoiding repeated writes during each adjustment.
+- **Implications:** UI can be responsive during selection changes; persistence behavior must remain explicit and testable across restarts.
 
-Decision:
-- <what was decided>
+### 2026-03-05 — Mount-driver identity is authoritative for MX4SIO vs USB
+- **Decision:** Classify mass roots by mount-driver identity (`getMassMountDriver`/driver classifier), with `sdc`/`mx4sio` indicating MX4SIO.
+- **Rationale:** Current Lua/native pipeline already separates lists using driver identity; path-shape/device-name guessing is less reliable.
+- **Implications:** Any future storage UI/backend changes must preserve this authority chain and avoid heuristic-only classification.
 
-Consequences:
-- Positive: <benefits>
-- Negative: <tradeoffs>
+### 2026-03-05 — No debug/logging additions in production by default
+- **Decision:** Keep production paths free of new debug/logging unless explicitly requested by task scope.
+- **Rationale:** Project guidance prioritizes minimal noise and performance-sensitive PS2 runtime behavior.
+- **Implications:** Diagnostics should be temporary, scoped, and removable; PRs adding logs require explicit justification.
 
-Alternatives considered:
-- <option A> - <why rejected>
-- <option B> - <why rejected>
-```
-
-## ADR-0000
-- ID: ADR-0000
-- Date: 2026-03-05
-- Status: Proposed
-
-### Context
-- TODO: No confirmed project-specific ADRs captured yet.
-
-### Decision
-- TODO: Add first accepted decision when project facts are confirmed.
-
-### Consequences
-- Positive: Establishes a consistent ADR format.
-- Negative: Contains placeholders until real decisions are recorded.
-
-### Alternatives
-- Keep decisions informal in PR threads only (rejected: poor long-term traceability).
+## TODO Decisions (planned, not yet implemented)
+- **ART asset strategy:** decide source of truth, cache policy, and fallback precedence.
+- **Packaging policy:** finalize transition from `POPS/*.tm2` to `PATCH5.bin` in CI/release artifacts.
+- **Network BDMA policy:** define SMB/iLink/UDPBD mode behavior, fallback order, and failure handling constraints.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -2,99 +2,93 @@ Last updated: 2026-03-05
 
 # PROMPTS
 
-## Bug Fix (Minimal Diff)
+## Reusable Codex PR prompt template
 ```markdown
 Goal:
-- Fix: <bug summary>
+- <single objective tied to POPSLoader behavior/docs/build>
 
-Non-goals:
-- No refactors, no feature additions, no formatting-only churn.
+Allowed files (allowlist):
+- <explicit paths only>
 
-Allowed files:
-- <explicit file paths or directories>
+Forbidden changes:
+- No edits outside allowlist
+- No behavior changes outside stated goal
+- No unrelated refactors/format churn
+- No debug/logging additions unless requested
 
-Constraints:
-- Minimal diff only.
-- Bounded loops only.
-- Avoid touching unrelated Lua/C/C++ files.
-- Do not add logging unless explicitly requested.
-- Preserve boot/launch and device detection logic unless this bug is in those areas.
+Invariants to preserve:
+- POPStarter launch pipeline remains intact
+- MX4SIO vs USB separation uses mount-driver identity (no guessing)
+- Settings persist only on confirm/leave Settings/Profile
+- Logic remains bounded/deterministic (no unbounded retries)
 
 Deliverables:
-- Summary, diffstat, key diff, test plan/results.
-
-Test plan:
-- Run targeted checks first: <TODO commands>
-- Add manual verification steps for uncovered paths.
+1) Summary of changes
+2) `git diff --stat`
+3) Full `git diff`
+4) Test plan/results (including unrun items)
 ```
 
-## Feature (Guardrails)
+## POPSLoader-tailored examples
+
+### 1) Bounded backend behavior change (MX4SIO quirk masking)
 ```markdown
 Goal:
-- Add: <feature summary>
-
-Non-goals:
-- No broad cleanup/refactor outside feature scope.
+- Implement bounded MX4SIO first-entry masking: initialize backend, attempt detect/list, wait ~1s once, retry once, then stop.
 
 Allowed files:
-- <explicit file paths or directories>
+- bin/POPSLDR/system.lua
+- bin/POPSLDR/ui.lua
 
-Constraints:
-- Keep architecture boundaries intact.
-- Bounded logic only.
-- Backward compatibility unless explicitly approved.
-- No logging additions unless requested.
+Forbidden:
+- No launch-policy rewrites
+- No packaging/CI edits
+- No unrelated UI redesign
 
-Deliverables:
-- Implementation, docs update, risk notes, test plan/results.
-
-Test plan:
-- New/updated targeted tests: <TODO commands>
-- Regression checks for adjacent behavior.
+Required checks:
+- USB list still excludes MX4SIO roots
+- MX4SIO list still depends on mount-driver identity
+- Retry count and delay are deterministic/bounded
 ```
 
-## Refactor (Explicit Approval Required)
+### 2) UI layout-only fix (settings alignment/icon stability)
 ```markdown
 Goal:
-- Refactor: <scope>
-
-Non-goals:
-- No behavior changes.
+- Fix Settings/Profile alignment so BDMA label/arrows stay visually stable regardless of text length.
 
 Allowed files:
-- <explicit file paths or directories>
+- bin/POPSLDR/ui.lua
 
-Constraints:
-- Proceed only with explicit refactor approval.
-- Preserve public interfaces unless approved.
-- Bounded loops only.
-- Keep commit(s) small and reviewable.
+Forbidden:
+- No backend/storage logic edits
+- No profile persistence logic changes
 
-Deliverables:
-- Before/after rationale, migration notes (if any), test plan/results.
-
-Test plan:
-- Baseline + post-refactor parity checks: <TODO commands>
+Required checks:
+- Icon coordinates are deterministic
+- No overlap at 4:3 safe area
+- No additional per-frame allocations/scans
 ```
 
-## Investigate + Propose Plan Only
+### 3) Packaging/CI edit (artifact contents)
 ```markdown
 Goal:
-- Investigate: <question/problem>
-
-Non-goals:
-- No code or config changes.
+- Change release artifact contents from POPS tm2 triplet to PATCH5.bin policy.
 
 Allowed files:
-- Read-only across relevant files.
+- .github/workflows/compilation.yml
+- README.md
 
-Constraints:
-- Gather evidence from repo only.
-- Do not infer unknown project facts; mark TODO where uncertain.
+Forbidden:
+- No runtime Lua/C/C++ changes
+- No gameplay/UI behavior changes
 
-Deliverables:
-- Findings, likely root cause(s), ranked options, recommended plan.
-
-Test plan:
-- If implementation follows, propose targeted validation steps.
+Required checks:
+- Artifact verifier enforces new expected set
+- Forbidden/legacy files are rejected explicitly
 ```
+
+## Prompt hygiene rules
+- Always specify an explicit allowlist of editable files.
+- Explicitly forbid unrelated changes.
+- Require summary + diffstat + full diff + test plan in output.
+- Require bounded/deterministic logic for retries, polling, and classification.

--- a/RULES.md
+++ b/RULES.md
@@ -2,39 +2,40 @@ Last updated: 2026-03-05
 
 # RULES
 
-## Purpose
-Short, enforceable repository rules.
+## Scope discipline
+- Keep changes small, local, and tied to one objective per PR whenever feasible.
+- Prefer the narrowest file set that can solve the task.
+- Do not mix behavior changes, refactors, and packaging edits in one PR unless explicitly requested.
 
-## Do
-- [ ] Keep diffs minimal and task-scoped.
-- [ ] Use bounded loops only.
-- [ ] Preserve determinism in logic and outputs.
-- [ ] Preserve boot/launch pipeline and device detection unless task explicitly targets them.
-- [ ] Document assumptions with `TODO` instead of guessing project facts.
+## Do-not-break invariants (POPSLoader)
+- POPStarter launching flow must stay intact (`RunPOPStarterGame` -> launch policy -> `LaunchEngine`).
+- BDMA mode behavior must remain consistent: selectable modes, save/load, and apply path must agree.
+- MX4SIO vs USB separation must use mount-driver identity as authority (`sdc`/`mx4sio` => MX4SIO), never UI guesswork.
+- Settings edits in the Settings/Profile screen are staged while navigating; persistence happens on confirm/leave, not on every adjustment.
+- No new debug/logging output in production unless explicitly requested.
 
-## Don't
-- [ ] Do not run destructive commands without explicit instruction.
-- [ ] Do not touch unrelated Lua/C/C++ files.
-- [ ] Do not add logging unless explicitly requested.
-- [ ] Do not introduce broad refactors without explicit approval.
-- [ ] Do not mix unrelated changes in one commit.
+## Persistence rules
+- Settings are loaded during startup via `PLDR.LoadSettingsNonFatal()` before entering the main UI loop.
+- Settings are saved through `PLDR.SaveSettingsAtomic()` when exiting Settings/Profile with pending changes.
+- Settings file path is currently `mc0:/POPSTARTER/.pldrs`.
+- UI labels and selectors must mirror runtime/persisted values (for example BDMA selector initializes from `PLDR.BDMA_MODE_KEY`).
 
-## Bounded Logic Only
-- [ ] Every loop must have a clear bound or termination condition.
-- [ ] Retries must have explicit max attempts and exit behavior.
-- [ ] Polling must use explicit limits and fail paths.
+## UI rules
+- Keep icon placement deterministic; do not anchor icon X positions to variable label length.
+- Preserve PS2 performance constraints: avoid heavy per-frame allocations, repeated full-device rescans, and unbounded retries in render/input loops.
 
-## Logging Policy
-- [ ] Default: no new logs.
-- [ ] If explicitly requested: keep logs minimal, scoped, and removable.
-- [ ] Never log secrets, keys, or sensitive identifiers.
+## Testing expectations
+- Minimum manual matrix for behavior-impacting changes:
+  - USB game list path
+  - MX4SIO game list path
+  - MMCE game list path
+  - HDD path (if touched)
+- Always include a settings persistence check: change profile/BDMA, exit Settings, restart, verify loaded state and labels.
+- If hardware paths cannot be tested locally, mark as `Unknown (verify on device)`.
 
-## Error Handling Expectations
-- [ ] Fail fast with actionable error messages.
-- [ ] Avoid silent failures and broad catch-all suppression.
-- [ ] Preserve existing error contracts unless change is intentional and documented.
-
-## Determinism Policy
-- [ ] Avoid nondeterministic ordering where output matters.
-- [ ] If randomness is required, seed and document behavior.
-- [ ] Keep time/external-state dependencies explicit and bounded.
+## PR hygiene
+- Every PR/task report should include:
+  - Summary
+  - Diffstat
+  - Full diff
+  - Test plan (what ran, what passed/failed, what was not run)

--- a/STATE.md
+++ b/STATE.md
@@ -2,30 +2,32 @@ Last updated: 2026-03-05
 
 # STATE
 
-## Purpose
-Current operational snapshot for humans and AI agents.
+## What POPSLoader is
+POPSLoader is a PS2 launcher for POPStarter built on the Enceladus runtime, with Lua-driven UI/flow (`bin/POPSLDR/system.lua`, `bin/POPSLDR/ui.lua`) and EE/IOP support in `src/` and `iop/`.
 
-## Current Goal
-- [ ] Finalize AI-oriented repo docs with concrete POPSLoader architecture, invariants, and usage guidance.
+## Current guarantees (repo-verified)
+- Startup loads `boot.lua`, which requires `system.lua`; `PLDR.LoadSettingsNonFatal()` runs before the main UI loop.
+- Settings persistence file is `mc0:/POPSTARTER/.pldrs`.
+- Settings/Profile edits are staged and persisted on Settings/Profile exit path (`queue_exit`) via `PLDR.SaveSettingsAtomic()`.
+- BDMA selectable modes currently implemented in UI/settings: `FAT32`, `USBEXFAT`, `MX4SIO`, `MMCE`.
+- MX4SIO vs USB list separation is based on mass mount driver identity (`System.getMassMountDriver` path, `sdc` detection for MX4SIO).
 
-## Current PR Objective
-- [ ] Replace placeholder docs with repo-grounded content (`README.md`, `ARCHITECTURE.md`, `TRUTHSHEET.md`, `STATE.md`).
-- [ ] Add a technical component map (`COMPONENTS.md`) to complement high-level architecture docs.
+## Known open work (backlog)
+- ART system integration.
+- Editable POPStarter path/profile via OSK.
+- Editable DKWDRV path via OSK.
+- Hide UI text toggle with exclusions (Splash/Credits/Settings/Games list text).
+- MX4SIO first-entry quirk masking target: init + two attempts + ~1s delay.
+- Packaging change target: ship `PATCH5.bin` instead of `POPS/*.tm2` in CI artifact.
+- Add BDMA modes: SMB, iLink, UDPBD.
+- Remove remaining debug/logging and continue size/speed optimization.
+- Settings save progress indicator UX improvements.
+- `mc?:/` alias support (`mc0` then `mc1`).
 
-## Known Regressions / Gaps
-- [ ] SMB path in main menu is currently marked `Not Implemented Yet` in UI.
-- [ ] One menu path (`UI.MainMenu.OPT == 3`) is currently marked `Not Implemented Yet`.
-- [ ] TODO: Add validated reproduction details for any runtime regressions as they are confirmed.
-
-## Current Constraints
-- [ ] Minimal diffs only; no unrelated code or formatting churn.
-- [ ] Avoid touching unrelated Lua/C/C++ files for docs-only tasks.
-- [ ] Bounded loops only.
-- [ ] Avoid adding logging unless explicitly requested.
-- [ ] Preserve boot/launch pipeline and device detection logic unless explicitly in scope.
-
-## How to Update This File
-- [ ] Update `Last updated` every time this file changes.
-- [ ] Keep entries short, factual, and tied to active work.
-- [ ] Move durable architectural decisions to `DECISIONS.md`.
-- [ ] Remove resolved items promptly to keep this snapshot current.
+## Release readiness checklist
+- [ ] POPStarter launch flow validated on target hardware.
+- [ ] Settings load/save verified across reboot.
+- [ ] BDMA mode selection/apply/persist verified for all implemented modes.
+- [ ] USB/MX4SIO separation validated via mount-driver identity.
+- [ ] Manual matrix completed (USB, MX4SIO, MMCE, HDD as applicable).
+- [ ] Packaging contents match release policy (current: tm2 set; target change tracked separately).


### PR DESCRIPTION
### Motivation
- Audit and replace template-like root meta docs with concise, repo-verified documentation to reduce future regressions and guide contributors. 
- Capture current, authoritative behavior for settings, BDMA modes, and mass-backend classification (MX4SIO vs USB) based on the codebase. 
- Provide actionable PR prompt templates and a lightweight decisions log so future changes follow the repository invariants.

### Description
- Updated five repo-root docs with verified facts and actionable guidance: `STATE.md`, `ARCHITECTURE.md`, `RULES.md`, `PROMPTS.md`, and `DECISIONS.md`.
- Documented verified settings lifecycle (`PLDR.LoadSettingsNonFatal()` on startup, `PLDR.SaveSettingsAtomic()` on Settings/Profile exit) and current settings file path (`mc0:/POPSTARTER/.pldrs`).
- Made mount-driver identity authoritative for MX4SIO vs USB classification (detection via `System.getMassMountDriver` / native `sdc` mapping) and captured current BDMA modes and apply/persist behavior.
- Added Codex PR prompt template plus three POPSLoader-tailored examples, an explicit PR-hygiene checklist, and a decision log with three accepted project policies and TODO decisions.
- Only the five target markdown files were modified in this change set.

### Testing
- Verified repository claims by inspecting implementation files (`bin/POPSLDR/system.lua`, `bin/POPSLDR/ui.lua`, `src/luasystem.cpp`, `src/main.cpp`, `etc/boot.lua`) using repository search and file reads, and used those results to populate docs (inspection succeeded).
- Ran lightweight repository checks: `git status --short`, `git diff --stat HEAD~1..HEAD`, and `git diff` per file for all five modified docs, and all checks reported the expected diff and passed.
- Committed the changes with `git commit` and confirmed only the five target files were staged/committed (operation succeeded).
- No runtime or device hardware tests were run here; hardware verification items are listed in the docs as checklist/todo items (marked `Unknown (verify)` where appropriate).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ada5638c83218c81ac37d445f804)