### PR TITLE
elf_loader: enforce POPSTARTER argv[0] contract for HDD-backed embedded loader launches

### DIFF
--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -116,6 +116,10 @@ static bool is_hdd_backed_exec_path(const char *path) {
 	        (strncmp(path, "hdd", 3) == 0 || strncmp(path, "pfs", 3) == 0));
 }
 
+static bool has_valid_target_argv0(int argc, char *argv[]) {
+	return (argc > 0 && argv != NULL && argv[0] != NULL && argv[0][0] != '\0');
+}
+
 static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *load_path, int argc, char *argv[]);
 
 #define EMBEDDED_LOADER_METADATA_ADDR ((volatile struct EmbeddedLoaderMetadata *)0x00083C00)
@@ -291,6 +295,13 @@ static int ExecuteHddBackedViaEmbeddedLoader(const char *resolved_path, const ch
 	unsigned int required_keep_mask;
 	int ret;
 
+	/* POPSTARTER contract for HDD-backed launch: argv[0] must carry the
+	 * selector literal/path. Loader metadata is written separately.
+	 */
+	if (!has_valid_target_argv0(argc, argv)) {
+		return -7;
+	}
+
 	partition_context = partition_context_override;
 	if ((partition_context == NULL || partition_context[0] == '\0') &&
 	    resolved_path != NULL && strncmp(resolved_path, "hdd", 3) == 0) {
@@ -372,6 +383,10 @@ static int ExecuteViaEmbeddedLoader(const char *partition_context, const char *l
 		    meta->valid != 1 || meta->load_path[0] == '\0') {
 			return -6;
 		}
+	}
+
+	if (!has_valid_target_argv0(extra_argc, argv)) {
+		return -7;
 	}
 
 	for (i = 0; i < extra_argc; i++) {
@@ -493,7 +508,7 @@ int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[])
 	char resolved_path[256];
 	int ret;
 
-	if (argc <= 0 || argv == NULL || argv[0] == NULL) {
+	if (!has_valid_target_argv0(argc, argv)) {
 		return -4;
 	}
 	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {


### PR DESCRIPTION
### Motivation
- Preserve POPSTARTER selector semantics by ensuring the selector literal/path is present in `argv[0]` for HDD-backed embedded-loader handoffs and keep loader metadata (partition/load path) separate from target argv semantics.
- Add a defensive early-fail before `ExecPS2` when the POPSTARTER route is missing the required `argv[0]`, while keeping generic ELF launch behavior unchanged.

### Description
- Added `has_valid_target_argv0(int argc, char *argv[])` helper to centralize validation that `argc > 0`, `argv != NULL`, and `argv[0]` is non-empty.
- Enforced the POPSTARTER contract in `ExecuteHddBackedViaEmbeddedLoader()` by returning explicit `-7` if the required `argv[0]` is missing before performing any partition/load-path work.
- Added a defensive guard in `ExecuteViaEmbeddedLoader()` to abort with `-7` prior to the `ExecPS2` handoff when `argv[0]` is invalid, leaving `EmbeddedLoaderMetadata` usage unchanged and separate from the target argv.
- Updated `LoadELFFromFileExecPS2()` to use the same helper-check for consistency, without altering generic `LoadELFFromFileWithPartition`/`LoadExecPS2` semantics.

### Testing
- Performed source inspection and targeted repository checks using `rg`, `sed`, and `nl` to verify the call-path and applied changes, and these inspections succeeded.
- Ran a sanity check for tool availability via `gcc --version` and executed `git diff`/`git commit` to record the change, all of which completed successfully.
- No full compile/link or hardware execution was run in this rollout, so runtime behavior on device is `Unknown (verify on hardware)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32c5cc9bc8321b09e9fbfd8cd8167)