### PR TITLE
docs: replace root meta-doc templates with POPSLoader-specific guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,43 +1,49 @@
-Last updated: 2026-03-05
-
 # ARCHITECTURE
 
-## Purpose
-High-level map of POPSLoader structure, flow, and boundaries.
+This document describes the intended high-level architecture. It should not be treated as a perfect description of current code if the implementation differs.
 
-## Top-Level Components
-- [ ] `src/` EE core runtime (`main.cpp`, rendering/audio/input, Lua host bindings).
-- [ ] `bin/POPSLDR/` Lua orchestration and UI (`system.lua`, `ui.lua`, profiles, assets).
-- [ ] `iop/embed/` embedded IRX modules loaded at runtime.
-- [ ] `iop/bdm_query/` RPC module for querying block-device backend identity.
-- [ ] `modules/` optional controller modules (`ds34bt`, `ds34usb`, `pademu`).
-- [ ] `Makefile` + `.github/workflows/compilation.yml` build/embed/package pipeline.
+## High-level components (conceptual)
+- UI layer
+  - Renders menus/pages
+  - Handles input
+  - Shows user-facing labels, icons, and notifications
+- System/Backend layer
+  - Device/backends initialization (USB/MX4SIO/MMCE/HDD/etc.)
+  - BDMA mode selection and initialization
+  - Filesystem probing and mount identity queries
+- Settings layer
+  - Loads settings on boot
+  - Applies settings to runtime
+  - Saves settings only on confirm/leave Settings page
+- Packaging/Assets
+  - Embedded or shipped assets (icons/artwork/binaries)
+  - Release artifacts layout controlled by CI workflow
 
-## Data / Control Flow
-- [ ] ELF startup (`src/main.cpp`) initializes IOP/runtime and executes boot Lua.
-- [ ] Boot script (`etc/boot.lua`) normalizes boot context and requires `system.lua`.
-- [ ] Runtime logic (`bin/POPSLDR/system.lua`) prepares devices, assets, and launch policies.
-- [ ] UI logic (`bin/POPSLDR/ui.lua`) handles scene navigation and user actions.
-- [ ] Device enumeration/classification uses mass roots + mount driver identity (`sdc` => MX4SIO path).
-- [ ] Game discovery scans device `POPS/` folders for `.vcd` files.
-- [ ] Launch path resolves POPStarter selector/device mode and transfers control.
+## Data flows (conceptual)
+### Boot
+1. Initialize core system modules
+2. Load settings (if present)
+3. Apply settings to runtime
+4. Enter UI main flow
 
-## Key Boundaries
-- [ ] Keep boot and launch pipeline behavior stable unless task explicitly targets startup/launch.
-- [ ] Keep device detection/classification logic stable and isolated (Lua + `luasystem.cpp` + `bdm_query`).
-- [ ] Keep UI scene code separate from low-level backend probing details.
-- [ ] Keep embedded assets/IRX packaging changes isolated to build+asset paths.
+### Settings edit
+1. User changes selection (no immediate persistence)
+2. User confirms/leaves Settings page
+3. Save settings atomically
+4. Update UI labels/state
 
-## Where to Add New Features vs Fixes
-- [ ] UI/UX features: `bin/POPSLDR/ui.lua` and related image/text assets.
-- [ ] Device/backend behavior: `bin/POPSLDR/system.lua` plus `src/luasystem.cpp` if native hooks are required.
-- [ ] Low-level module behavior: `iop/` and `src/` only when Lua-level changes are insufficient.
-- [ ] Build/package changes: `Makefile` and CI workflow.
-- [ ] Bug fixes should land closest to defect source; avoid cross-layer rewrites.
+### Device identity (conceptual rule)
+- Classify mounted roots by querying the mount driver name from the mounted root itself (not by guessing slot index).
+- If driver contains “sdc” (case-insensitive) => MX4SIO
+- If driver is known and not “sdc” => USB
+- If driver unknown/nil/empty => exclude from both pages
 
