### PR TITLE
Deterministic pfsN:/ slot recovery in BuildHddPartitionContext

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -447,8 +447,12 @@ local function BuildHddPartitionContext(path, recovery_candidates)
   end
 
   local candidate = tostring(path or "")
-  local slot = ParsePfsSlot(candidate)
-  if slot ~= nil then
+  if string.match(candidate, "^pfs%d*:/") ~= nil then
+    local slot = ParsePfsSlot(candidate)
+    if slot == nil then
+      return nil, "slot_unmapped"
+    end
+
     local relpath = string.gsub(candidate, "^pfs%d*:/", "")
     if relpath == "" then
       return nil, "slot_relpath_missing"
@@ -460,6 +464,7 @@ local function BuildHddPartitionContext(path, recovery_candidates)
     end
 
     local candidates = BuildPartitionRecoveryCandidates(recovery_candidates)
+
     for i = 1, #candidates do
       local part = ParseHddPartitionMount(candidates[i])
       if part ~= nil then
@@ -475,6 +480,11 @@ local function BuildHddPartitionContext(path, recovery_candidates)
     end
 
     return nil, "slot_recovery_candidates_failed"
+  end
+
+  local slot = ParsePfsSlot(candidate)
+  if slot ~= nil then
+    return nil, "slot_unmapped"
   end
 
   local mounted_part, mounted_reason = RecoverHddPartitionFromMountedPath(path, recovery_candidates)


### PR DESCRIPTION
### Motivation
- Resolve mounted POPSTARTER exec paths that use `pfsN:/` deterministically by mapping `pfs` slots to HDD partitions when the in-memory slot mapping is missing. 
- Provide a recovery path that tries known/boot/configured HDD partitions instead of failing early when a `pfsN:/...` path is encountered. 
- Persist successful slot-to-partition mappings so subsequent launches can mount deterministically without repeated probing.

### Description
- Add an explicit branch in `BuildHddPartitionContext(path, recovery_candidates)` that triggers when the input matches `^pfs%d*:/` and extract slot `N` via `ParsePfsSlot`. 
- Return `"slot_unmapped"` early if the path matches the `pfsN:/` pattern but `ParsePfsSlot` fails. 
- When no recorded mapping exists in `HDD_MOUNT_STATE.slots[N]`, build deterministic recovery candidates via `BuildPartitionRecoveryCandidates(...)`, mount each candidate to slot `N` with `MountHddPartitionTracked(...)`, probe the exact `pfsN:/...` relative path using `ProbePathExists(...)`, and on success call `RememberRecordedHddMount(...)` and return the partition as `hdd0:PART:` form. 
- Preserve prior fallback/failure semantics for non-`pfsN:/` inputs and only return `slot_recovery_candidates_failed` after exhausting all deterministic candidates.

### Testing
- Attempted a Lua syntax/load check with `lua -e 'assert(loadfile("bin/POPSLDR/system.lua"))'`, which failed because the `lua` binary is not installed in this environment, so no runtime/compile validation was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f321de068483219ea16bfe32473508)