### PR TITLE
D-10: restore post-load reset HDD child handoff

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,4 +1,4 @@
-Last updated: 2026-04-02
+Last updated: 2026-04-19
 
 # DECISIONS
 
@@ -59,6 +59,12 @@ Each entry records:
 - Rationale: repeated experiment history had started drifting across the root docs and obscuring the actual current handoff state.
 - Implications: root docs should point to the matrix for detailed chronology instead of carrying their own competing mini-ledgers.
 - Evidence: repository documentation audit on 2026-03-29.
+
+### 2026-04-19 — Restore post-load reset child handoff for partition-aware HDD POPSTARTER
+- Decision: the embedded child loader now uses mounted-path `SifLoadElf` for partition-aware HDD POPSTARTER and restores the post-load child-side `SifIopReset("")` + ROM MC module reload (`SIO2MAN`, `MCMAN`, `MCSERV`) before `ExecPS2`.
+- Rationale: the 2026-04-02 hardware artifact still black-screened on the no-reset/fileXio-first child path, so current source reverts to the earlier reset-first handoff contract for the HDD-partition-aware branch.
+- Implications: this keeps non-HDD direct fileXio flows intact while narrowing the HDD partition-aware branch to one deterministic handoff shape for the next hardware artifact.
+- Evidence: `src/elf_loader/src/loader/src/loader.c`, `QA_REGRESSION_MATRIX.md` (latest recorded 2026-04-02 D-10 FAIL).
 
 ## Open Investigations
 - HDD startup auto-init on HDD boot/configured paths:
@@ -124,7 +130,7 @@ Each entry records:
   - current source therefore restores partition context only as loader metadata for HDD-backed POPSTARTER so the child uses the partition-aware remount path again, while still keeping no launch CWD and the same visible resolved exec path.
   - audit also found a Lua binding bug in `src/luasystem.cpp`: the trailing reboot partition context was only parsed when `System.loadELF(...)` had at least four Lua arguments, so the new HDD reboot path could not actually pass loader-only partition metadata until current source widened that check to the three-argument form.
   - audit then exposed one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset("")`, while later `HEAD` had drifted to jump straight to `ExecPS2`.
-  - current source then realigns that partition-aware HDD child handoff to a no-reset-first path with a bounded reference-style load fallback: mount `pfs0:`, try mounted-path fileXio segment load first, and fall back to mounted-path `SifLoadElf`; handoff stays `SifExitRpc`/`ExecPS2` without a second child-side `SifIopReset("")` + module-reload stage. Hardware on this exact line remains `Unknown (verify on hardware)`.
+  - current source then realigns that partition-aware HDD child handoff to a post-load reset path: mount `pfs0:`, load through mounted-path `SifLoadElf`, then run `SifIopReset("")`/`SifIopSync()`, reinitialize RPC, reload `rom0:SIO2MAN` + `rom0:MCMAN` + `rom0:MCSERV`, and finally jump with `ExecPS2`. Hardware on this exact line remains `Unknown (verify on hardware)`.
   - latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened on `D-10`.
   - audit then exposed another remaining carry-over in parent-side launch prep: `PrepareForExternalELFLaunch(...)` still auto-kept the mounted `pfsN` slot whenever the exec path itself was on `pfsN:/...`. Current source now suppresses that implicit exec-slot keep specifically for HDD-backed POPSTARTER, so the stripped line no longer preserves the mounted parent slot just because the executable was resolved there.
   - the latest hardware re-test on that stripped selectorless line still black-screened, while the only recorded move away from a black screen happened before the selector was stripped.

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -1,6 +1,6 @@
 # POPSLoader Regression Matrix
 
-Last updated: 2026-04-02
+Last updated: 2026-04-19
 Target line: current repository source
 
 ## Scope
@@ -184,7 +184,7 @@ This file is the authoritative detailed run ledger for CI and hardware outcomes.
     - repo comparison then showed the stripped line was still using the child loader's newer `fileXio` direct-load shortcut for `pfsN:/...` because `exec_partition_context` had been cleared; current source now restores partition context only as loader metadata so the child uses the older partition-aware remount path again while still keeping the same visible exec path.
     - audit also found a Lua binding bug in `src/luasystem.cpp`: the trailing reboot partition context was only recognized when `System.loadELF(...)` had at least four Lua arguments, so the HDD reboot path could not actually pass loader-only partition metadata until current source widened that check to the three-argument form.
     - audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset("")`, while later `HEAD` had drifted to jump straight to `ExecPS2`.
