### PR TITLE
Add sidecar cover art loading from resolved VCD path with SQUARE toggle and persistence

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -35,6 +35,9 @@ local IMG_REGISTRATIONS = {
   {"right", "right.png"},
   {"up",    "up.png"},
   {"down",  "down.png"},
+  {"default", "default.png"},
+  {"disable_art", "disable_art.png"},
+  {"frame", "frame.png"},
 }
 
 local IMG_SOURCES = {}

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -265,6 +265,7 @@ local pldr_defaults = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
   POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
   CHECK_POPSTARTER_FILES = false;
+  ART_ENABLED = true;
   GAMEPATH = ".";
   GAMES = {};
   HDDCACHE = nil;
@@ -795,12 +796,33 @@ function PLDR.BdmaSourceCandidates(rel)
 end
 
 local function EncodeSettings()
+  local art_enabled = 1
+  if PLDR.ART_ENABLED == false then
+    art_enabled = 0
+  end
   local lines = {
     "PROFILE="..tostring(tonumber(PLDR.SELECTED_PROFILE) or 1),
     "POPSTARTER_PATH="..tostring(PLDR.POPSTARTER_PATH or ""),
-    "BDMA="..tostring(PLDR.BDMA_MODE_KEY or "FAT32")
+    "BDMA="..tostring(PLDR.BDMA_MODE_KEY or "FAT32"),
+    "ART_ENABLED="..tostring(art_enabled)
   }
   return table.concat(lines, "\n").."\n"
+end
+
+local function ParseBoolish(raw, fallback)
+  if raw == nil then
+    return fallback
+  end
+  local value = string.lower(tostring(raw or ""))
+  value = string.gsub(value, "^%s+", "")
+  value = string.gsub(value, "%s+$", "")
+  if value == "1" or value == "true" or value == "yes" or value == "on" then
+    return true
+  end
+  if value == "0" or value == "false" or value == "no" or value == "off" then
+    return false
+  end
+  return fallback
 end
 
 local function NormalizeBdmaModeKey(mode)
@@ -877,6 +899,7 @@ function PLDR.LoadSettingsNonFatal()
   PLDR.EnsurePopstarterDir()
   PLDR.SELECTED_PROFILE = defaults_profile
   PLDR.BDMA_MODE_KEY = "FAT32"
+  PLDR.ART_ENABLED = true
   if PLDR.PROFILES ~= nil and PLDR.PROFILES[defaults_profile] ~= nil then
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[defaults_profile].ELF
   end
@@ -892,6 +915,7 @@ function PLDR.LoadSettingsNonFatal()
   local profile = tonumber(string.match(data, "\nPROFILE=([^\n]+)")) or tonumber(string.match(data, "^PROFILE=([^\n]+)"))
   local popstarter_path = string.match(data, "\nPOPSTARTER_PATH=([^\n]*)") or string.match(data, "^POPSTARTER_PATH=([^\n]*)")
   local bdma_mode = string.match(data, "\nBDMA=([^\n]+)") or string.match(data, "^BDMA=([^\n]+)") or string.match(data, "\nBDMA_MODE=([^\n]+)") or string.match(data, "^BDMA_MODE=([^\n]+)")
+  local art_enabled = string.match(data, "\nART_ENABLED=([^\n]+)") or string.match(data, "^ART_ENABLED=([^\n]+)")
   if profile ~= nil and PLDR.PROFILES ~= nil and PLDR.PROFILES[profile] ~= nil then
     PLDR.SELECTED_PROFILE = profile
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[profile].ELF
@@ -900,6 +924,7 @@ function PLDR.LoadSettingsNonFatal()
     PLDR.POPSTARTER_PATH = popstarter_path
   end
   PLDR.BDMA_MODE_KEY = NormalizeBdmaModeKey(bdma_mode) or PLDR.BDMA_MODE_KEY
