### PR TITLE
Add guarded pfs POPSTARTER launch fallback when partition context is unavailable

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3877,6 +3877,16 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   local popstarter_partition_context = ResolvePopstarterPartitionContext(configured_popstarter, popstarter)
   local popstarter_on_hdd = IsHddExecContextPath(popstarter)
   local popstarter_exec_path = popstarter
+  local use_pfs_exec_fallback_without_partition_context = false
+  local normalized_popstarter_exec = string.lower(tostring(popstarter or ""))
+  if popstarter_partition_context == nil
+    and string.match(normalized_popstarter_exec, "^pfs%d*:/") ~= nil
+    and popstarter_on_hdd
+  then
+    -- Controlled fallback: keep mounted pfsN:/ exec path and skip
+    -- partition-aware embedded-loader contract only for this explicit case.
+    use_pfs_exec_fallback_without_partition_context = true
+  end
   if popstarter_partition_context ~= nil and popstarter_partition_context ~= "" then
     local normalized_exec_path = BuildPartitionScopedExecPath(popstarter)
     if normalized_exec_path ~= nil then
@@ -4084,21 +4094,30 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
     exec_path = popstarter_exec_path,
     exec_partition_context = popstarter_partition_context
   }
+  if use_pfs_exec_fallback_without_partition_context then
+    context.launch_route = tostring(context.launch_route).."+pfs_exec_fallback_no_partition_context"
+  end
 
   if popstarter_on_hdd then
-    local gate_ok, gate_err = ValidateHddPopstarterExecGate(popstarter_exec_path, popstarter_partition_context)
-    if not gate_ok then
-      BlockLaunchFailure(
-        "POPSTARTER HDD pre-exec gate failed: "..tostring(gate_err or "unknown error"),
-        popstarter,
-        device_page,
-        nil,
-        vcd_basename_raw,
-        APP_DIR_LOCAL,
-        nil,
-        nil
-      )
-      return
+    local should_run_gate = true
+    if use_pfs_exec_fallback_without_partition_context then
+      should_run_gate = false
+    end
+    if should_run_gate then
+      local gate_ok, gate_err = ValidateHddPopstarterExecGate(popstarter_exec_path, popstarter_partition_context)
+      if not gate_ok then
+        BlockLaunchFailure(
+          "POPSTARTER HDD pre-exec gate failed: "..tostring(gate_err or "unknown error"),
+          popstarter,
+          device_page,
+          nil,
+          vcd_basename_raw,
+          APP_DIR_LOCAL,
+          nil,
+          nil
+        )
+        return
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation
- Provide a controlled fallback when POPSTARTER resolves to a `pfsN:/...` path but partition context resolution fails so already-mounted `pfsN:/` executables can still be attempted.
- Surface this fallback explicitly in launch diagnostics so the UI failure text shows the route used and does not silently mask root causes.
- Keep non-HDD pathing and selector formatting untouched while preventing the fallback from hiding unrelated failures with a single guard.

### Description
- Added a boolean guard `use_pfs_exec_fallback_without_partition_context` in `PLDR.RunPOPStarterGame` that is set only when `popstarter_partition_context == nil`, the POPSTARTER path matches `^pfs%d*:/`, and `popstarter_on_hdd` is true.
- When the guard is set, the code preserves the existing mounted `pfsN:/...` `exec_path` and skips the partition-aware pre-exec gate (`ValidateHddPopstarterExecGate`) for this specific case only.
- The code appends `+pfs_exec_fallback_no_partition_context` to `context.launch_route` so the failure UI shows that this fallback route was attempted.
- Change is localized to `bin/POPSLDR/system.lua` around the POPSTARTER exec-path/context preparation and the HDD pre-exec gate call site, and all other behavior is preserved.

### Testing
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/system.lua` but `luac` is not installed in this environment so the static check could not be run.
- No automated runtime tests were executed in this environment; recommend running the updated launch path through normal runtime validation and hardware checks (see `QA_REGRESSION_MATRIX.md`) to confirm behavior on target platforms.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e2235d0083219ae211b33dabc8ab)