-    - current source now applies a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER with bounded reference-style load fallback: mount `pfs0:`, try mounted-path fileXio segment load first, and fall back to mounted-path `SifLoadElf`, then `SifExitRpc`/`ExecPS2` without a child-side post-load `SifIopReset("")` + module-reload stage. Hardware on this exact line is still `Unknown (verify on hardware)`.
+    - current source now applies a post-load reset child-loader handoff for partition-aware HDD POPSTARTER: mount `pfs0:`, load with mounted-path `SifLoadElf`, then run `SifIopReset("")`/`SifIopSync()`, reinitialize RPC, reload `rom0:SIO2MAN` + `rom0:MCMAN` + `rom0:MCSERV`, and jump via `ExecPS2`. Hardware on this exact line is still `Unknown (verify on hardware)`.
     - latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened on `D-10`.
     - audit then found another remaining carry-over in parent-side launch prep: `PrepareForExternalELFLaunch(...)` still auto-kept the mounted `pfsN` slot whenever the exec path itself was on `pfsN:/...`. Current source now suppresses that implicit exec-slot keep specifically for HDD-backed POPSTARTER, so the stripped line no longer preserves the mounted parent slot just because the executable was resolved there.
     - a later 2026-03-29 hardware re-test on the selectorless stripped current `HEAD` line still black-screened.
@@ -195,7 +195,7 @@ This file is the authoritative detailed run ledger for CI and hardware outcomes.
     - the user later clarified that the other same-day 2026-03-28 success result referred to `D-15`, not this case.
     - a later 2026-03-28 re-test on the forced-`reboot_iop = 1` source still black-screened on `X`; `R2` produced no response in that non-HDD-game repro.
     - a later 2026-03-28 re-test on the direct-`hdd0:PART:pfsN:/POPSTARTER.ELF` preference source still black-screened on `X`.
-    - current source now uses the same partition-aware HDD reboot contract as `D-10`, including the no-reset-first child-loader handoff with mounted-path fileXio-first and mounted-path `SifLoadElf` fallback, rather than the earlier ad hoc source-context handoff or whichever mounted `pfsN:` path Lua happened to resolve first; hardware result is still `Unknown (verify on hardware)`.
+    - current source now uses the same partition-aware HDD reboot contract as `D-10`, including the post-load reset child-loader handoff with mounted-path `SifLoadElf` plus post-load reset/module reload, rather than the earlier ad hoc source-context handoff or whichever mounted `pfsN:` path Lua happened to resolve first; hardware result is still `Unknown (verify on hardware)`.
   - `D-15`: reported FAIL on 2026-03-27 when booting from a non-HDD device and launching an HDD title with sidecar/cwd `POPSTARTER.ELF` on that boot device.
     - the user identified this as a regression on the EE-side HDD direct-load attempt.
     - a later 2026-03-27 broader stripped-handoff source also failed, a 2026-03-28 experimental source still black-screened, and the 2026-03-28 rolled-back current source still black-screened with USB boot plus USB sidecar/cwd `POPSTARTER.ELF`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPSLoader
 
-Last updated: 2026-04-02
+Last updated: 2026-04-19
 
 POPSLoader is a PlayStation 2 launcher for POPStarter, built on Enceladus runtime components and driven primarily by embedded Lua scripts.
 
@@ -56,14 +56,14 @@ Reported hardware issues currently being tracked are:
   - latest recorded hardware outcomes still fail when `POPSTARTER.ELF` itself is HDD-backed.
   - `D-15` passing again isolates the remaining blocker to HDD-backed POPSTARTER execution, not HDD games in general.
   - one 2026-03-29 artifact briefly moved `D-10` from a black screen to `rc=-1 (returned after 22618 ms)`, but later artifacts returned to a black screen, so that boundary was not stable.