+  PLDR.ART_ENABLED = ParseBoolish(art_enabled, PLDR.ART_ENABLED)
   PLDR.ReconcileBdmaModeWithEffectiveState()
   return true
 end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -54,34 +54,26 @@ local function ResolveFirstExistingElf(candidates)
   end
   return nil
 end
-local function ExtractGameRelPath(entry)
-  if entry == nil then return nil end
-  local relpath = string.match(entry, "^[^|]+|(.+)$")
-  return relpath or entry
-end
 local function StripExtension(path)
   if path == nil then return nil end
   local stripped = string.match(path, "(.+)%.[^%.]+$")
   return stripped or path
 end
-local function BuildCoverCandidates(entry, game_path)
-  -- TODO: verify cover art naming/layout. For now, assume sidecar image next to the VCD.
-  local relpath = ExtractGameRelPath(entry)
-  if relpath == nil or relpath == "" then return {} end
-  local fullpath = relpath
-  if type(JoinPath) == "function" then
-    fullpath = JoinPath(game_path or "", relpath)
-  elseif game_path ~= nil and game_path ~= "" then
-    if string.sub(game_path, -1) == "/" then
-      fullpath = game_path..relpath
-    else
-      fullpath = game_path.."/"..relpath
-    end
+local function ResolveSelectedVcdPath(entry)
+  if entry == nil or entry == "" then
+    return nil
   end
