### PR TITLE
Make C exec-time PFS unmount a no-op and update D-10 status docs

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -54,10 +54,17 @@ Each entry records:
 - Implications: docs and workflow validation must stay synchronized.
 - Evidence: `.github/workflows/compilation.yml`.
 
+### 2026-03-27 — C-side PFS unmount is superseded by Lua multi-slot keep policy
+- Decision: `unmount_pfs_slots_for_exec()` in `src/elf_loader/src/elf.c` is intentionally a no-op.
+- Rationale: Lua launch preparation owns selective keep/unmount behavior and can preserve multiple required slots for HDD-backed POPSTARTER launches.
+- Implications: avoid C-side post-processing that can conflict with Lua-managed HDD slot preservation during external ELF handoff.
+- Evidence: `src/elf_loader/src/elf.c`, `bin/POPSLDR/system.lua`.
+
 ## Open Investigations
 - HDD `POPSTARTER.ELF` when launcher/sidecar/CWD is on HDD:
-  - current reported hardware result is still a black-screen hang.
-  - current code contains path/mount/CWD mitigations, but no final verified fix.
+  - previously reported hardware result was a black-screen hang.
+  - source now includes a C-side unmount no-op to avoid conflict with Lua multi-slot keep behavior.
+  - current status is `Unknown (verify on hardware)` on latest source.
 - `BOOT.ELF` after HDD page init:
   - the last failed backend experiment was reverted in source,
   - current hardware status on that restored source is still `Unknown (verify on hardware)`.

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -94,6 +94,6 @@ This matrix tracks current behavior across:
 - CI gates: repository-verified by workflow definition.
 - Reported hardware outcomes:
   - `U-05`: reported PASS.
-  - `D-10`: reported FAIL when booted from HDD and launching an HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
+  - `D-10`: previously reported FAIL when booted from HDD and launching an HDD title with HDD `POPSTARTER.ELF` sidecar/CWD; latest source includes C-side unmount no-op and requires re-test.
   - `U-10`: one artifact was reported good before a later regression experiment; current source has been restored away from that experiment and must be re-tested.
 - All other manual hardware items remain `Unknown (verify on hardware)` unless run logs are added above.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ The workflow uses the `ps2dev/ps2dev` container and validates packaging after bu
 - `U-05` OSDSYS exit:
   - reported fixed.
 - `D-10` HDD POPSTARTER on HDD:
-  - reported failing.
+  - previously reported failing.
+  - C-side unmount conflict has been resolved in source (see `DECISIONS.md`).
+  - hardware re-test is still required.
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later failed experiment regressed it,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,12 +10,11 @@ Last updated: 2026-03-26
 ## Immediate Priorities
 
 ### 1) HDD POPSTARTER on HDD
-- Reproduce and resolve `D-10`:
+- Re-test `D-10` on hardware after C-side unmount no-op change:
   - POPSLoader booted from HDD,
   - HDD game launched from HDD (PFS),
-  - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path,
-  - current reported result: black-screen hang.
-- Keep `BOOT.ELF` and OSDSYS behavior stable while iterating on this.
+  - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path.
+- Confirm no black-screen and keep `BOOT.ELF`/OSDSYS behavior stable.
 
 ### 2) External exit/launch re-validation
 - Re-run `U-05` (`OSDSYS`) and `U-10` (`BOOT.ELF after HDD page init`) on current source after the last reverted launch-backend experiment.

--- a/STATE.md
+++ b/STATE.md
@@ -48,9 +48,9 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - `U-05` OSDSYS exit:
   - reported fixed on hardware.
 - `D-10` HDD POPSTARTER on HDD:
-  - reported failing on hardware.
-  - repro: boot from HDD, launch HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
-  - result: black-screen hang.
+  - previously reported failing on hardware.
+  - source now includes a C-side unmount no-op to avoid conflicting with Lua multi-slot keep logic.
+  - current status: `Unknown (verify on hardware)` on latest source.
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later launch-backend experiment regressed it,
@@ -61,7 +61,7 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - hardware result is still `Unknown (verify on hardware)`.
 
 ## Known Open Work