-## Dependency Rules
-- [ ] Lua UI/runtime may depend on exposed `System.*` APIs; avoid bypassing through ad hoc globals.
-- [ ] EE core (`src/`) can embed/use Lua/assets and IRX blobs; embedded data must not depend on runtime state.
-- [ ] IOP modules remain isolated and communicate through explicit RPC/IOCTL boundaries.
-- [ ] Optional controller modules must not become hard runtime requirements for core boot/launch.
-- [ ] Runtime behavior must remain deterministic for the same inputs/device state.
+## Non-goals
+- No unbounded scanning/retry loops.
+- No adding debug logging in production without explicit request.
+- No “smart guessing” for backend identity when driver identity is unknown.
+
+## Unknowns / Verify
+- TODO: Confirm exact module/file boundaries in this repo (e.g., which files own UI vs system vs settings).
+- TODO: Confirm settings storage format and filenames (document here once verified).
+- TODO: Confirm final asset strategy post-ART integration (what stays embedded vs shipped).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,45 +1,36 @@
-Last updated: 2026-03-05
-
 # DECISIONS
 
-## Purpose
-Lightweight ADR log for architectural and process decisions.
+This file tracks project decisions so future changes don’t accidentally reverse them.
 
-## ADR Template
-```markdown
-ID: ADR-XXXX
-Date: YYYY-MM-DD
-Status: Proposed | Accepted | Superseded | Deprecated
+Format:
+- Date: YYYY-MM-DD
+- Decision:
+- Rationale:
+- Implications:
 
-Context:
-- <problem, constraints, and background>
+---
 
-Decision:
-- <what was decided>
+## 2026-03-05 — Settings persistence is commit-on-exit only
+- Decision: Settings are applied/saved only when confirming or leaving the Settings page; not while adjusting controls.
+- Rationale: Prevent partial/accidental persistence and mismatched runtime/UI states.
+- Implications:
+  - Any settings UI work must preserve this behavior.
+  - UI labels must reflect persisted/runtime state on boot and after saving.
 
-Consequences:
-- Positive: <benefits>
-- Negative: <tradeoffs>
+## 2026-03-05 — Mount-driver identity is authoritative for MX4SIO vs USB
+- Decision: Classify mounted roots by querying the mount driver name from the mounted root; do not guess from slot indices.
+- Rationale: Avoid false positives and regression from backend list scanning/heuristics.
+- Implications:
+  - Unknown/nil/empty driver identity excludes the mount from both pages.
+  - “sdc” (case-insensitive) indicates MX4SIO.
 
-Alternatives considered:
-- <option A> - <why rejected>
-- <option B> - <why rejected>
-```
+## 2026-03-05 — Avoid debug/logging in production
+- Decision: Do not add debug logging unless explicitly requested; prefer smaller footprint.
+- Rationale: ELF size and runtime performance.
+- Implications:
+  - Remove legacy debug logs where safe during optimization passes.
 
