### PR TITLE
elf_loader: skip SIF teardown for HDD-backed embedded loader

### DIFF
--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -377,10 +377,12 @@ static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *l
 		}
 	}
 
-	SifExitIopHeap();
+	if (!is_hdd_backed_exec_path(partition_context)) {
+SifExitIopHeap();
 	SifExitRpc();
 	SifExitCmd();
-	FlushCache(0);
+	}
+FlushCache(0);
 	FlushCache(2);
 
 	ret = ExecPS2((void *)boot_header->entry, 0, final_argc, launch_argv);


### PR DESCRIPTION
Fix D-10 black-screen regression. The parent embedded loader unconditionally shuts down the SIF subsystem before handing control to the child loader, which breaks HDD-backed launches because the child loader depends on the SIF layer. Add a check in ExecuteViaEmbeddedLoader() to skip SifExitIopHeap(), SifExitRpc(), and SifExitCmd() when launching from an HDD path (using is_hdd_backed_exec_path). Non-HDD paths continue to cleanup the SIF as before.

# Pull Request

## Summary

Provide a clear and concise description of the change.

- What does this PR do?
- Why is it necessary?
- What problem does it solve?

---

## Type of Change

Select all that apply:

- [ ] Bug fix
- [ ] Feature addition
- [ ] Performance improvement
- [ ] Refactor (non-functional change)
- [ ] Documentation update
- [ ] Breaking change
- [ ] Other (explain below)

---

## Related Issues

Link related issues using:

Closes #  
Fixes #  
Related to #

---

## Scope

- [ ] This PR contains a single logical change.
- [ ] No unrelated refactoring is included.
- [ ] No formatting-only noise is included.

If this PR modifies multiple subsystems, explain why that is necessary:

---

## Technical Details

Describe:

- What files are affected
- What systems are impacted
- Why this approach was chosen
- Any alternative approaches considered

If modifying core logic, explain potential side effects.

---

## Testing

- [ ] Builds successfully
- [ ] No new warnings introduced
- [ ] Existing functionality tested
- [ ] Regression risk evaluated
- [ ] Tested on latest default branch

Describe how you tested this change:

---

## Breaking Changes

If this is a breaking change, describe:

- What breaks
- Why it is justified
- Migration path (if applicable)

If not applicable, state: "No breaking changes."

---

## Security Considerations

Does this change affect:

- Authentication
- External inputs
- File handling
- Device access
- Network behavior

If yes, explain impact.

---

## Checklist

- [ ] I have read CONTRIBUTING.md
- [ ] I have followed the project code standards
- [ ] I have rebased on the latest default branch
- [ ] CI passes locally or via GitHub
- [ ] This PR does not introduce hidden side effects

---

## Additional Notes

Provide any additional context here.
