### PR TITLE
HDD: pass absolute mounted POPSTARTER selector and stop forcing HDD launch CWD (D-10 mitigation)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-26
+Last updated: 2026-03-27
 
 # DECISIONS
 
@@ -54,10 +54,16 @@ Each entry records:
 - Implications: docs and workflow validation must stay synchronized.
 - Evidence: `.github/workflows/compilation.yml`.
 
+### 2026-03-27 — HDD selector/CWD mitigation staged for `D-10` investigation
+- Decision: for HDD game launches, when HDD mount prep succeeds, pass selector/bootparam as absolute mounted `pfsN:/<title>.ELF` and stop forcing launch CWD to the mounted game partition root.
+- Rationale: current remaining failure (`D-10`) is a black-screen when POPSTARTER itself is on HDD, and repo flow still mixed a relative selector with HDD-root CWD forcing.
+- Implications: this is a narrow mitigation under test, not a validated hardware fix; `U-05` and `U-10` must be re-checked alongside `D-10`.
+- Evidence: `bin/POPSLDR/system.lua` (`PLDR.RunPOPStarterGame`, HDD branch and launch context assembly).
+
 ## Open Investigations
 - HDD `POPSTARTER.ELF` when launcher/sidecar/CWD is on HDD:
   - current reported hardware result is still a black-screen hang.
-  - current code contains path/mount/CWD mitigations, but no final verified fix.
+  - source now includes absolute-selector plus CWD fallback mitigation, but no final verified hardware fix yet.
 - `BOOT.ELF` after HDD page init:
   - the last failed backend experiment was reverted in source,
   - current hardware status on that restored source is still `Unknown (verify on hardware)`.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -57,13 +57,20 @@ Each entry records:
 ### 2026-03-27 — HDD selector/CWD mitigation staged for `D-10` investigation
 - Decision: for HDD game launches, when HDD mount prep succeeds, pass selector/bootparam as absolute mounted `pfsN:/<title>.ELF` and stop forcing launch CWD to the mounted game partition root.
 - Rationale: current remaining failure (`D-10`) is a black-screen when POPSTARTER itself is on HDD, and repo flow still mixed a relative selector with HDD-root CWD forcing.
-- Implications: this is a narrow mitigation under test, not a validated hardware fix; `U-05` and `U-10` must be re-checked alongside `D-10`.
+- Implications: this was a narrow mitigation under test and is now known insufficient by follow-up hardware report; `U-05` and `U-10` still must be re-checked alongside `D-10`.
 - Evidence: `bin/POPSLDR/system.lua` (`PLDR.RunPOPStarterGame`, HDD branch and launch context assembly).
+
+### 2026-03-27 — Preserve POPSTARTER executable PFS slot during HDD exec handoff
+- Decision: resolve the POPSTARTER exec path to a mounted PFS path when possible and explicitly preserve its PFS slot alongside the HDD game slot during launch prep.
+- Rationale: follow-up hardware result kept black-screening after selector/CWD adjustment, pointing to slot-loss risk across launch unmount/keep-mask prep.
+- Implications: this is another mitigation under test, not a validated fix; preserve only required slot union (game slot + exec slot + existing boot-preservation behavior), not all slots.
+- Evidence: `bin/POPSLDR/system.lua` (`ResolveExecPathAndKeepSlot`, `RunPOPStarterGame`, `PrepareForExternalELFLaunch`), `src/elf_loader/src/elf.c` (`build_exec_keep_mask`).
 
 ## Open Investigations
 - HDD `POPSTARTER.ELF` when launcher/sidecar/CWD is on HDD:
   - current reported hardware result is still a black-screen hang.
-  - source now includes absolute-selector plus CWD fallback mitigation, but no final verified hardware fix yet.
+  - selector/CWD mitigation alone was insufficient on hardware.
+  - source now includes absolute-selector + CWD fallback + exec-slot preservation mitigations, but no final verified hardware fix yet.
 - `BOOT.ELF` after HDD page init:
   - the last failed backend experiment was reverted in source,
   - current hardware status on that restored source is still `Unknown (verify on hardware)`.

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -1,7 +1,7 @@
 # POPSLoader Regression Matrix
 
-Last updated: 2026-03-26
-Target branch: `BETA-10-play`
+Last updated: 2026-03-27
+Target branch: `work`
 
 ## Scope
 This matrix tracks current behavior across:
@@ -95,5 +95,8 @@ This matrix tracks current behavior across:
 - Reported hardware outcomes:
   - `U-05`: reported PASS.
   - `D-10`: reported FAIL when booted from HDD and launching an HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
