### PR TITLE
Improve pfsN slot recovery and POPSTARTER HDD partition resolution

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -440,12 +440,44 @@ local function RecoverHddPartitionFromMountedPath(path, candidates)
   return nil, "mount_probe_failed"
 end
 
-local function BuildHddPartitionContext(path)
+local function BuildHddPartitionContext(path, recovery_candidates)
   local mount_part = ParseHddPartitionMount(path)
   if mount_part ~= nil then
     return mount_part..":", nil
   end
-  local mounted_part, mounted_reason = RecoverHddPartitionFromMountedPath(path)
+
+  local candidate = tostring(path or "")
+  local slot = ParsePfsSlot(candidate)
+  if slot ~= nil then
+    local relpath = string.gsub(candidate, "^pfs%d*:/", "")
+    if relpath == "" then
+      return nil, "slot_relpath_missing"
+    end
+
+    local entry = HDD_MOUNT_STATE.slots[slot]
+    if entry ~= nil and entry.partition ~= nil then
+      return ParseHddPartitionMount(entry.partition)..":", nil
+    end
+
+    local candidates = BuildPartitionRecoveryCandidates(recovery_candidates)
+    for i = 1, #candidates do
+      local part = ParseHddPartitionMount(candidates[i])
+      if part ~= nil then
+        local mount_ok, _ = MountHddPartitionTracked(part, slot, FIO_MT_RDONLY)
+        if mount_ok then
+          local probe_path = "pfs"..tostring(slot)..":/"..relpath
+          if ProbePathExists(probe_path) then
+            RememberRecordedHddMount(part, BuildMountedPfsPrefix(slot))
+            return part..":", nil
+          end
+        end
+      end
+    end
+
+    return nil, "slot_recovery_candidates_failed"
+  end
+
+  local mounted_part, mounted_reason = RecoverHddPartitionFromMountedPath(path, recovery_candidates)
   if mounted_part ~= nil then
     return mounted_part..":", nil
   end
@@ -1256,13 +1288,23 @@ local function ResolvePopstarterPartitionContext(path, resolved_path)
     end
   end
 
+  local recovery_candidates = BuildPartitionRecoveryCandidates({
+    PLDR and PLDR.POPS_GAME_PARTITION or nil,
+    PLDR and PLDR.GAME_PARTITION or nil,
+    configured,
+    resolved_path,
+    rawget(_G, "BOOT_HDD_MOUNTPART"),
+    rawget(_G, "BOOT_HDD_PARTITION"),
+    rawget(_G, "BOOT_PARTITION")
+  })
+
   if IsHddExecContextPath(configured) then
-    local part, _ = BuildHddPartitionContext(configured)
+    local part, _ = BuildHddPartitionContext(configured, recovery_candidates)
     return part
   end
 
   if IsHddExecContextPath(resolved_path) then
-    local part, _ = BuildHddPartitionContext(resolved_path)
+    local part, _ = BuildHddPartitionContext(resolved_path, recovery_candidates)
     return part
   end
 


### PR DESCRIPTION
### Motivation
- Resolve `pfsN:/...` exec paths when the runtime slot mapping is missing by attempting deterministic recovery candidates drawn from launch/game/config and boot globals. 
- Persist recovered slot→partition mappings so subsequent accesses succeed without repeated probing.

### Description
- Add slot-aware handling to `BuildHddPartitionContext(path, recovery_candidates)` to extract `N` from `pfsN:/...`, check `HDD_MOUNT_STATE.slots[N]`, and short-circuit when a mapping already exists. 
- When the slot is unmapped, build ordered recovery candidates and for each candidate parse the partition, mount it into slot `N` with `MountHddPartitionTracked(...)`, probe the exact `pfsN:/...` target via `ProbePathExists(...)`, and on first success call `RememberRecordedHddMount(...)` and return the `hdd0:PART:` context. 
- Introduce explicit failure reason codes (`slot_relpath_missing`, `slot_recovery_candidates_failed`) for clearer UI diagnostics. 
- Update `ResolvePopstarterPartitionContext(path, resolved_path)` to assemble deterministic recovery candidates (from `PLDR` launch/game partition fields, configured/resolved POPSTARTER paths, and boot HDD globals) and pass them into `BuildHddPartitionContext(...)` for both configured and resolved paths. 

### Testing
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/system.lua`, but the `luac` tool is not installed in this environment so the check could not be run. 
- Performed local static validation by inspecting the modified hunks and cross-checking symbol references in the file, and the local inspection found the changes consistent with existing APIs. 
- No runtime or hardware tests were executed in this environment (hardware-related behavior should be verified on target hardware and recorded in `QA_REGRESSION_MATRIX.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2fcf2e3e083218ce365e762026298)