### PR TITLE
Support mounted-pfs-fallback when POPSTARTER HDD partition context is unavailable

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -4076,6 +4076,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   local popstarter_keep_slot = popstarter_source_slot
   local popstarter_original_slot = popstarter_source_slot
   local use_pfs_exec_fallback_without_partition_context = false
+  local launch_route_pfs_fallback = "mounted-pfs-fallback"
   local normalized_popstarter_exec = string.lower(tostring(popstarter or ""))
   if popstarter_partition_context == nil
     and string.match(normalized_popstarter_exec, "^pfs%d*:/") ~= nil
@@ -4324,7 +4325,7 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
     source_pfs_slot = popstarter_source_slot
   }
   if use_pfs_exec_fallback_without_partition_context then
-    context.launch_route = tostring(context.launch_route).."+pfs_exec_fallback_no_partition_context"
+    context.launch_route = launch_route_pfs_fallback
   end
 
   if popstarter_on_hdd then


### PR DESCRIPTION
### Motivation
- Permit launching an explicitly mounted `pfsN:/...` POPSTARTER exec path when partition-context resolution fails, instead of hard-failing the HDD pre-exec gate, while keeping the gate strict for raw `hdd0:...` paths.
- Make the fallback visible in UI/debug output by exporting a distinct launch route label for hardware validation.

### Description
- Added a local route constant `launch_route_pfs_fallback = "mounted-pfs-fallback"` and wired it into the existing mounted-`pfsN:/` + missing-partition-context branch in `PLDR.RunPOPStarterGame` in `bin/POPSLDR/system.lua`.
- Replaced the previous appended debug suffix with the explicit route string by setting `context.launch_route = launch_route_pfs_fallback` when this fallback branch is taken.
- Preserved the HDD pre-exec gate for all non-fallback cases by keeping the `should_run_gate` logic unchanged so only the specific `pfsN:/` unresolved-partition branch bypasses the partition-aware contract.

### Testing
- Attempted repository-level syntax/load check with `lua -e 'assert(loadfile("bin/POPSLDR/system.lua"))'`, but the check failed to run due to the environment missing the `lua` binary (`/bin/bash: line 1: lua: command not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f331897b3c8321820e105aac1650b4)