-- Resolve HDD `POPSTARTER.ELF` handoff when POPSTARTER itself is on HDD.
+- Re-verify HDD `POPSTARTER.ELF` handoff when POPSTARTER itself is on HDD (D-10) on latest source.
 - Re-verify `BOOT.ELF` after HDD page init on current source.
 - Record concrete run logs in `QA_REGRESSION_MATRIX.md`.
 - Implement HDD exFAT menu flow.

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -119,15 +119,15 @@ static int extract_exec_pfs_slot(const char *path) {
 }
 
 static void unmount_pfs_slots_for_exec(unsigned int keep_mask) {
-	(void)keep_mask;
-	/* NO-OP: superseded by Lua-side PrepareForExternalELFLaunch +
-	 * CollectHddKeepSlots/PreserveBootPfsSlotsDuringElfLoad.
-	 *
-	 * Lua now owns context-aware selective unmount behavior, including
-	 * preserving both HDD_SLOT_POPSTARTER and HDD_SLOT_GAME when required.
-	 * Running an additional C-side unmount pass here can invalidate that
-	 * multi-slot state for HDD POPSTARTER launches.
-	 */
+	char mount_name[6] = "pfs0:";
+	int slot;
+	for (slot = 0; slot <= 3; slot++) {
+		if ((keep_mask & (1U << slot)) != 0) {
+			continue;
+		}
+		mount_name[3] = '0' + slot;
+		fileXioUmount(mount_name);
+	}
 }
 
 static unsigned int build_exec_keep_mask(const char *resolved_path) {
@@ -291,6 +291,9 @@ int LoadELFFromFileWithPartition(const char *filename, int argc, char *argv[]) {
 	DPRINTF("LAUNCH: argv0_final=%s\n", launch_argv[0] ? launch_argv[0] : "(null)");
 	DPRINTF("LAUNCH: argv1=%s\n", launch_argv[1] ? launch_argv[1] : "(null)");
 	DPRINTF("LAUNCH: argv2_is_null=%s\n", launch_argv[2] == NULL ? "yes" : "no");
+	if (is_hdd_backed_exec_path(resolved_path)) {
+		unmount_pfs_slots_for_exec(build_exec_keep_mask(resolved_path));
+	}
 	/* LoadExecPS2 should not return on success. */
 	LoadExecPS2(resolved_path, new_argc, launch_argv);
 	DPRINTF("LAUNCH: RETURNED rc=%d\n", -1);

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -119,15 +119,15 @@ static int extract_exec_pfs_slot(const char *path) {
 }
 
 static void unmount_pfs_slots_for_exec(unsigned int keep_mask) {
-	char mount_name[6] = "pfs0:";
-	int slot;
-	for (slot = 0; slot <= 3; slot++) {
-		if ((keep_mask & (1U << slot)) != 0) {
-			continue;
-		}
-		mount_name[3] = '0' + slot;
-		fileXioUmount(mount_name);
-	}
+	(void)keep_mask;
+	/* NO-OP: superseded by Lua-side PrepareForExternalELFLaunch +
+	 * CollectHddKeepSlots/PreserveBootPfsSlotsDuringElfLoad.
+	 *
+	 * Lua now owns context-aware selective unmount behavior, including
+	 * preserving both HDD_SLOT_POPSTARTER and HDD_SLOT_GAME when required.
+	 * Running an additional C-side unmount pass here can invalidate that
+	 * multi-slot state for HDD POPSTARTER launches.
+	 */
 }
 
 static unsigned int build_exec_keep_mask(const char *resolved_path) {


### PR DESCRIPTION
### Motivation
- The C-side `unmount_pfs_slots_for_exec` performed a legacy single-keep unmount that could undo Lua's multi-slot keep state and cause the D-10 HDD POPSTARTER black-screen; the fix is to stop the redundant C-side unmount and let Lua remain authoritative. 
- Keep the change minimal and reversible to avoid touching Lua launch prep, boot paths, or device-lock policies while addressing the reported failure mode.

### Description
- Changed `unmount_pfs_slots_for_exec()` in `src/elf_loader/src/elf.c` to a no-op and added an explanatory comment documenting that Lua `PrepareForExternalELFLaunch` / `CollectHddKeepSlots` is the source of truth for selective PFS slot preservation. 
- Updated status and guidance docs to reflect the source change and pending hardware verification by editing `README.md`, `STATE.md`, `ROADMAP.md`, `DECISIONS.md`, and `QA_REGRESSION_MATRIX.md`. 
- Documented the decision rationale in `DECISIONS.md` and marked `D-10` as requiring a hardware re-test rather than claiming a hardware fix. 
- No runtime Lua changes were made and no other runtime behavior paths were modified.

### Testing
- Attempted local build with `make elfloader`, which failed in this environment due to a missing PS2SDK include (`/samples/Makefile.eeglobal`), so the full ELF build could not be validated locally. (failure)
- Basic repository-level checks were run (`rg`/file inspections) to verify the source edit and doc updates were applied; these are repository text checks and succeeded. (success)
- CI/package validation is expected to run `make clean elfloader all` and will verify packaging in the normal workflow; hardware re-test of `D-10` is required and listed in the updated `QA_REGRESSION_MATRIX.md` as pending. (pending)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c620d64158832181b3a2b3e15f680b)