### PR TITLE
Restrict PLDR.RunPOPStarterGame mounted-pfs fallback to HDD-derived launches

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -4096,10 +4096,20 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   local hdd_preexec_gate_mode = strict_hdd_preexec_gate and "strict-hard-fail" or "fallback-mounted-pfs"
   local launch_route_pfs_fallback = "mounted-pfs-fallback"
   local normalized_popstarter_exec = string.lower(tostring(popstarter or ""))
+  local normalized_game_location = string.lower(tostring(gamelocation or ""))
+  local is_hdd_device_route = policy.name == "HDD"
+  local popstarter_is_mounted_pfs_exec = string.match(normalized_popstarter_exec, "^pfs%d*:/") ~= nil
+  local selected_game_is_hdd_derived = is_hdd_device_route and (
+    (hdd_partition_label ~= nil and hdd_partition_label ~= "")
+    or string.match(normalized_game_location, "^pfs%d*:/") ~= nil
+    or string.match(normalized_game_location, "^hdd%d:") ~= nil
+  )
   if (not strict_hdd_preexec_gate)
     and popstarter_partition_context == nil
-    and string.match(normalized_popstarter_exec, "^pfs%d*:/") ~= nil
+    and popstarter_is_mounted_pfs_exec
     and popstarter_on_hdd
+    and is_hdd_device_route
+    and selected_game_is_hdd_derived
   then
     -- Controlled fallback: keep mounted pfsN:/ exec path and skip
     -- partition-aware embedded-loader contract only for this explicit case.


### PR DESCRIPTION
### Motivation
- Prevent the `mounted-pfs-fallback` from applying in unintended cases by ensuring it only triggers when the device route is HDD, the configured POPSTARTER exec is a mounted `pfsN:/...` path, and the selected game context is HDD-derived.
- Preserve existing non-HDD POPSTARTER flows (D-15) and startup auto-init paths (D-12/D-16) by narrowing the fallback gate rather than changing broader launch or init behavior.
- Leave reboot handling untouched for now to avoid altering boot/reboot semantics.

### Description
- Added `normalized_game_location`, `is_hdd_device_route`, `popstarter_is_mounted_pfs_exec`, and `selected_game_is_hdd_derived` local variables in `PLDR.RunPOPStarterGame` to capture the required predicates. 
- Tightened the fallback condition so `use_pfs_exec_fallback_without_partition_context` is set only when `(not strict_hdd_preexec_gate)` and `popstarter_partition_context == nil` and `popstarter` is a mounted `pfsN:/` exec on HDD and the launch `policy.name` is `HDD` and the selected game is HDD-derived. 
- Change is localized to `bin/POPSLDR/system.lua` and does not modify other launch, init, or reboot code paths.

### Testing
- Attempted a syntax check with `luac -p bin/POPSLDR/system.lua`, which was not run successfully in this environment due to `luac` not being available (failed).
- Verified the patch scope and content using `git diff -- bin/POPSLDR/system.lua` and line inspection commands, confirming only `bin/POPSLDR/system.lua` was modified and the conditional was tightened (succeeded).
- Created a commit with the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3331c80248321bede36481218f1ef)