### PR TITLE
Preserve original POPSTARTER PFS slot during external ELF launch

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -893,8 +893,12 @@ local function BuildPfsKeepMask(keep_slots)
   return mask
 end
 
-local function PrepareForExternalELFLaunch(path, extra_keep_slots, keep_slots_after_load)
+local function PrepareForExternalELFLaunch(path, extra_keep_slots, keep_slots_after_load, forced_keep_slot)
   local keep_slots = CollectHddKeepSlots(path, extra_keep_slots)
+  local forced_slot = tonumber(forced_keep_slot)
+  if forced_slot ~= nil and forced_slot >= 0 and forced_slot <= 3 then
+    keep_slots[forced_slot] = true
+  end
   local lowered_path = string.lower(tostring(path or ""))
   local is_hdd_exec_context = string.match(lowered_path, "^hdd%d:") ~= nil or string.match(lowered_path, "^pfs%d*:/") ~= nil
   if not is_hdd_exec_context then
@@ -903,6 +907,8 @@ local function PrepareForExternalELFLaunch(path, extra_keep_slots, keep_slots_af
   local postload_keep_slots = keep_slots_after_load
   if type(postload_keep_slots) ~= "table" then
     postload_keep_slots = keep_slots
+  elseif forced_slot ~= nil and forced_slot >= 0 and forced_slot <= 3 then
+    postload_keep_slots[forced_slot] = true
   end
   if type(System) == "table" and type(System.setExecKeepPfsMask) == "function" then
     pcall(System.setExecKeepPfsMask, BuildPfsKeepMask(postload_keep_slots))
@@ -3912,7 +3918,8 @@ local function LaunchEngine(popstarter, argv, reboot_iop, context)
     PrepareForExternalELFLaunch(
       popstarter,
       context and context.keep_hdd_slots or nil,
-      context and context.keep_hdd_slots_after_load or nil
+      context and context.keep_hdd_slots_after_load or nil,
+      context and context.exec_pfs_slot or nil
     )
   end
   local rc
@@ -4253,6 +4260,9 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
     end
   end
   local keep_slots = {}
+  if popstarter_original_slot == nil then
+    popstarter_original_slot = ExtractLaunchPfsSlot(popstarter_exec_path)
+  end
   if popstarter_keep_slot ~= nil then
     keep_slots[#keep_slots + 1] = popstarter_keep_slot
   end


### PR DESCRIPTION
### Motivation
- Prevent the original HDD/PFS slot used by a POPSTARTER exec path from being lost when path forms are normalized (for example `pfs3:/` → `pfs:/`) which can cause the exec keep-mask and unmount pass to drop the wrong slot.
- Ensure the resolved original POPSTARTER slot is recorded in the launch context and enforced during pre-exec preparation so the slot remains mounted through the handoff.
- Preserve existing behavior for non-HDD POPSTARTER launches while hardening HDD-based flows.

### Description
- Added a `forced_keep_slot` parameter to `PrepareForExternalELFLaunch(...)` and treat it as a numeric PFS slot to always include in the transient `keep_slots` set used for unmount decisions.
- Ensure the `forced_keep_slot` is also applied to the post-load keep set used to build the exec keep-mask (`System.setExecKeepPfsMask`).
- Pass `context.exec_pfs_slot` into `PrepareForExternalELFLaunch(...)` from the launch path so the preserved slot from the launch context is actually enforced during handoff preparation.
- Populate `popstarter_original_slot` as soon as `popstarter_exec_path` is resolved by extracting the launch PFS slot (`ExtractLaunchPfsSlot(popstarter_exec_path)`), and keep `context.exec_pfs_slot` set to that value.

### Testing
- Confirmed the source changes with `git diff -- bin/POPSLDR/system.lua` and verified the intended hunks were added and localized to `bin/POPSLDR/system.lua`.
- Committed the change successfully with `git commit` and inspected file regions using `nl -ba` to validate insertion points; the commit succeeded.
- Attempted a Lua bytecode syntax check with `luac -p bin/POPSLDR/system.lua` but `luac` is not available in this environment, so no runtime/build validation was run (runtime behavior should be verified on device as `Unknown (verify on hardware)`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32919764483218d2ebf06b6bdfb36)