### PR TITLE
elf_loader: move embedded loader control args off POPSTARTER argv

### DIFF
--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -117,6 +117,19 @@ static bool is_hdd_backed_exec_path(const char *path) {
 }
 
 static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *load_path, int argc, char *argv[]);
+
+#define EMBEDDED_LOADER_METADATA_ADDR ((volatile struct EmbeddedLoaderMetadata *)0x00083C00)
+#define EMBEDDED_LOADER_METADATA_MAGIC 0x504F504CU /* POPL */
+#define EMBEDDED_LOADER_METADATA_VERSION 1
+
+typedef struct EmbeddedLoaderMetadata {
+	u32 magic;
+	u32 version;
+	u32 valid;
+	u32 reserved;
+	char partition_context[128];
+	char load_path[256];
+} EmbeddedLoaderMetadata;
 int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
 
 static int extract_exec_pfs_slot(const char *path) {
@@ -326,8 +339,8 @@ static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *l
 	int i;
 	int ret;
 	int extra_argc = (argc > 0 && argv != NULL) ? argc : 0;
-	int final_argc = extra_argc + 2;
-	static const int kMaxArgc = 34;
+	int final_argc = extra_argc;
+	static const int kMaxArgc = 32;
 	static char *launch_argv[35];
 	static char launch_arg_storage[2048];
 	size_t storage_offset = 0;
@@ -347,20 +360,26 @@ static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *l
 	 */
 	wipe_bramMem();
 
-	launch_argv[0] = store_arg(partition_context != NULL ? partition_context : "", launch_arg_storage, sizeof(launch_arg_storage), &storage_offset);
-	if (!launch_argv[0]) {
-		return -3;
+	{
+		volatile EmbeddedLoaderMetadata *meta = EMBEDDED_LOADER_METADATA_ADDR;
+		memset((void *)meta, 0, sizeof(*meta));
+		meta->magic = EMBEDDED_LOADER_METADATA_MAGIC;
+		meta->version = EMBEDDED_LOADER_METADATA_VERSION;
+		snprintf((char *)meta->partition_context, sizeof(meta->partition_context), "%s", partition_context != NULL ? partition_context : "");
+		snprintf((char *)meta->load_path, sizeof(meta->load_path), "%s", load_path != NULL ? load_path : "");
+		meta->valid = 1;
+		if (meta->magic != EMBEDDED_LOADER_METADATA_MAGIC || meta->version != EMBEDDED_LOADER_METADATA_VERSION ||
+		    meta->valid != 1 || meta->load_path[0] == '\0') {
+			return -6;
+		}
 	}
-	launch_argv[1] = store_arg(load_path, launch_arg_storage, sizeof(launch_arg_storage), &storage_offset);
-	if (!launch_argv[1]) {
-		return -3;
-	}
+
 	for (i = 0; i < extra_argc; i++) {
 		char *stored_arg = store_arg(argv[i], launch_arg_storage, sizeof(launch_arg_storage), &storage_offset);
 		if (!stored_arg) {
 			return -3;
 		}
-		launch_argv[i + 2] = stored_arg;
+		launch_argv[i] = stored_arg;
 	}
 	launch_argv[final_argc] = NULL;
 

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -135,6 +135,40 @@ static int build_default_target_arg0(const char *partition_context, const char *
 	return 0;
 }
 
+
+#define EMBEDDED_LOADER_METADATA_ADDR ((volatile embedded_loader_metadata_t *)0x00083C00)
+#define EMBEDDED_LOADER_METADATA_MAGIC 0x504F504CU /* POPL */
+#define EMBEDDED_LOADER_METADATA_VERSION 1
+
+typedef struct {
+	unsigned int magic;
+	unsigned int version;
+	unsigned int valid;
+	unsigned int reserved;
+	char partition_context[128];
+	char load_path[256];
+} embedded_loader_metadata_t;
+
+static int read_embedded_loader_metadata(char *partition_context, size_t partition_context_size, char *load_path, size_t load_path_size)
+{
+	const volatile embedded_loader_metadata_t *meta = EMBEDDED_LOADER_METADATA_ADDR;
+
+	if (partition_context == NULL || load_path == NULL || partition_context_size == 0 || load_path_size == 0) {
+		return -EINVAL;
+	}
+
+	if (meta->magic != EMBEDDED_LOADER_METADATA_MAGIC ||
+	    meta->version != EMBEDDED_LOADER_METADATA_VERSION ||
+	    meta->valid != 1 ||
+	    meta->load_path[0] == '\0') {
+		return -3302;
+	}
+
+	snprintf(partition_context, partition_context_size, "%s", (const char *)meta->partition_context);
+	snprintf(load_path, load_path_size, "%s", (const char *)meta->load_path);
+	return 0;
+}
+
 #define LOADER_ELF_MAGIC        0x464c457fU
 #define LOADER_PT_LOAD          1
 #define LOADER_PT_MIPS_REGINFO  0x70000000U
@@ -256,21 +290,12 @@ int main(int argc, char *argv[])
 
 	elfdata.epc = 0;
 
-	// argv[0]=partition context when present, argv[1]=load path,
-	// argv[2..]=arguments for the target ELF
-	if (argc < 2) {  
+	ret = read_embedded_loader_metadata(partition_context, sizeof(partition_context), load_path, sizeof(load_path));
+	if (ret != 0) {
 		SET_GS_BGCOLOUR(RED_BG);
-		return -EINVAL;
+		return ret;
 	}
-	strncpy(partition_context, argv[0] ? argv[0] : "", sizeof(partition_context) - 1);
-	partition_context[sizeof(partition_context) - 1] = '\0';
-	strncpy(load_path, argv[1] ? argv[1] : "", sizeof(load_path) - 1);
-	load_path[sizeof(load_path) - 1] = '\0';
-	if (load_path[0] == '\0') {
-		SET_GS_BGCOLOUR(RED_BG);
-		return -EINVAL;
-	}
-	target_argc = argc - 2;
+	target_argc = argc;
 	if (target_argc > 32) {
 		return -E2BIG;
 	}
@@ -281,13 +306,13 @@ int main(int argc, char *argv[])
 		target_argv[0] = default_target_arg0;
 		target_argc = 1;
 	} else {
-		for (i = 2; i < argc; i++) {
+		for (i = 0; i < argc; i++) {
 			size_t arg_len = strlen(argv[i]) + 1;
 			if ((target_arg_offset + arg_len) > sizeof(target_arg_storage)) {
 				return -E2BIG;
 			}
 			memcpy(&target_arg_storage[target_arg_offset], argv[i], arg_len);
-			target_argv[i - 2] = &target_arg_storage[target_arg_offset];
+			target_argv[i] = &target_arg_storage[target_arg_offset];
 			target_arg_offset += arg_len;
 		}
 	}


### PR DESCRIPTION
### Motivation
- Prevent the embedded loader from shifting the child program's `argv` by removing `partition_context`/`load_path` from the child `argv` and instead provide them via a separate control channel. 
- Preserve the target program's (POPSTARTER) normal launch argument layout so its selector remains at `argv[0]`. 
- Provide a guarded deterministic failure when the metadata channel is invalid to avoid launching with corrupted/shifted `argv`.

### Description
- Replaced the previous prepending of `partition_context` and `load_path` into the child's `argv` in `ExecuteViaEmbeddedLoader` with a BRAM-based metadata handoff at address `0x00083C00` using a new `EmbeddedLoaderMetadata` struct, populated by the caller before loader handoff. 
- Updated `ExecuteViaEmbeddedLoader` (`src/elf_loader/src/elf.c`) to populate the fixed metadata block and to pass only the original target args through unchanged (no two-slot offset). 
- Updated the embedded-loader consumer logic (`src/elf_loader/src/loader/src/loader.c`) to read and validate the metadata via `read_embedded_loader_metadata`, derive `partition_context`/`load_path` from that block, and use the incoming `argc/argv` as the target process args. 
- Added deterministic guarded fallbacks: the caller preflight returns `-6` when metadata preflight fails, and the embedded loader returns `-3302` when the runtime metadata validation fails; non-embedded and non-HDD launch paths were left untouched. 

### Testing
- Attempted to build the embedded loader with `make -C src/elf_loader/src/loader`, but the build failed in this environment due to a missing PS2SDK sample include (`/samples/Makefile.eeglobal`), so no EE binary could be produced here. 
- Performed static verification by running quick repository searches and inspecting diffs to ensure the caller and loader sides were updated consistently; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cb14af0883219c85e575c6aed46e)