-  - `U-10`: one artifact was reported good before a later regression experiment; current source has been restored away from that experiment and must be re-tested.
+  - `U-10`: one artifact was reported good before a later regression experiment; current source has been restored away from that experiment, includes an HDD selector/CWD mitigation under test, and must be re-tested.
+- Repo-verified `D-10` mitigation now in source (hardware unverified):
+  - HDD launch rewrites selector/bootparam to absolute mounted `pfsN:/<title>.ELF` when mount prep succeeds.
+  - HDD launch context no longer forces launch CWD to HDD game mount root (launch CWD now falls back to POPSTARTER path directory behavior).
 - All other manual hardware items remain `Unknown (verify on hardware)` unless run logs are added above.

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -95,8 +95,10 @@ This matrix tracks current behavior across:
 - Reported hardware outcomes:
   - `U-05`: reported PASS.
   - `D-10`: reported FAIL when booted from HDD and launching an HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
-  - `U-10`: one artifact was reported good before a later regression experiment; current source has been restored away from that experiment, includes an HDD selector/CWD mitigation under test, and must be re-tested.
-- Repo-verified `D-10` mitigation now in source (hardware unverified):
+  - `D-10` follow-up: selector/CWD mitigation attempt still black-screened when booted from HDD and launching HDD with POPSTARTER on HDD.
+  - `U-10`: one artifact was reported good before a later regression experiment; current source has been restored away from that experiment, now includes selector/CWD + exec-slot preservation mitigations under test, and must be re-tested.
+- Repo-verified `D-10` mitigations now in source (hardware unverified):
   - HDD launch rewrites selector/bootparam to absolute mounted `pfsN:/<title>.ELF` when mount prep succeeds.
   - HDD launch context no longer forces launch CWD to HDD game mount root (launch CWD now falls back to POPSTARTER path directory behavior).
+  - HDD launch now resolves/preserves POPSTARTER executable PFS slot and preserves the union of game-slot + exec-slot during launch keep-mask/unmount prep.
 - All other manual hardware items remain `Unknown (verify on hardware)` unless run logs are added above.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPSLoader
 
-Last updated: 2026-03-26
+Last updated: 2026-03-27
 
 POPSLoader is a PlayStation 2 launcher for POPStarter, built on Enceladus runtime components and driven primarily by embedded Lua scripts.
 
@@ -40,7 +40,7 @@ That package contract is enforced by `.github/workflows/compilation.yml`.
 | MMCE menu path | Implemented in code | Unknown (verify on hardware) |
 | MX4SIO menu path | Implemented in code | Unknown (verify on hardware) |
 | USB menu path | Implemented in code | Unknown (verify on hardware) |
-| HDD (PFS) menu path | Implemented in code | Mixed; HDD POPSTARTER-on-HDD handoff still failing |
+| HDD (PFS) menu path | Implemented in code; HDD selector/CWD mitigation now staged in source | Mixed; `D-10` still reported FAIL pending re-test of current source |
 | Disc (`DKWDRV`) menu path | Implemented in code | Unknown (verify on hardware) |
 | Exit to OSDSYS | Implemented in code | Reported PASS |
 | Exit to `BOOT.ELF` | Implemented in code | Current source needs re-test after last reverted regression |
@@ -56,6 +56,10 @@ The main unresolved hardware issue is:
     - launch an HDD title,
     - POPSTARTER also resolves from HDD sidecar/CWD or configured HDD path,
     - result: black-screen hang.
+  - current source mitigation under test:
+    - HDD launch now passes an absolute mounted selector (`pfsN:/<title>.ELF`) when HDD mount prep succeeds,
+    - HDD launch no longer forces launch CWD to the game partition mount prefix,
+    - launch CWD falls back to the resolved `POPSTARTER.ELF` directory.
 
 ## Runtime Behavior (Current Code)
 
@@ -182,7 +186,7 @@ The workflow uses the `ps2dev/ps2dev` container and validates packaging after bu
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later failed experiment regressed it,
-  - current source has been restored away from that experiment,
+  - current source has been restored away from that experiment and now includes the HDD selector/CWD mitigation under test,
   - current hardware status still needs re-test.
 
 ## Documentation Map

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That package contract is enforced by `.github/workflows/compilation.yml`.
 | MMCE menu path | Implemented in code | Unknown (verify on hardware) |
 | MX4SIO menu path | Implemented in code | Unknown (verify on hardware) |
 | USB menu path | Implemented in code | Unknown (verify on hardware) |
