### PR TITLE
Preserve System.loadELF argv contract for HDD reboot paths

### DIFF
--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -543,8 +543,7 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 
 	if (partition != NULL && partition[0] != '\0' &&
 	    is_hdd_backed_exec_path(partition) &&
-	    is_hdd_backed_exec_path(filename) &&
-	    argc > 0 && argv != NULL && argv[0] != NULL) {
+	    is_hdd_backed_exec_path(filename)) {
 		return ExecuteHddBackedViaEmbeddedLoader(filename, partition, argc, argv);
 	}
 
@@ -552,8 +551,7 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return -1;
 	}
 
-	if ((is_hdd_backed_exec_path(resolved_path) || is_hdd_backed_exec_path(partition)) &&
-	    argc > 0 && argv != NULL && argv[0] != NULL) {
+	if (is_hdd_backed_exec_path(resolved_path) || is_hdd_backed_exec_path(partition)) {
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -993,7 +993,6 @@ static int lua_loadELF(lua_State *L)
 		const char *maybe_partition = luaL_checkstring(L, argc);
 		if (is_partition_context_arg(maybe_partition)) {
 			partition_context = maybe_partition;
-			arg_end = argc - 1;
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Caller-visible argv was being mutated for reboot + partition-context launches because the trailing partition-context Lua argument was removed before forwarding, and HDD embedded-loader routing was gated on `argc/argv[0]` shape which could skip the embedded handoff; the change keeps the original caller argument contract intact. 
- The scope is limited to preserving argument forwarding semantics for reboot/HDD cases and avoiding implicit argv rewrites, without changing mount policy or broader runtime behavior.

### Description
- Stop removing the trailing partition-context argument in `lua_loadELF` by eliminating the `arg_end = argc - 1` rewrite so all caller args are forwarded unchanged. 
- Relaxed the guard in `LoadELFFromFileExecPS2RebootIOPWithPartition` so HDD-backed launches route through `ExecuteHddBackedViaEmbeddedLoader` whenever the filename or partition is HDD-backed, removing the extra `argc > 0 && argv != NULL && argv[0] != NULL` gating. 
- Kept all other launch, mount and embedded-loader logic unchanged to limit the change to argument-contract preservation.

### Testing
- Verified code locations and matches with repository searches using `rg` to find `System.loadELF` and related helpers and inspected the surrounding code with `sed`/`nl` to confirm the intended edits. 
- Confirmed the source diff contains only the two targeted condition changes in `src/luasystem.cpp` and `src/elf_loader/src/elf.c` and no unrelated file modifications. 
- No build or runtime regression tests were executed in this change; static inspections above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cdb9e01c83218bb1c390f2c9917a)