### PR TITLE
Passive sidecar cover-art preview (single-path) with SQUARE toggle

### DIFF
--- a/bin/POPSLDR/images.lua
+++ b/bin/POPSLDR/images.lua
@@ -35,6 +35,9 @@ local IMG_REGISTRATIONS = {
   {"right", "right.png"},
   {"up",    "up.png"},
   {"down",  "down.png"},
+  {"default", "default.png"},
+  {"frame", "frame.png"},
+  {"MISSING", "MISSING.png"},
 }
 
 local IMG_SOURCES = {}

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -265,6 +265,7 @@ local pldr_defaults = {
   REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0;
   POPSTARTER_PATH = "mass:/POPS/POPSTARTER.ELF";--"mass:/POPS/POPSTARTER.ELF";
   CHECK_POPSTARTER_FILES = false;
+  ART_ENABLED = true;
   GAMEPATH = ".";
   GAMES = {};
   HDDCACHE = nil;
@@ -794,11 +795,26 @@ function PLDR.BdmaSourceCandidates(rel)
   return out
 end
 
+local function ParseBoolSetting(value, default_value)
+  if value == nil then
+    return default_value
+  end
+  local norm = string.lower(string.gsub(tostring(value), "^%s*(.-)%s*$", "%1"))
+  if norm == "1" or norm == "true" or norm == "on" or norm == "yes" then
+    return true
+  end
+  if norm == "0" or norm == "false" or norm == "off" or norm == "no" then
+    return false
+  end
+  return default_value
+end
+
 local function EncodeSettings()
   local lines = {
     "PROFILE="..tostring(tonumber(PLDR.SELECTED_PROFILE) or 1),
     "POPSTARTER_PATH="..tostring(PLDR.POPSTARTER_PATH or ""),
-    "BDMA="..tostring(PLDR.BDMA_MODE_KEY or "FAT32")
+    "BDMA="..tostring(PLDR.BDMA_MODE_KEY or "FAT32"),
+    "ART_ENABLED="..(PLDR.ART_ENABLED and "1" or "0")
   }
   return table.concat(lines, "\n").."\n"
 end
@@ -877,6 +893,7 @@ function PLDR.LoadSettingsNonFatal()
   PLDR.EnsurePopstarterDir()
   PLDR.SELECTED_PROFILE = defaults_profile
   PLDR.BDMA_MODE_KEY = "FAT32"
+  PLDR.ART_ENABLED = true
   if PLDR.PROFILES ~= nil and PLDR.PROFILES[defaults_profile] ~= nil then
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[defaults_profile].ELF
   end
@@ -892,6 +909,7 @@ function PLDR.LoadSettingsNonFatal()
   local profile = tonumber(string.match(data, "\nPROFILE=([^\n]+)")) or tonumber(string.match(data, "^PROFILE=([^\n]+)"))
   local popstarter_path = string.match(data, "\nPOPSTARTER_PATH=([^\n]*)") or string.match(data, "^POPSTARTER_PATH=([^\n]*)")
   local bdma_mode = string.match(data, "\nBDMA=([^\n]+)") or string.match(data, "^BDMA=([^\n]+)") or string.match(data, "\nBDMA_MODE=([^\n]+)") or string.match(data, "^BDMA_MODE=([^\n]+)")
+  local art_enabled = string.match(data, "\nART_ENABLED=([^\n]+)") or string.match(data, "^ART_ENABLED=([^\n]+)")
   if profile ~= nil and PLDR.PROFILES ~= nil and PLDR.PROFILES[profile] ~= nil then
     PLDR.SELECTED_PROFILE = profile
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[profile].ELF
@@ -900,6 +918,7 @@ function PLDR.LoadSettingsNonFatal()
     PLDR.POPSTARTER_PATH = popstarter_path
   end
   PLDR.BDMA_MODE_KEY = NormalizeBdmaModeKey(bdma_mode) or PLDR.BDMA_MODE_KEY
+  PLDR.ART_ENABLED = ParseBoolSetting(art_enabled, PLDR.ART_ENABLED)
   PLDR.ReconcileBdmaModeWithEffectiveState()
   return true
 end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -54,34 +54,23 @@ local function ResolveFirstExistingElf(candidates)
   end
   return nil
 end
-local function ExtractGameRelPath(entry)
-  if entry == nil then return nil end
-  local relpath = string.match(entry, "^[^|]+|(.+)$")
-  return relpath or entry
-end
 local function StripExtension(path)
   if path == nil then return nil end
   local stripped = string.match(path, "(.+)%.[^%.]+$")
   return stripped or path
 end
-local function BuildCoverCandidates(entry, game_path)
-  -- TODO: verify cover art naming/layout. For now, assume sidecar image next to the VCD.
-  local relpath = ExtractGameRelPath(entry)
-  if relpath == nil or relpath == "" then return {} end
-  local fullpath = relpath
-  if type(JoinPath) == "function" then
-    fullpath = JoinPath(game_path or "", relpath)
-  elseif game_path ~= nil and game_path ~= "" then
-    if string.sub(game_path, -1) == "/" then
-      fullpath = game_path..relpath
-    else
-      fullpath = game_path.."/"..relpath
-    end
+local function ResolveSelectedVcdPath(entry, game_path)
+  if entry == nil or entry == "" then return nil end
+  local root, rel = string.match(entry, "^([^|]+)|(.+)$")
+  if root ~= nil then
+    return root..rel
   end
-  local base = StripExtension(fullpath)
-  return {
-    base..".png"
-  }
+  return tostring(game_path or "")..tostring(entry)
+end
+local function BuildSidecarCoverPath(entry, game_path)
+  local vcd_path = ResolveSelectedVcdPath(entry, game_path)
+  if vcd_path == nil or vcd_path == "" then return nil end
+  return StripExtension(vcd_path)..".png"
 end
 local CoverCache = {
   max = 3,
@@ -159,13 +148,11 @@ function CoverCache:UpdateSelection(entry, game_path)
   if entry == nil or entry == "" then
     return nil
   end
-  local candidates = BuildCoverCandidates(entry, game_path)
-  for i = 1, #candidates do
-    local img = self:GetOrLoad(candidates[i])
-    if img ~= nil then
-      self.last_img = img
-      return img
-    end
+  local cover_path = BuildSidecarCoverPath(entry, game_path)
+  local img = self:GetOrLoad(cover_path)
+  if img ~= nil then
+    self.last_img = img
+    return img
   end
   return nil
 end
@@ -1061,6 +1048,7 @@ UI = {
       CoverPending = false;
       CoverPendingAt = 0;
       CoverIdleMs = 200;
+      isArtEnabled = true;
       Reset = function ()
         UI.GameList.CURR = 1;
         UI.GameList.CoverLastIndex = nil
@@ -1125,15 +1113,26 @@ UI = {
 	          local c = (i == UI.GameList.CURR) and UI.COLORS.LIST_SELECTED or UI.COLORS.LIST_UNSELECTED
 	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, string.sub(display_name,1, -5), c)
         end
-        local cover_img = nil
-        if UI.CoverCache ~= nil then
-          cover_img = UI.CoverCache.last_img
-        end
         if layout.PREVIEW_W > 0 then
-          Graphics.drawRect(layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4, UI.CCOL.GREY)
-          local preview_img = cover_img
-          if preview_img ~= nil then
-            Graphics.drawScaleImage(preview_img, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
+          local preview_underlay = nil
+          if UI.GameList.isArtEnabled then
+            if UI.CoverCache ~= nil then
+              preview_underlay = UI.CoverCache.last_img
+            end
+            if preview_underlay == nil then
+              preview_underlay = IMG["MISSING"]
+            end
+          else
+            preview_underlay = IMG["default"]
+          end
+          if preview_underlay ~= nil then
+            Graphics.drawScaleImage(preview_underlay, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
+          end
+          local frame_img = IMG["frame"]
+          if frame_img ~= nil then
+            Graphics.drawScaleImage(frame_img, layout.PREVIEW_X, layout.PREVIEW_Y, layout.PREVIEW_W, layout.PREVIEW_H)
+          else
+            Graphics.drawRect(layout.PREVIEW_X - 2, layout.PREVIEW_Y - 2, layout.PREVIEW_W + 4, layout.PREVIEW_H + 4, UI.CCOL.GREY)
           end
         end
         if ammount <= 0 then
@@ -1148,13 +1147,28 @@ UI = {
         if UI.Pad.Events.NAV_RIGHT then UI.GameList.CURR = CLAMP(UI.GameList.CURR+UI.GameList.MAXDRAW, 1, ammount) end
         if UI.Pad.Events.NAV_UP then UI.GameList.CURR = CLAMP(UI.GameList.CURR-1, 1, ammount) end
         if UI.Pad.Events.NAV_LEFT then UI.GameList.CURR = CLAMP(UI.GameList.CURR-UI.GameList.MAXDRAW, 1, ammount) end
+        if UI.Pad.Events.SQUARE then
+          UI.GameList.isArtEnabled = not UI.GameList.isArtEnabled
+          PLDR.ART_ENABLED = UI.GameList.isArtEnabled
+          UI.GameList.CoverPending = false
+          UI.GameList.CoverPendingAt = 0
+          if UI.CoverCache ~= nil then
+            UI.CoverCache:UpdateSelection(nil, PLDR.GAMEPATH)
+          end
+          if UI.GameList.isArtEnabled and ammount > 0 then
+            UI.GameList.CoverPending = true
+            if UI.Pad.Timer ~= nil then
+              UI.GameList.CoverPendingAt = Timer.getTime(UI.Pad.Timer)
+            end
+          end
+        end
         if UI.CoverCache ~= nil then
           local now = 0
           if UI.Pad.Timer ~= nil then
             now = Timer.getTime(UI.Pad.Timer)
           end
           local nav_event = UI.Pad.Events.NAV_DOWN or UI.Pad.Events.NAV_RIGHT or UI.Pad.Events.NAV_UP or UI.Pad.Events.NAV_LEFT
-          if ammount <= 0 then
+          if (not UI.GameList.isArtEnabled) or ammount <= 0 then
             UI.GameList.CoverLastIndex = nil
             UI.GameList.CoverPending = false
             UI.GameList.CoverPendingAt = now
@@ -1164,15 +1178,11 @@ UI = {
               UI.GameList.CoverLastIndex = UI.GameList.CURR
               UI.GameList.CoverPending = true
               UI.GameList.CoverPendingAt = now
+              UI.CoverCache:UpdateSelection(nil, PLDR.GAMEPATH)
             end
             if UI.GameList.CoverPending and not nav_event and (now - UI.GameList.CoverPendingAt) >= UI.GameList.CoverIdleMs then
               local entry = PLDR.GAMES[UI.GameList.CURR]
-              local cover_path = PLDR.GAMEPATH
-              local root = string.match(entry or "", "^([^|]+)|.+$")
-              if root ~= nil then
-                cover_path = root
-              end
-              UI.CoverCache:UpdateSelection(entry, cover_path)
+              UI.CoverCache:UpdateSelection(entry, PLDR.GAMEPATH)
               UI.GameList.CoverPending = false
             end
           end
@@ -1327,6 +1337,7 @@ UI = {
           PLDR.SELECTED_PROFILE = UI.ProfileQuery.curopt
           PLDR.POPSTARTER_PATH = PLDR.PROFILES[UI.ProfileQuery.curopt].ELF
           PLDR.BDMA_MODE_KEY = UI.BdmaModes[UI.BdmaModeIndex].key
+          PLDR.ART_ENABLED = UI.GameList.isArtEnabled
           UI.SavingActive = true
           local save_token = nil
           if type(PLDR.NextBdmaApplyToken) == "function" then
@@ -1704,6 +1715,7 @@ UI = {
         BACK = false,
         EXIT = false,
         START = false,
+        SQUARE = false,
         SELECT = false,
         R2 = false,
         ANY = false,
@@ -1740,6 +1752,7 @@ UI = {
         UI.Pad.Events.BACK = false
         UI.Pad.Events.EXIT = false
         UI.Pad.Events.START = false
+        UI.Pad.Events.SQUARE = false
         UI.Pad.Events.SELECT = false
         UI.Pad.Events.R2 = false
         UI.Pad.Events.ANY = false
@@ -1767,6 +1780,7 @@ UI = {
         if (pressed & PAD_CIRCLE) ~= 0 then emit_action("BACK") end
         if (pressed & PAD_TRIANGLE) ~= 0 then emit_action("EXIT") end
         if (pressed & PAD_START) ~= 0 then emit("START") end
+        if (pressed & PAD_SQUARE) ~= 0 then emit_action("SQUARE") end
         if (pressed & PAD_SELECT) ~= 0 then emit("SELECT") end
         if (pressed & PAD_R2) ~= 0 then emit_action("R2") end
 
@@ -1942,6 +1956,7 @@ function UI.SyncSettingsSelectionFromRuntime()
   end
   local selected_profile = tonumber(PLDR.SELECTED_PROFILE) or tonumber(PLDR.DEFAULT_PROFILE) or 1
   UI.ProfileQuery.curopt = CLAMP(selected_profile, 1, #PLDR.PROFILES)
+  UI.GameList.isArtEnabled = not not PLDR.ART_ENABLED
 end
 UI.SyncSettingsSelectionFromRuntime()
 function Input_GetEvent()


### PR DESCRIPTION
### Motivation
- Provide a very small, passive cover-art preview that follows the already-resolved selected game VCD path and does not change device/back-end logic. 
- Keep behavior minimal: derive exactly one sidecar path from the selected-entry semantics and render it behind a persistent frame.

### Description
- Implemented single sidecar derivation `resolved_vcd_path -> StripExtension(resolved_vcd_path) .. ".png"` and replaced the multi-candidate lookup with `BuildSidecarCoverPath` and `ResolveSelectedVcdPath` in `bin/POPSLDR/ui.lua`.
- Updated preview rendering in `bin/POPSLDR/ui.lua` so Layer 1 underlay is `IMG["default"]` when art is OFF, or the sidecar image when art is ON with `IMG["MISSING"]` fallback when missing, and Layer 2 always draws `IMG["frame"]` with the existing rectangle fallback when the frame image is unavailable.
- Preserved the lightweight delayed-load/cache behavior and explicit clearing on selection change via the existing `CoverCache` logic and idle delay; only one load attempt is made per settled selection.
- Added runtime toggle `UI.GameList.isArtEnabled` (default true) controlled by the SQUARE button while browsing; toggling OFF clears pending/current external preview and skips external loads, and toggling ON resumes delayed sidecar loads.
- Added persisted runtime setting `PLDR.ART_ENABLED` (default true) in `bin/POPSLDR/system.lua`, saved/loaded through the existing `EncodeSettings`/`LoadSettingsNonFatal` flow with a new permissive `ParseBoolSetting` helper accepting `1/0`, `true/false`, `on/off`, `yes/no`; syncing to `UI.GameList.isArtEnabled` on boot; no call to `SaveSettingsAtomic()` is performed on SQUARE press (persistence happens later via normal Settings save flow).
- Registered required images in `bin/POPSLDR/images.lua` if absent: `{"default","default.png"}`, `{"frame","frame.png"}`, and `{"MISSING","MISSING.png"}`.
- No changes were made to device enumeration, backend inference, game-list generation, page-entry logic, or game launching paths; no directory scanning or candidate lists were added.

### Testing
- Ran repository checks to confirm the three files were updated and the diffstat reflected the intended narrow changes (files inspected: `bin/POPSLDR/ui.lua`, `bin/POPSLDR/system.lua`, `bin/POPSLDR/images.lua`).
- Verified runtime wiring by inspecting the code paths for SQUARE handling, cover derivation, preview layering, and settings encode/load logic, confirming `PLDR.ART_ENABLED` is written only via `EncodeSettings` and not on SQUARE press.
- Attempted a Lua syntax check with `luac -p` but the `luac` binary is not available in this environment, so a compile-time syntax check was not run; no automated unit tests exist for this UI shim so behavioral validation is via code inspection above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa61ef53b08321bb7fd4c481d03b42)