-| HDD (PFS) menu path | Implemented in code; HDD selector/CWD mitigation now staged in source | Mixed; `D-10` still reported FAIL pending re-test of current source |
+| HDD (PFS) menu path | Implemented in code; selector/CWD mitigation was insufficient and executable-slot preservation mitigation is now staged in source | Mixed; `D-10` still reported FAIL pending re-test of current source |
 | Disc (`DKWDRV`) menu path | Implemented in code | Unknown (verify on hardware) |
 | Exit to OSDSYS | Implemented in code | Reported PASS |
 | Exit to `BOOT.ELF` | Implemented in code | Current source needs re-test after last reverted regression |
@@ -56,10 +56,12 @@ The main unresolved hardware issue is:
     - launch an HDD title,
     - POPSTARTER also resolves from HDD sidecar/CWD or configured HDD path,
     - result: black-screen hang.
+  - latest reported hardware result on prior mitigation:
+    - selector/CWD mitigation did not resolve the black-screen hang.
   - current source mitigation under test:
-    - HDD launch now passes an absolute mounted selector (`pfsN:/<title>.ELF`) when HDD mount prep succeeds,
-    - HDD launch no longer forces launch CWD to the game partition mount prefix,
-    - launch CWD falls back to the resolved `POPSTARTER.ELF` directory.
+    - previous selector/CWD adjustment remains in source,
+    - HDD launch now also resolves and preserves the PFS slot backing `POPSTARTER.ELF` for exec-slot keep-mask behavior,
+    - preserved slots are now the union of HDD game mount slot plus POPSTARTER executable slot when detected.
 
 ## Runtime Behavior (Current Code)
 
@@ -186,7 +188,7 @@ The workflow uses the `ps2dev/ps2dev` container and validates packaging after bu
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later failed experiment regressed it,
-  - current source has been restored away from that experiment and now includes the HDD selector/CWD mitigation under test,
+  - current source has been restored away from that experiment and now includes HDD selector/CWD plus executable-slot preservation mitigations under test,
   - current hardware status still needs re-test.
 
 ## Documentation Map

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,20 @@
-Last updated: 2026-03-26
+Last updated: 2026-03-27
 
 # ROADMAP
 
 ## Status Snapshot
 - Core launcher functionality is present in code for MMCE, MX4SIO, HDD (PFS), USB, Disc (`DKWDRV`), settings persistence, cover preview, path editing, startup backend auto-init, and exit flows.
-- The main stabilization blocker is still HDD `POPSTARTER.ELF` when the launcher and/or sidecar/CWD are on HDD. Reported hardware result is still a black-screen hang.
+- The main stabilization blocker is still HDD `POPSTARTER.ELF` when the launcher and/or sidecar/CWD are on HDD. Current source now has an HDD selector/CWD mitigation under test, but reported hardware result is still a black-screen hang pending re-test.
 - `HDD (exFAT)` and `SMB (v1)` remain intentionally unimplemented menu entries.
 
 ## Immediate Priorities
 
 ### 1) HDD POPSTARTER on HDD
-- Reproduce and resolve `D-10`:
+- Re-test `D-10` on current source with the new mitigation:
   - POPSLoader booted from HDD,
   - HDD game launched from HDD (PFS),
   - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path,
-  - current reported result: black-screen hang.
+  - current source behavior to validate: absolute mounted selector (`pfsN:/<title>.ELF`) plus POPSTARTER-directory CWD fallback.
 - Keep `BOOT.ELF` and OSDSYS behavior stable while iterating on this.
 
 ### 2) External exit/launch re-validation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Last updated: 2026-03-27
 
 ## Status Snapshot
 - Core launcher functionality is present in code for MMCE, MX4SIO, HDD (PFS), USB, Disc (`DKWDRV`), settings persistence, cover preview, path editing, startup backend auto-init, and exit flows.
-- The main stabilization blocker is still HDD `POPSTARTER.ELF` when the launcher and/or sidecar/CWD are on HDD. Current source now has an HDD selector/CWD mitigation under test, but reported hardware result is still a black-screen hang pending re-test.
+- The main stabilization blocker is still HDD `POPSTARTER.ELF` when the launcher and/or sidecar/CWD are on HDD. Hardware re-test showed selector/CWD mitigation alone was insufficient; current source now adds executable-slot preservation under test, and reported hardware result is still a black-screen hang pending re-test.
 - `HDD (exFAT)` and `SMB (v1)` remain intentionally unimplemented menu entries.
 
 ## Immediate Priorities
@@ -14,7 +14,7 @@ Last updated: 2026-03-27
   - POPSLoader booted from HDD,
   - HDD game launched from HDD (PFS),
   - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path,