-  - current repo line keeps the partition-aware HDD reboot contract, separate exec-path reporting, profile-path normalization, and a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER loads.
+  - current repo line keeps the partition-aware HDD reboot contract, separate exec-path reporting, profile-path normalization, and a post-load reset child-loader handoff for partition-aware HDD POPSTARTER loads.
   - a later hardware re-test on that child-remount/cold-parent line still black-screened.
   - the later stripped direct-HDD-ELF line moved `D-10` back to a returned `rc=-1`, but the popup also showed the launcher was still probing/opening `pfs3:/.../POPSTARTER.ELF` while separately trying to exec a rewritten `pfs:/.../POPSTARTER.ELF`.
   - current repo line now removes the stale exec-path rewrite from the stripped HDD-backed POPSTARTER experiment so probe/open and exec both use the same resolved HDD ELF path, retries that stripped HDD ELF attempt through `reboot_iop = 1`, and still lets the reboot path enter the HDD embedded loader.
   - repo comparison then exposed a larger drift in that stripped line: with `exec_partition_context = nil`, the child loader falls into the newer `fileXio` direct-load shortcut for `pfsN:/...` and skips the older partition-aware remount path.
   - current repo line now restores partition context only as loader metadata for HDD-backed POPSTARTER so the child uses the partition-aware remount path again, while still keeping no launch CWD and the same visible resolved exec path.
   - audit also found a Lua binding bug in `src/luasystem.cpp`: the trailing reboot partition context was only parsed when `System.loadELF(...)` received at least four Lua arguments, so the new HDD path could not actually deliver loader-only partition metadata in the three-argument reboot form. Current source now accepts that trailing partition context with three arguments as well.
-  - audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset("")`, while later `HEAD` had drifted to jump straight to `ExecPS2`. Current source keeps the no-reset-first route, but now does a bounded child-loader fallback aligned to the `wLaunchELF` `pfs0:` pattern: mount `pfs0:`, try mounted-path fileXio segment load first, and fall back to mounted-path `SifLoadElf` if that copy fails; handoff remains `SifExitRpc`/`ExecPS2` with no child-side post-load reset/module-reload stage. Hardware on this exact line is still `Unknown (verify on hardware)`.
+  - audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset("")`, while later `HEAD` had drifted to jump straight to `ExecPS2`. Current source now uses a post-load reset child-loader path aligned to the older POPSLoader HDD handoff contract: mount `pfs0:`, load with mounted-path `SifLoadElf`, then perform `SifIopReset("")`/`SifIopSync()`, reinitialize RPC, reload `rom0:SIO2MAN` + `rom0:MCMAN` + `rom0:MCSERV`, and finally jump with `ExecPS2`. Hardware on this exact line is still `Unknown (verify on hardware)`.
   - latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened on `D-10`.
   - audit then found another remaining carry-over in parent-side launch prep: `PrepareForExternalELFLaunch(...)` still auto-kept the mounted `pfsN` slot whenever the exec path itself was on `pfsN:/...`. Current source now suppresses that implicit exec-slot keep specifically for HDD-backed POPSTARTER, so the stripped line no longer preserves the mounted parent slot just because the executable was resolved there.
   - the latest hardware re-test on that stripped selectorless line still black-screened, and the only recorded move away from a black screen happened before the selector was stripped. Current source therefore restores selector-only `argv[0]` for HDD-backed POPSTARTER while still avoiding slot/CWD preservation and keeping partition context only as loader metadata.
@@ -221,9 +221,9 @@ The workflow uses the `ps2dev/ps2dev` container and validates packaging after bu
   - latest recorded hardware outcomes still fail when `POPSTARTER.ELF` itself is HDD-backed.
   - `D-15` passing again isolates the remaining blocker to HDD-backed POPSTARTER execution.
   - one 2026-03-29 artifact briefly returned `rc=-1 (returned after 22618 ms)` instead of black-screening, but later artifacts returned to black screen, so that boundary is not treated as the stable current state.