-## ADR-0000
-- ID: ADR-0000
-- Date: 2026-03-05
-- Status: Proposed
-
-### Context
-- TODO: No confirmed project-specific ADRs captured yet.
-
-### Decision
-- TODO: Add first accepted decision when project facts are confirmed.
-
-### Consequences
-- Positive: Establishes a consistent ADR format.
-- Negative: Contains placeholders until real decisions are recorded.
-
-### Alternatives
-- Keep decisions informal in PR threads only (rejected: poor long-term traceability).
+## TODO decisions (fill once implemented)
+- TODO: ART asset strategy (embedded vs shipped files)
+- TODO: Packaging decision: PATCH5.bin replaces POPS/*.tm2 in release artifacts
+- TODO: Network BDMA decisions (SMB/iLink/UDPBD behaviors and fallbacks)

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,100 +1,40 @@
-Last updated: 2026-03-05
-
 # PROMPTS
 
-## Bug Fix (Minimal Diff)
-```markdown
-Goal:
-- Fix: <bug summary>
+This file stores “known-good” prompt patterns for AI-assisted contributions (Codex) to minimize regressions.
 
-Non-goals:
-- No refactors, no feature additions, no formatting-only churn.
+## General PR prompt template
+Use this when asking Codex to implement a bounded change.
 
-Allowed files:
-- <explicit file paths or directories>
+### Template
+- Repo/branch: <fill in>
+- Objective: <one sentence>
+- Files allowed to change: <explicit list>
+- Forbidden changes: logging, unrelated refactors, UI layout changes, etc.
+- Behavioral invariants: <do-not-break list>
+- Deliverables: diffstat, diff, test plan
 
-Constraints:
-- Minimal diff only.
-- Bounded loops only.
-- Avoid touching unrelated Lua/C/C++ files.
-- Do not add logging unless explicitly requested.
-- Preserve boot/launch and device detection logic unless this bug is in those areas.
+## Examples (fill/extend over time)
 
-Deliverables:
-- Summary, diffstat, key diff, test plan/results.
+### Example: Bounded backend behavior fix
+- Objective: Mask MX4SIO first-entry quirk by performing exactly two mount attempts after one init, with ~1s delay between attempts.
+- Files allowed: <explicit list>
+- Constraints:
+  - No new retry systems elsewhere
+  - No identity rule changes
+  - No added logging
+  - Deterministic/bounded behavior only
+- Deliverables: diffstat, diff, test plan
 
-Test plan:
-- Run targeted checks first: <TODO commands>
-- Add manual verification steps for uncovered paths.
-```
+### Example: UI layout fix
+- Objective: Fix Settings page alignment and prevent icon shift due to variable string lengths.
+- Constraints:
+  - No behavioral changes to backend logic
+  - No new assets unless required
+  - Keep layout deterministic
+- Deliverables: before/after screenshots if possible + diff
 
-## Feature (Guardrails)
-```markdown
-Goal:
-- Add: <feature summary>
-
-Non-goals:
-- No broad cleanup/refactor outside feature scope.
-
-Allowed files:
-- <explicit file paths or directories>
-
-Constraints:
-- Keep architecture boundaries intact.
-- Bounded logic only.
-- Backward compatibility unless explicitly approved.
-- No logging additions unless requested.
-
-Deliverables:
-- Implementation, docs update, risk notes, test plan/results.
-
-Test plan:
-- New/updated targeted tests: <TODO commands>
-- Regression checks for adjacent behavior.
-```
-
-## Refactor (Explicit Approval Required)
-```markdown
-Goal:
-- Refactor: <scope>
-
-Non-goals:
-- No behavior changes.
-
-Allowed files:
-- <explicit file paths or directories>
-
-Constraints:
-- Proceed only with explicit refactor approval.
-- Preserve public interfaces unless approved.
-- Bounded loops only.
-- Keep commit(s) small and reviewable.
-
-Deliverables:
-- Before/after rationale, migration notes (if any), test plan/results.
-
-Test plan:
-- Baseline + post-refactor parity checks: <TODO commands>
-```
-
-## Investigate + Propose Plan Only
-```markdown
-Goal:
-- Investigate: <question/problem>
-
-Non-goals:
-- No code or config changes.
-
-Allowed files:
-- Read-only across relevant files.
-
-Constraints:
-- Gather evidence from repo only.
-- Do not infer unknown project facts; mark TODO where uncertain.
-
-Deliverables:
-- Findings, likely root cause(s), ranked options, recommended plan.
-
-Test plan:
-- If implementation follows, propose targeted validation steps.
-```
+## Prompt hygiene rules
+- Always specify the file allowlist.
+- Always specify “no unrelated changes.”
+- Require full diffs and minimal commits.
+- Require a test plan appropriate for PS2 hardware constraints.

--- a/RULES.md
+++ b/RULES.md
@@ -1,40 +1,45 @@
-Last updated: 2026-03-05
-
 # RULES
 
-## Purpose
-Short, enforceable repository rules.
+These rules exist to prevent regressions and keep changes reviewable.
 
-## Do
-- [ ] Keep diffs minimal and task-scoped.
-- [ ] Use bounded loops only.
-- [ ] Preserve determinism in logic and outputs.
-- [ ] Preserve boot/launch pipeline and device detection unless task explicitly targets them.
-- [ ] Document assumptions with `TODO` instead of guessing project facts.
+## Scope discipline
+- Make changes as small and local as possible.
+- One objective per PR whenever feasible.
+- Avoid “drive-by refactors” mixed with feature work.
+- Prefer deterministic, bounded logic (no unbounded scans, no infinite retries).
 
-## Don't
-- [ ] Do not run destructive commands without explicit instruction.
-- [ ] Do not touch unrelated Lua/C/C++ files.
-- [ ] Do not add logging unless explicitly requested.
-- [ ] Do not introduce broad refactors without explicit approval.
-- [ ] Do not mix unrelated changes in one commit.
+## Do-not-break list (non-negotiable)
+- POPStarter launching flow must continue to work.
+- BDMA mode detection/selection/persistence must not regress.
+- MX4SIO vs USB separation rules must remain correct (mount driver identity remains authoritative).
+- Settings must not “half apply” during adjustments; apply/persist only on confirm/leave Settings page.
+- No added debug logging in release builds (unless explicitly requested).
 
-## Bounded Logic Only
-- [ ] Every loop must have a clear bound or termination condition.
-- [ ] Retries must have explicit max attempts and exit behavior.
-- [ ] Polling must use explicit limits and fail paths.
+## Persistence rules
+- Settings load on boot if present.
+- Settings save only when confirming/leaving Settings page (not while adjusting controls).
+- UI labels must reflect persisted/runtime state (no “fat32 label while exFAT is active” situations).
 
-## Logging Policy
-- [ ] Default: no new logs.
-- [ ] If explicitly requested: keep logs minimal, scoped, and removable.
-- [ ] Never log secrets, keys, or sensitive identifiers.
+## UI rules
+- No layout jitter from dynamic string lengths (icons/arrows must not shift based on preceding text length).
+- Keep PS2-safe performance: avoid heavy per-frame allocations and repeated filesystem scans.
+- Any new UI toggle must not affect excluded pages unless specified.
 
-## Error Handling Expectations
-- [ ] Fail fast with actionable error messages.
-- [ ] Avoid silent failures and broad catch-all suppression.
-- [ ] Preserve existing error contracts unless change is intentional and documented.
+## Performance and size
+- Avoid new large embedded assets unless justified.
+- Prefer reusing assets and caching where safe.
+- Remove/avoid verbose logs and debug strings in production.
 
-## Determinism Policy
-- [ ] Avoid nondeterministic ordering where output matters.
-- [ ] If randomness is required, seed and document behavior.
-- [ ] Keep time/external-state dependencies explicit and bounded.
+## Testing expectations (minimum)
+- Verify on at least one real-hardware path for each affected backend:
+  - USB
+  - MX4SIO
+  - MMCE
+  - HDD (if applicable)
+- Validate settings persistence across reboot.
+- Validate “missing file” handling (missing POPSTARTER.ELF / DKWDRV.ELF) is graceful.
+
+## PR hygiene
+- Include: summary, diffstat, and a short test plan.
+- Mention any behavior changes explicitly.
+- If behavior is unchanged, say so explicitly.

--- a/STATE.md
+++ b/STATE.md
@@ -1,31 +1,34 @@
-Last updated: 2026-03-05
-
 # STATE
 
-## Purpose
-Current operational snapshot for humans and AI agents.
+This file is the current snapshot of “where the project stands” and what remains.
 
-## Current Goal
-- [ ] Finalize AI-oriented repo docs with concrete POPSLoader architecture, invariants, and usage guidance.
+## Project
+- Name: POPSLoader
+- Purpose: PS2 homebrew launcher/manager for POPStarter/POPS workflows, including BDMA backends and device handling.
 
-## Current PR Objective
-- [ ] Replace placeholder docs with repo-grounded content (`README.md`, `ARCHITECTURE.md`, `TRUTHSHEET.md`, `STATE.md`).
-- [ ] Add a technical component map (`COMPONENTS.md`) to complement high-level architecture docs.
+## Current guarantees (must remain true)
+- Settings load on boot (when present) and UI labels reflect actual persisted/runtime state.
+- Settings save only when confirming/leaving Settings page.
+- MX4SIO vs USB classification uses mount-driver identity rules (do not guess).
+- Unknown/empty driver identity is excluded from both MX4SIO and USB pages (never default unknown to USB).
+- No debug logging in production builds unless explicitly requested.
 
-## Known Regressions / Gaps
-- [ ] SMB path in main menu is currently marked `Not Implemented Yet` in UI.
-- [ ] One menu path (`UI.MainMenu.OPT == 3`) is currently marked `Not Implemented Yet`.
-- [ ] TODO: Add validated reproduction details for any runtime regressions as they are confirmed.
+## Known open work (high-level)
+- ART system integration (port from other version).
+- Editable POPStarter path/profile via on-screen keyboard.
+- Editable DKWDRV path via on-screen keyboard.
+- Global “Hide UI text” toggle (excluded: Splash/Credits/Settings/Gameslist text).
+- MX4SIO first-entry quirk masking (one init, two mount attempts with ~1s delay).
+- Packaging change: remove POPS/*.tm2 from artifacts and ship POPS/PATCH5.bin instead.
+- Add BDMA modes: SMB, iLink, UDPBD (UDPBD is highest complexity).
+- Strip debug/logging and reduce size; improve performance.
+- Settings-save progress indicator.
+- Add mc?:/ alias support (try mc0 then mc1).
 
-## Current Constraints
-- [ ] Minimal diffs only; no unrelated code or formatting churn.
-- [ ] Avoid touching unrelated Lua/C/C++ files for docs-only tasks.
-- [ ] Bounded loops only.
-- [ ] Avoid adding logging unless explicitly requested.
-- [ ] Preserve boot/launch pipeline and device detection logic unless explicitly in scope.
-
-## How to Update This File
-- [ ] Update `Last updated` every time this file changes.
-- [ ] Keep entries short, factual, and tied to active work.
-- [ ] Move durable architectural decisions to `DECISIONS.md`.
-- [ ] Remove resolved items promptly to keep this snapshot current.
+## Release readiness checklist (rolling)
+- [ ] No overlapping UI text; settings layout stable with long paths
+- [ ] Settings persistence verified (change -> leave settings -> reboot -> labels correct)
+- [ ] MX4SIO entry works with known double-entry quirk masked
+- [ ] Backends validated on real hardware (USB/MX4SIO/MMCE/…)
+- [ ] Artifact packaging matches expected files
+- [ ] No debug logs, acceptable ELF/artifact size


### PR DESCRIPTION
### Motivation
- Replace generic or templated repo-root meta-docs with concise, project-relevant guidance for POPSLoader to prevent regressions and guide contributors. 
- Keep changes strictly docs-only and avoid inventing implementation details by marking unknowns as `TODO`/verify where appropriate.

### Description
- Replaced/updated five root markdown files with POPSLoader-focused content: `RULES.md`, `STATE.md`, `ARCHITECTURE.md`, `PROMPTS.md`, and `DECISIONS.md`. 
- Content additions include non-regression rules (persistence/UI/backends), a current project state snapshot and rolling release checklist, a conceptual architecture and data flows section, AI prompt templates for bounded PRs, and recorded decisions with TODOs for unresolved items. 
- No source code, assets, CI, build files, or unrelated Lua/C/C++ files were modified. 
- Unknown implementation details were left as explicit `TODO`/verify entries rather than being assumed or invented.

### Testing
- Ran repository validation and inspection commands to verify the change set with `git status --short`, `git diff --stat`, and `git diff`, and reviewed the committed patch with `git show --stat HEAD` and `git show HEAD -- <file>` for each modified file, and all commands completed successfully. 
- Committed the changes with message `docs: replace root meta-doc templates with project guardrails` and confirmed the commit shows 5 files changed with `185` insertions and `240` deletions. 
- No runtime or unit tests were applicable because this is a docs-only change, so no code tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99bc51d2c8321aad81172d76a492e)