-  - current source behavior to validate: absolute mounted selector (`pfsN:/<title>.ELF`) plus POPSTARTER-directory CWD fallback.
+  - current source behavior to validate: selector/CWD adjustments plus exec-slot keep preservation (game-slot + POPSTARTER-slot union).
 - Keep `BOOT.ELF` and OSDSYS behavior stable while iterating on this.
 
 ### 2) External exit/launch re-validation

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-26
+Last updated: 2026-03-27
 
 # STATE
 
@@ -30,6 +30,9 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - `BOOT.ELF` lookup order is:
   - `mc0:/BOOT/BOOT.ELF`
   - `mc1:/BOOT/BOOT.ELF`
+- HDD launch path currently applies a mitigation under test for `D-10`:
+  - when HDD mount prep succeeds, selector/bootparam are rewritten to absolute mounted `pfsN:/<title>.ELF`,
+  - HDD launch context no longer forces `launch_cwd` to the mounted HDD game partition root (launch CWD falls back to POPSTARTER path directory).
 - Current cover sources are:
   - sidecar PNG next to the selected `.VCD`,
   - `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
@@ -51,6 +54,7 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - reported failing on hardware.
   - repro: boot from HDD, launch HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
   - result: black-screen hang.
+  - source now includes selector/CWD mitigation, but hardware result is still `Unknown (verify on hardware)` until re-tested.
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later launch-backend experiment regressed it,

--- a/STATE.md
+++ b/STATE.md
@@ -30,9 +30,10 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - `BOOT.ELF` lookup order is:
   - `mc0:/BOOT/BOOT.ELF`
   - `mc1:/BOOT/BOOT.ELF`
-- HDD launch path currently applies a mitigation under test for `D-10`:
-  - when HDD mount prep succeeds, selector/bootparam are rewritten to absolute mounted `pfsN:/<title>.ELF`,
-  - HDD launch context no longer forces `launch_cwd` to the mounted HDD game partition root (launch CWD falls back to POPSTARTER path directory).
+- HDD launch path currently applies mitigations under test for `D-10`:
+  - selector/bootparam are rewritten to absolute mounted `pfsN:/<title>.ELF` when HDD mount prep succeeds,
+  - HDD launch context no longer forces `launch_cwd` to the mounted HDD game partition root (launch CWD falls back to POPSTARTER path directory),
+  - launch now resolves/preserves the POPSTARTER executable-backed PFS slot and keeps the union of game-slot + exec-slot for launch unmount/keep-mask prep.
 - Current cover sources are:
   - sidecar PNG next to the selected `.VCD`,
   - `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
@@ -54,7 +55,8 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - reported failing on hardware.
   - repro: boot from HDD, launch HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
   - result: black-screen hang.
-  - source now includes selector/CWD mitigation, but hardware result is still `Unknown (verify on hardware)` until re-tested.
+  - follow-up report confirms selector/CWD mitigation was insufficient.
+  - source now includes executable-slot preservation mitigation in addition to selector/CWD, but hardware result is still `Unknown (verify on hardware)` until re-tested.
 - `U-10` BOOT.ELF after HDD page init:
   - one prior artifact was reported good,
   - a later launch-backend experiment regressed it,

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3144,6 +3144,19 @@ local function SelectHddLaunchGameSlot(popstarter)
   return HDD_SLOT_GAME
 end
 
