### PR TITLE
Move RESET_IOP reboot into _ps2sdk_memory_init hook

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,13 +293,6 @@ int main(int argc, char * argv[])
     boot_start = clock();
     BootStamp("EE init start");
 
-#ifdef RESET_IOP  
-    SifInitRpc(0);
-    while (!SifIopReset("", 0)){};
-    while (!SifIopSync()){};
-    SifInitRpc(0);
-    BootStamp("IOP reset");
-#endif
     
     // install sbv patch fix
     DPRINTF("Installing SBV Patches...\n");
@@ -432,4 +425,13 @@ int main(int argc, char * argv[])
     }
 
 	return 0;
+}
+
+extern "C" void _ps2sdk_memory_init() {
+#ifdef RESET_IOP  
+    SifInitRpc(0);
+    while (!SifIopReset("", 0)){};
+    while (!SifIopSync()){};
+    SifInitRpc(0);
+#endif
 }


### PR DESCRIPTION
### Motivation
- Ensure the IOP reboot sequence runs before PS2SDK libc memory initialization so any incompatible launcher-provided CDVDFSV/FILEIO modules do not interfere with libc startup.
- Limit behavior changes to builds where `RESET_IOP` is enabled so normal builds are unaffected.

### Description
- Removed the `#ifdef RESET_IOP` `SifInitRpc`/`SifIopReset`/`SifIopSync` block from the start of `main()` in `src/main.cpp`.
- Added an `extern "C" void _ps2sdk_memory_init()` function at the end of `src/main.cpp` that runs the same reboot sequence under `#ifdef RESET_IOP`.
- The change is localized to `src/main.cpp` and preserves the `RESET_IOP` conditional so the sequence only runs in targeted builds.

### Testing
- Performed an automated source edit to move the reset block and saved the updated `src/main.cpp` file.
- Inspected the resulting diff and file contents to confirm the reset block was removed from `main()` and added as the `_ps2sdk_memory_init` hook.
- No build or runtime tests were executed as part of this change (compilation and hardware validation are not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f299fdf74c83218e36db64f7e1bb3b)