-  - current repo line keeps the partition-aware reboot contract, separate exec-path reporting, profile-path normalization, and a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER loads.
+  - current repo line keeps the partition-aware reboot contract, separate exec-path reporting, profile-path normalization, and a post-load reset child-loader handoff for partition-aware HDD POPSTARTER loads.
   - latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened.
-  - current source now keeps no-reset handoff but changes the partition-aware child-loader load order to match the bounded reference pattern: mount `pfs0:`, try mounted-path fileXio segment copy first, then fall back to mounted-path `SifLoadElf` if needed; exact-line hardware status is `Unknown (verify on hardware)`.
+  - current source now keeps a post-load reset handoff for partition-aware HDD POPSTARTER: mount `pfs0:`, load with mounted-path `SifLoadElf`, then reset/sync IOP and reload required MC ROM modules before `ExecPS2`; exact-line hardware status is `Unknown (verify on hardware)`.
   - a later hardware re-test on that child-remount/cold-parent line still black-screened.
   - the later stripped direct-HDD-ELF line moved `D-10` back to a returned `rc=-1`, but the popup also showed the launcher was still probing/opening `pfs3:/.../POPSTARTER.ELF` while separately trying to exec a rewritten `pfs:/.../POPSTARTER.ELF`.
   - current repo line now removes that stale exec-path rewrite from the stripped HDD-backed POPSTARTER experiment, keeps the reboot/embedded-loader path plus loader-only partition metadata, and restores selector-only `argv[0]` because the selectorless stripped line still black-screened while the only recorded non-black-screen boundary preceded the strip.
@@ -233,7 +233,7 @@ The workflow uses the `ps2dev/ps2dev` container and validates packaging after bu
   - reported failing.
   - 2026-03-27 user hardware also black-screened when launching a USB game with Profile 2 pointing `POPSTARTER.ELF` to HDD.
   - later recorded hardware still failed when `POPSTARTER.ELF` itself was on HDD, confirming the broader blocker is HDD-backed POPSTARTER execution rather than HDD game routing alone.
-  - current repo line uses the same partition-aware HDD reboot contract as `D-10`, including no-reset child handoff with mounted-path fileXio-first and mounted-path `SifLoadElf` fallback; a current-line hardware re-test is still `Unknown (verify on hardware)`.
+  - current repo line uses the same partition-aware HDD reboot contract as `D-10`, including post-load reset child handoff with mounted-path `SifLoadElf` followed by IOP reset/module reload; a current-line hardware re-test is still `Unknown (verify on hardware)`.
 - `D-15` HDD game with non-HDD sidecar POPSTARTER:
   - a later 2026-03-27 hardware report said booting from another device and launching an HDD game with sidecar `POPSTARTER.ELF` on that boot device also black-screened.
   - that was reported as a regression on the EE-side HDD direct-load attempt, which has now been reverted in source.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Last updated: 2026-04-02
+Last updated: 2026-04-19
 
 # ROADMAP
 
@@ -8,14 +8,14 @@ Last updated: 2026-04-02
 - Recorded hardware confirms `D-12` startup/Profile lookup is restored, `D-16` first-entry USB discovery is restored, and `D-15` non-HDD-POPSTARTER HDD-game launch is restored.
 - The main stabilization blocker is still HDD-backed `POPSTARTER.ELF` execution when the launcher, sidecar/CWD, or configured POPSTARTER path lives on HDD (`D-10`, `D-14`).
 - One 2026-03-29 artifact briefly moved `D-10` to a returned `rc=-1`, but later artifacts returned to black screen, so that was not a stable new boundary.