+local function ResolveExecPathAndKeepSlot(path)
+  local resolved_path = path
+  local keep_slot = ExtractLaunchPfsSlot(resolved_path)
+  if keep_slot == nil and string.match(string.lower(tostring(resolved_path or "")), "^hdd%d:") ~= nil then
+    local mounted_exec = ResolveHddExecMountedPath(resolved_path)
+    if mounted_exec ~= nil then
+      resolved_path = mounted_exec
+      keep_slot = ExtractLaunchPfsSlot(resolved_path)
+    end
+  end
+  return resolved_path, keep_slot
+end
+
 local function EnsureHDDReadyForLaunch(game, partition_override, slot_override)
   local result = {
     init_ok = false,
@@ -3394,6 +3407,8 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   local policy, device_page = ResolveLaunchPolicy(gamelocation, ui_scene)
   local selected_entry = tostring(game or "")
   local popstarter = ResolvePopstarterPath(PLDR.POPSTARTER_PATH)
+  local popstarter_keep_slot = nil
+  popstarter, popstarter_keep_slot = ResolveExecPathAndKeepSlot(popstarter)
   if selected_entry == "" then
     BlockLaunchFailure(
       "Invalid game selection",
@@ -3573,6 +3588,16 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     end
   end
   local argv = {argv0_selector}
+  local keep_hdd_slots = {}
+  if hdd_init ~= nil and hdd_init.mount_ok == true and hdd_init.mount_slot ~= nil then
+    table.insert(keep_hdd_slots, hdd_init.mount_slot)
+  end
+  if popstarter_keep_slot ~= nil then
+    table.insert(keep_hdd_slots, popstarter_keep_slot)
+  end
+  if #keep_hdd_slots < 1 then
+    keep_hdd_slots = nil
+  end
 
   local context = {
     device_page = device_page,
@@ -3596,7 +3621,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     game_name = game_name,
     bootparam_source = boot_source_mode,
     hdd_init = hdd_init,
-    keep_hdd_slots = (hdd_init ~= nil and hdd_init.mount_ok == true and hdd_init.mount_slot ~= nil) and {hdd_init.mount_slot} or nil,
+    keep_hdd_slots = keep_hdd_slots,
     launch_cwd = nil
   }
   local reboot_iop = PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3541,6 +3541,14 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
   end
   local selector_prefix = SelectPopstarterSelectorPrefix(device_page)
   local argv0_selector = BuildPopstarterSelectorPath(device_page, game_name)
+  if policy.name == "HDD" and hdd_init ~= nil and hdd_init.mount_ok == true and hdd_init.mount_prefix ~= nil then
+    local absolute_selector = BuildMountedReadablePath(hdd_init.mount_prefix, BuildLiteralElfName(game_name))
+    if absolute_selector ~= nil then
+      argv0_selector = absolute_selector
+      bootparam = absolute_selector
+      bootparam_exists = doesFileExist(absolute_selector)
+    end
+  end
   if selector_prefix == "" and string.upper(game_name) == "POPSTARTER" then
     BlockLaunchFailure(
       "Internal error: game_base derived as POPSTARTER; refusing to launch.",
@@ -3589,7 +3597,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene)
     bootparam_source = boot_source_mode,
     hdd_init = hdd_init,
     keep_hdd_slots = (hdd_init ~= nil and hdd_init.mount_ok == true and hdd_init.mount_slot ~= nil) and {hdd_init.mount_slot} or nil,
-    launch_cwd = (hdd_init ~= nil and hdd_init.mount_ok == true) and hdd_init.mount_prefix or nil
+    launch_cwd = nil
   }
   local reboot_iop = PLDR.REBOOT_IOP_WHILE_LOADING_POPSTARTER
   if policy.name == "HDD" then


### PR DESCRIPTION
### Motivation
- The remaining HDD repro (`D-10`) appears caused by a relative selector combined with a forced HDD-game-partition CWD when `POPSTARTER.ELF` is also on HDD, producing a selector/CWD misalignment and a black-screen hang. 
- Apply the smallest, reversible change that tests that hypothesis without adding retries, sleeps, or refactors. 
- Keep docs in sync so the repo accurately reflects that this is a mitigation under test, not a validated hardware fix.

### Description
- In `bin/POPSLDR/system.lua` (inside `PLDR.RunPOPStarterGame`) when `policy.name == "HDD"` and mount prep succeeded, build an absolute mounted selector via `BuildMountedReadablePath(hdd_init.mount_prefix, BuildLiteralElfName(game_name))` and, if present, set `argv0_selector`, `bootparam`, and refresh `bootparam_exists` from that absolute path. 
- In the same launch context, stop forcing `launch_cwd` to the mounted HDD game partition root by setting `launch_cwd = nil`, allowing `LaunchEngine` to fall back to the resolved POPSTARTER directory behavior. 
- Synchronized documentation files (`README.md`, `STATE.md`, `ROADMAP.md`, `DECISIONS.md`, `QA_REGRESSION_MATRIX.md`) to record that the absolute-selector + CWD fallback is staged in source as a mitigation under test and to note that hardware re-tests are required.

### Testing
- Repository checks performed: `git diff --stat` and `git status --short` to verify the expected files changed, and a commit was produced to capture the change (repo-local verification succeeded). 
- Attempted static Lua syntax check with `luac -p bin/POPSLDR/system.lua` but `luac` is not available in this environment so that check was not run. 
- No hardware tests were run here; required hardware validation plan (not executed) includes `D-10` (HDD boot + HDD game, cases A/B for POPSTARTER sidecar vs configured HDD path), `U-05` (OSDSYS exit after opening HDD page), `U-10` (BOOT.ELF after HDD page init), duplicate-title HDD sanity, and a known-good non-HDD POPSTARTER path sanity check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62101cc348321aa0304af563f6ac5)