### PR TITLE
ci: add deterministic loader.c content verification

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -88,6 +88,14 @@ jobs:
             exit 1
           }
 
+          TMP_LOADER_C="$(mktemp)"
+          trap 'rm -f "$TMP_LOADER_C"' EXIT
+          "${PS2SDK}/bin/bin2c" src/loader/bin/loader.elf "$TMP_LOADER_C" loader_elf
+          if ! cmp -s "$TMP_LOADER_C" src/elf_loader/loader.c; then
+            echo "ERROR: src/elf_loader/loader.c content diverges from deterministic bin2c output of src/loader/bin/loader.elf" >&2
+            exit 1
+          fi
+
           require_marker "Exec path:" bin/enceladus.elf
           require_marker "PrepareForColdExternalELFLaunch" bin/enceladus.elf
           require_marker "BOOT.ELF launch failed" bin/enceladus.elf

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -88,11 +88,14 @@ jobs:
             exit 1
           }
 
+          LOADER_ELF="src/elf_loader/src/loader/bin/loader.elf"
+          [ -f "$LOADER_ELF" ] || { echo "ERROR: expected loader ELF missing at $LOADER_ELF" >&2; exit 1; }
+
           TMP_LOADER_C="$(mktemp)"
           trap 'rm -f "$TMP_LOADER_C"' EXIT
-          "${PS2SDK}/bin/bin2c" src/loader/bin/loader.elf "$TMP_LOADER_C" loader_elf
+          "${PS2SDK}/bin/bin2c" "$LOADER_ELF" "$TMP_LOADER_C" loader_elf
           if ! cmp -s "$TMP_LOADER_C" src/elf_loader/loader.c; then
-            echo "ERROR: src/elf_loader/loader.c content diverges from deterministic bin2c output of src/loader/bin/loader.elf" >&2
+            echo "ERROR: src/elf_loader/loader.c content diverges from deterministic bin2c output of $LOADER_ELF" >&2
             exit 1
           fi
 


### PR DESCRIPTION
### Motivation
- The existing timestamp-only freshness check can miss byte-level drift between the checked-in `src/elf_loader/loader.c` and the deterministic output produced from `src/loader/bin/loader.elf`, so add a bytewise verification to catch silent divergences.

### Description
- Preserve the existing timestamp assertion that verifies `src/elf_loader/loader.c` is newer than `src/elf_loader/src/loader/src/loader.c`.
- Regenerate `loader.c` into a temporary file using `"${PS2SDK}/bin/bin2c" src/loader/bin/loader.elf "$TMP_LOADER_C" loader_elf` with `TMP_LOADER_C="$(mktemp)"` and a `trap` to remove the temp file.
- Compare the regenerated output to `src/elf_loader/loader.c` with `cmp -s` and fail with a clear error message if the contents diverge.

### Testing
- Ran `git diff --check` which returned no warnings.
- Committed the change with `git commit -m "ci: verify loader.c content deterministically"` successfully; no CI build was run as part of this local change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f32d683b748321b975959791d72206)