-- Current repo line uses the partition-aware HDD reboot contract, separate exec-path reporting, profile-path normalization, and a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER loads while preserving the restored non-HDD POPSTARTER path.
+- Current repo line uses the partition-aware HDD reboot contract, separate exec-path reporting, profile-path normalization, and a post-load reset child-loader handoff for partition-aware HDD POPSTARTER loads while preserving the restored non-HDD POPSTARTER path.
 - The later child-remount/cold-parent HDD POPSTARTER line still black-screened on hardware.
 - Current repo line no longer keeps the selectorless stripped experiment. That selectorless line still black-screened on hardware, while the only recorded move away from a black screen happened before the selector was stripped.
 - The latest stripped-line hardware popup returned `rc=-1`, but it also showed one more repo bug: probe/open used `pfs3:/.../POPSTARTER.ELF` while exec still used a rewritten `pfs:/.../POPSTARTER.ELF`.
 - Current repo line now removes that stale exec-path rewrite from the stripped HDD-backed POPSTARTER experiment so probe/open and exec use the same resolved HDD ELF path, keeps reboot mode instead of non-reboot `LoadExecPS2`, and still uses the HDD embedded loader path.
 - Repo comparison then showed the stripped HDD line was still hitting the child loader's newer `fileXio` direct-load shortcut for `pfsN:/...` because `exec_partition_context` had been cleared; current source now restores partition context only as loader metadata so the child uses the older partition-aware remount path again while still keeping the same visible exec path.
 - Audit also found a Lua binding bug: the trailing reboot partition context was only recognized when `System.loadELF(...)` had at least four Lua arguments, so the HDD reboot path could not actually pass loader-only partition metadata in the three-argument form. Current source now accepts that form as well.
-- Audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset(\"\")`, while later `HEAD` had drifted to jump straight to `ExecPS2`. Current source now uses a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER with bounded mounted-path load fallback (`fileXio` segment load first, mounted-path `SifLoadElf` fallback, then `SifExitRpc`/`ExecPS2` without child-side reset/module reload); hardware on this exact line is still `Unknown (verify on hardware)`.
+- Audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset(\"\")`, while later `HEAD` had drifted to jump straight to `ExecPS2`. Current source now uses a post-load reset child-loader handoff for partition-aware HDD POPSTARTER: mount `pfs0:`, load with mounted-path `SifLoadElf`, then run child-side `SifIopReset("")`/`SifIopSync()`, reinitialize RPC, reload `rom0:SIO2MAN` + `rom0:MCMAN` + `rom0:MCSERV`, and jump via `ExecPS2`; hardware on this exact line is still `Unknown (verify on hardware)`.
 - Latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened on `D-10`.
 - Audit then found another remaining carry-over in parent-side launch prep: `PrepareForExternalELFLaunch(...)` still auto-kept the mounted `pfsN` slot whenever the exec path itself was on `pfsN:/...`. Current source now suppresses that implicit exec-slot keep specifically for HDD-backed POPSTARTER.
 - The current hypothesis boundary is now narrower again: preserve the later loader/binding fixes, but give HDD-backed POPSTARTER back its selector-only `argv[0]` because the selectorless line did not improve hardware behavior.
@@ -33,7 +33,7 @@ Last updated: 2026-04-02
   - HDD game launched from HDD (PFS),
   - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path,
   - current reported result: black-screen hang.
-  - current no-reset-first iteration keeps selector-only `argv[0]` and loader partition metadata, removes the child-side post-load reset/module-reload stage, and now uses mounted-path fileXio-first with mounted-path `SifLoadElf` fallback for the partition-aware HDD POPSTARTER child-loader load step.
+  - current iteration keeps selector-only `argv[0]` and loader partition metadata, and now uses mounted-path `SifLoadElf` followed by post-load IOP reset/module reload for the partition-aware HDD POPSTARTER child-loader load step.
   - preserve `D-15`, `D-12`, `D-16`, `U-05`, and shared Profile 1/default sidecar behavior while iterating.
   - treat `D-14` as the paired non-HDD-game repro for the same HDD-backed POPSTARTER blocker.
   - use `QA_REGRESSION_MATRIX.md` for the full experiment chronology instead of rebuilding that ledger here.

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-04-02
+Last updated: 2026-04-19
 
 # STATE
 
@@ -101,7 +101,7 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - current source therefore restores partition context only as loader metadata for HDD-backed POPSTARTER so the child uses the partition-aware remount path again, while still keeping no launch CWD and the same visible resolved exec path.
   - audit also found a Lua binding bug in `src/luasystem.cpp`: the trailing reboot partition context was only parsed when `System.loadELF(...)` had at least four Lua arguments, so the new HDD path could not actually deliver loader-only partition metadata in the three-argument reboot form. Current source now accepts that trailing partition context with three arguments as well.
   - audit then found one more regression in the exact HDD child-loader path now in use: older child-loader source reloaded `SIO2MAN`, `MCMAN`, and `MCSERV` after HDD `SifIopReset("")`, while later `HEAD` had drifted to jump straight to `ExecPS2`.
-  - current source now applies a no-reset-first child-loader handoff for partition-aware HDD POPSTARTER, but updates the load order to a bounded reference-style fallback: after mount on `pfs0:`, the child tries mounted-path fileXio segment copy first and falls back to mounted-path `SifLoadElf` if needed, then exits RPC and jumps via `ExecPS2` without a second child-side `SifIopReset("")` + module-reload stage; hardware on this exact line is `Unknown (verify on hardware)`.
+  - current source now applies a post-load reset child handoff for partition-aware HDD POPSTARTER: mount `pfs0:`, load the target with mounted-path `SifLoadElf`, then do `SifIopReset("")`, `SifIopSync()`, `SifInitRpc(0)`, and reload `rom0:SIO2MAN`, `rom0:MCMAN`, and `rom0:MCSERV` before `ExecPS2`; hardware on this exact line is `Unknown (verify on hardware)`.
   - latest user hardware report from the 2026-04-02 GitHub artifact (`cd76569`) still black-screened on `D-10`.
   - audit then found another remaining carry-over in parent-side launch prep: `PrepareForExternalELFLaunch(...)` still auto-kept the mounted `pfsN` slot whenever the exec path itself was on `pfsN:/...`. Current source now suppresses that implicit exec-slot keep specifically for HDD-backed POPSTARTER, so the stripped line no longer preserves the mounted parent slot just because the executable was resolved there.
   - current source now restores more of the original parent-side embedded-loader jump contract in `src/elf_loader/src/elf.c`: BRAM wipe plus `SifInitRpc`/`SifLoadFileInit`/`SifLoadFileExit` before the copy, and `SifExitIopHeap`/`SifExitRpc`/`SifExitCmd` before the final `ExecPS2`.
@@ -116,7 +116,7 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - the user later clarified that the other same-day 2026-03-28 success report referred to `D-15`, not this case.
   - a later 2026-03-28 re-test on the forced-`reboot_iop = 1` source still black-screened on `X`; `R2` produced no response in that non-HDD-game repro.
   - a later 2026-03-28 re-test on the direct-`hdd0:PART:pfsN:/POPSTARTER.ELF` preference source still black-screened on `X`.
-  - current source now uses the same partition-aware HDD reboot contract as `D-10`, including the no-reset-first child-loader handoff with mounted-path fileXio-first and mounted-path `SifLoadElf` fallback, rather than the earlier ad hoc source-context handoff or whichever mounted `pfsN:` path Lua happened to resolve first.
+  - current source now uses the same partition-aware HDD reboot contract as `D-10`, including the post-load reset child-loader handoff with mounted-path `SifLoadElf` plus post-load reset/module reload, rather than the earlier ad hoc source-context handoff or whichever mounted `pfsN:` path Lua happened to resolve first.
   - latest recorded hardware remains `FAIL`; current exact-line result is still `Unknown (verify on hardware)`.
 - `D-15` HDD game with non-HDD sidecar POPSTARTER:
   - reported as a regression on hardware.

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -171,6 +171,13 @@ static int build_default_target_arg0(const char *partition_context, const char *
 	return 0;
 }
 
+static void load_post_reset_mc_modules(void)
+{
+	SifLoadModule("rom0:SIO2MAN", 0, NULL);
+	SifLoadModule("rom0:MCMAN", 0, NULL);
+	SifLoadModule("rom0:MCSERV", 0, NULL);
+}
+
 #define LOADER_ELF_MAGIC        0x464c457fU
 #define LOADER_PT_LOAD          1
 #define LOADER_PT_MIPS_REGINFO  0x70000000U
@@ -361,31 +368,9 @@ int main(int argc, char *argv[])
 	} else {
 		ret = mount_partition_context_on_pfs0(partition_context);
 		if (ret == 0) {
-			if (is_hdd_partition_context(partition_context)) {
-				/* Keep the partition-aware mount contract, but for HDD-backed
-				 * targets prefer the same mounted-path fileXio segment-copy
-				 * style that wLaunchELF's pfs0 flow uses. If that load fails,
-				 * fall back to SifLoadElf on the same mounted path.
-				 */
-				loaded_via_filexio = 1;
-				fileXioInit();
-				ret = load_elf_via_filexio(load_path, &filexio_entry, &filexio_gp);
-				if (ret == 0) {
-					elfdata.epc = filexio_entry;
-					elfdata.gp = filexio_gp;
-				} else {
-					loaded_via_filexio = 0;
-					elfdata.epc = 0;
-					elfdata.gp = 0;
-					SifLoadFileInit();
-					ret = SifLoadElf(load_path, &elfdata);
-					SifLoadFileExit();
-				}
-			} else {
-				SifLoadFileInit();
-				ret = SifLoadElf(load_path, &elfdata);
-				SifLoadFileExit();
-			}
+			SifLoadFileInit();
+			ret = SifLoadElf(load_path, &elfdata);
+			SifLoadFileExit();
 		} else {
 			elfdata.epc = 0;
 			elfdata.gp = 0;
@@ -406,11 +391,14 @@ int main(int argc, char *argv[])
 		}
 
 		if (is_hdd_partition_context(partition_context)) {
-			/* Keep partition-aware HDD handoff aligned with the PS2SDK
-			 * loader contract: once SifLoadElf copied the target ELF,
-			 * jump without a second child-side IOP reset/module-reload
-			 * stage.
-			 */
+			while (!SifIopReset("", 0)) {
+			}
+			while (!SifIopSync()) {
+			}
+			SifInitRpc(0);
+			SifLoadFileInit();
+			load_post_reset_mc_modules();
+			SifLoadFileExit();
 			SifExitRpc();
 		} else {
 			SifExitRpc();


### PR DESCRIPTION
### Motivation
- Previous no-reset/fileXio-first child-loader line for partition-aware HDD launches did not produce a stable improvement for `D-10` on recorded hardware, so the partition-aware handoff must be narrowed to a deterministic contract the embedded loader historically used. 
- Keep non-HDD direct fileXio flows intact while removing ambiguity in the partition-aware `pfs0:` branch to reduce experiment noise for the next CI hardware artifact. 

### Description
- Reworked the partition-aware HDD child-loader path in `src/elf_loader/src/loader/src/loader.c` to always call `SifLoadElf` for mounted `pfs0:` loads and restore a post-load IOP reset and module reload sequence before `ExecPS2`. 
- Added `load_post_reset_mc_modules()` and the sequence `SifIopReset("")` / `SifIopSync()` / `SifInitRpc(0)` / `SifLoadFileInit()` + module reloads (`rom0:SIO2MAN`, `rom0:MCMAN`, `rom0:MCSERV`) / `SifLoadFileExit()` in the child before jumping. 
- Removed the earlier mounted-path fileXio-first branch for the partition-aware child path while preserving the fallback `fileXio` and `SifLoadElf` behavior for non-partition-aware/direct iomanX paths. 
- Synchronized documentation to describe the new experiment line and status by updating `README.md`, `STATE.md`, `ROADMAP.md`, `DECISIONS.md`, and `QA_REGRESSION_MATRIX.md`. 

### Testing
- Attempted a local rebuild with `make elfloader`, which failed in this environment due to missing PS2SDK build include (`/samples/Makefile.eeglobal`), so no local ELF artifact was produced. 
- Repo-level sanity: committed the targeted source change and updated docs; CI artifact validation and hardware verification remain `Unknown (verify on hardware)` until the next GitHub Actions build and hardware run produce results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4470c9fc08321bc5a70ddf2b60ed3)