-  local base = StripExtension(fullpath)
-  return {
-    base..".png"
-  }
+  local root, rel = string.match(entry, "^([^|]+)|(.+)$")
+  if root ~= nil then
+    return root..rel
+  end
+  return tostring(PLDR.GAMEPATH or "")..entry
+end
+local function BuildCoverPathFromResolvedVcd(resolved_vcd_path)
+  if resolved_vcd_path == nil or resolved_vcd_path == "" then
+    return nil
+  end
+  return StripExtension(resolved_vcd_path)..".png"
 end
 local CoverCache = {
   max = 3,
@@ -114,7 +106,15 @@ function CoverCache:EvictIfNeeded()
       end
       self.entries[evict_key] = nil
     end
+    if self.last_key == evict_key then
+      self.last_key = nil
+      self.last_img = nil
+    end
   end
+end
+function CoverCache:ResetPreview()
+  self.last_key = nil
+  self.last_img = nil
 end
 function CoverCache:GetOrLoad(path)
   if path == nil or path == "" then return nil end
@@ -146,26 +146,21 @@ function CoverCache:GetOrLoad(path)
   self:EvictIfNeeded()
   return img
 end
-function CoverCache:UpdateSelection(entry, game_path)
-  local key = tostring(entry or "")
-  if game_path ~= nil then
-    key = key.."@"..tostring(game_path)
-  end
+function CoverCache:UpdateSelection(resolved_vcd_path)
+  local key = tostring(resolved_vcd_path or "")
   if self.last_key == key then
     return self.last_img
   end
   self.last_key = key
   self.last_img = nil
-  if entry == nil or entry == "" then
+  if resolved_vcd_path == nil or resolved_vcd_path == "" then
     return nil
   end
-  local candidates = BuildCoverCandidates(entry, game_path)
-  for i = 1, #candidates do
-    local img = self:GetOrLoad(candidates[i])
-    if img ~= nil then
-      self.last_img = img
-      return img
-    end
+  local cover_path = BuildCoverPathFromResolvedVcd(resolved_vcd_path)
+  local img = self:GetOrLoad(cover_path)
+  if img ~= nil then
+    self.last_img = img
+    return img
   end
   return nil
 end
@@ -1061,11 +1056,15 @@ UI = {
       CoverPending = false;
       CoverPendingAt = 0;
       CoverIdleMs = 200;
+      isArtEnabled = true;
       Reset = function ()
         UI.GameList.CURR = 1;
         UI.GameList.CoverLastIndex = nil
         UI.GameList.CoverPending = false
         UI.GameList.CoverPendingAt = 0
+        if UI.CoverCache ~= nil and UI.CoverCache.ResetPreview ~= nil then
+          UI.CoverCache:ResetPreview()
+        end
       end;
       Play = function()
         local layout = UI.LAYOUT
@@ -1130,8 +1129,18 @@ UI = {
           cover_img = UI.CoverCache.last_img
         end
         if layout.PREVIEW_W > 0 then
-          Graphics.drawRect(layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4, UI.CCOL.GREY)
-          local preview_img = cover_img
+          local frame_img = IMG["frame"]
+          if frame_img ~= nil then
+            Graphics.drawScaleImage(frame_img, layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4)
+          else
+            Graphics.drawRect(layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4, UI.CCOL.GREY)
+          end
+          local preview_img = nil
+          if UI.GameList.isArtEnabled then
+            preview_img = cover_img or IMG["default"] or IMG["MISSING"]
+          else
+            preview_img = IMG["disable_art"] or IMG["MISSING"]
+          end
           if preview_img ~= nil then
             Graphics.drawScaleImage(preview_img, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
           end
@@ -1148,6 +1157,13 @@ UI = {
         if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
         if UI.Pad.Events.NAV_UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
         if UI.Pad.Events.NAV_LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
+        if UI.Pad.Events.SQUARE then
+          UI.GameList.isArtEnabled = not UI.GameList.isArtEnabled
+          UI.GameList.CoverPending = false
+          if UI.CoverCache ~= nil and UI.CoverCache.ResetPreview ~= nil then
+            UI.CoverCache:ResetPreview()
+          end
+        end
         if UI.CoverCache ~= nil then
           local now = 0
           if UI.Pad.Timer ~= nil then
@@ -1158,21 +1174,20 @@ UI = {
             UI.GameList.CoverLastIndex = nil
             UI.GameList.CoverPending = false
             UI.GameList.CoverPendingAt = now
-            UI.CoverCache:UpdateSelection(nil, PLDR.GAMEPATH)
+            UI.CoverCache:ResetPreview()
           else
             if UI.GameList.CURR ~= UI.GameList.CoverLastIndex then
               UI.GameList.CoverLastIndex = UI.GameList.CURR
               UI.GameList.CoverPending = true
               UI.GameList.CoverPendingAt = now
+              UI.CoverCache:ResetPreview()
             end
-            if UI.GameList.CoverPending and not nav_event and (now - UI.GameList.CoverPendingAt) >= UI.GameList.CoverIdleMs then
+            if (not UI.GameList.isArtEnabled) then
+              UI.GameList.CoverPending = false
+            elseif UI.GameList.CoverPending and not nav_event and (now - UI.GameList.CoverPendingAt) >= UI.GameList.CoverIdleMs then
               local entry = PLDR.GAMES[UI.GameList.CURR]
-              local cover_path = PLDR.GAMEPATH
-              local root = string.match(entry or "", "^([^|]+)|.+$")
-              if root ~= nil then
-                cover_path = root
-              end
-              UI.CoverCache:UpdateSelection(entry, cover_path)
+              local resolved_vcd_path = ResolveSelectedVcdPath(entry)
+              UI.CoverCache:UpdateSelection(resolved_vcd_path)
               UI.GameList.CoverPending = false
             end
           end
@@ -1327,6 +1342,7 @@ UI = {
           PLDR.SELECTED_PROFILE = UI.ProfileQuery.curopt
           PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
           PLDR.BDMA_MODE_KEY = UI.BdmaModes[UI.BdmaModeIndex].key
+          PLDR.ART_ENABLED = UI.GameList.isArtEnabled == true
           UI.SavingActive = true
           local save_token = nil
           if type(PLDR.NextBdmaApplyToken) == "function" then
@@ -1942,6 +1958,14 @@ function UI.SyncSettingsSelectionFromRuntime()
   end
   local selected_profile = tonumber(PLDR.SELECTED_PROFILE) or tonumber(PLDR.DEFAULT_PROFILE) or 1
   UI.ProfileQuery.curopt = CLAMP(selected_profile, 1, #PLDR.PROFILES)
+  UI.SyncArtToggleFromRuntime()
+end
+function UI.SyncArtToggleFromRuntime()
+  local enabled = PLDR.ART_ENABLED
+  if enabled == nil then
+    enabled = true
+  end
+  UI.GameList.isArtEnabled = enabled == true
 end
 UI.SyncSettingsSelectionFromRuntime()
 function Input_GetEvent()


### PR DESCRIPTION
### Motivation
- Provide a robust sidecar cover-art mechanism that always derives the external PNG from the already-resolved VCD launch path (the exact path the launcher uses) and avoid any device/back-end inference or directory scanning. 

### Description
- Derive the cover sidecar strictly from the resolved VCD path using `StripExtension(resolved_vcd_path) .. ".png"` via the new helper `ResolveSelectedVcdPath` and `BuildCoverPathFromResolvedVcd` in `bin/POPSLDR/ui.lua`, ensuring the same `root..rel` or `PLDR.GAMEPATH..entry` shape that the launcher uses for launching. 
- Replace multi-candidate scanning with a single-path load through the existing `CoverCache:GetOrLoad` and preserve delayed loading behavior by clearing preview state on selection changes and only attempting to load after the idle gate expires; added `CoverCache:ResetPreview` and improved eviction to clear `last_key`/`last_img`. (changes in `bin/POPSLDR/ui.lua`) 
- Add a runtime SQUARE toggle `UI.GameList.isArtEnabled` (default true) that flips on `UI.Pad.Events.SQUARE`; when disabled external loads are skipped and `IMG["disable_art"]` is shown, while enabled shows loaded cover or `IMG["default"]` (both falling back to `IMG["MISSING"]`). (changes in `bin/POPSLDR/ui.lua`) 
- Draw `IMG["frame"]` around the preview slot with a rectangle fallback if the frame image is missing. (changes in `bin/POPSLDR/ui.lua`) 
- Register the new image keys in `bin/POPSLDR/images.lua`: `{"default","default.png"}`, `{"disable_art","disable_art.png"}`, and `{"frame","frame.png"}`. 
- Persist the art toggle via `PLDR.ART_ENABLED` (default true) only during the existing Settings save pipeline: added encoding to `EncodeSettings`, tolerant parsing via `ParseBoolish`, boot-time load in `PLDR.LoadSettingsNonFatal`, and write-back when the user confirms/leaves Settings (same path that writes other settings). (changes in `bin/POPSLDR/system.lua` and `bin/POPSLDR/ui.lua`) 
- No changes were made to device enumeration, BDMA behavior, POPStarter launching, scene navigation, list building rules, ART-folder logic, or directory scanning. 

### Testing
- Ran `git diff --stat` and `git diff` to review changes; commit created with message "Add sidecar cover art derived from resolved VCD path" and files modified are `bin/POPSLDR/ui.lua`, `bin/POPSLDR/system.lua`, and `bin/POPSLDR/images.lua`. 
- Performed manual file inspections of the inserted logic and printed key regions to verify correct hook points for launch-path derivation, delay gating, toggle handling, image registration, and settings persistence. 
- Attempted Lua syntax checks (`lua -e ...` and `luac -p ...`) but runtime tools are not installed in this environment so bytecode/preflight parsing was not executed; functional validation is recommended on-device or in an environment with `lua`/`luac`. 

Notes: the PR is intentionally conservative — it uses the exact resolved selection format the launcher already uses to produce the cover path, avoids backend assumptions or scans, implements the SQUARE toggle and persistence only via the Settings save pipeline, and ensures loaded images are evicted/freed by the existing cache lifecycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa2b5226488321bf7af4ea6b4fb222)