### PR TITLE
Harden POPSTARTER default path handling for absolute custom device paths

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1318,13 +1318,36 @@ local function ResolveHddBootSidecarSourceContext()
   return nil
 end
 
+local function IsExplicitAbsoluteCustomPopstarterPath(path)
+  local candidate = string.lower(NormalizeFsPathRaw(tostring(path or "")))
+  if candidate == "" then
+    return false
+  end
+  if string.match(candidate, "^mc[01]:/") ~= nil then
+    return true
+  end
+  if string.match(candidate, "^mass%d*:/") ~= nil then
+    return true
+  end
+  if string.match(candidate, "^hdd%d:/") ~= nil then
+    return true
+  end
+  return string.match(candidate, "^hdd%d:[^:]+:[%a]+%d*:/") ~= nil
+end
+
 local function IsDefaultRelativePopstarterPath(path)
+  if IsExplicitAbsoluteCustomPopstarterPath(path) or IsAbsoluteDevicePath(path) then
+    return false
+  end
   local candidate = string.lower(string.gsub(tostring(path or ""), "\\", "/"))
   candidate = string.gsub(candidate, "^%./", "")
   return candidate == "" or candidate == "popstarter.elf"
 end
 
 local function IsLegacyDefaultPopstarterPath(path)
+  if IsExplicitAbsoluteCustomPopstarterPath(path) or IsAbsoluteDevicePath(path) then
+    return false
+  end
   local candidate = string.lower(NormalizeFsPathRaw(tostring(path or "")))
   return string.match(candidate, "^mass%d*:/pops/popstarter%.elf$") ~= nil
 end
@@ -1408,7 +1431,8 @@ end
 
 local function ResolvePopstarterPartitionContext(path, resolved_path, preferred_partition_label)
   local configured = tostring(path or "")
-  if IsDefaultRelativePopstarterPath(configured) or IsLegacyDefaultPopstarterPath(configured) then
+  local can_sidecar_source_fallback = (configured == "" or not IsAbsoluteDevicePath(configured)) and not IsExplicitAbsoluteCustomPopstarterPath(configured)
+  if can_sidecar_source_fallback and (IsDefaultRelativePopstarterPath(configured) or IsLegacyDefaultPopstarterPath(configured)) then
     local sidecar_source = ResolveHddBootSidecarSourceContext()
     if sidecar_source ~= nil then
       return sidecar_source


### PR DESCRIPTION
### Motivation
- Prevent absolute custom POPSTARTER paths (e.g. `mc0:/`, `mc1:/`, `mass:/`, `hdd0:/`) from being misclassified as default-relative and accidentally routed into HDD sidecar auto-discovery. 
- Avoid surprising behavior where an explicit absolute user configuration triggers fallback/auto-discovery logic intended only for default or relative values.

### Description
- Added `IsExplicitAbsoluteCustomPopstarterPath` to detect explicit absolute custom POPSTARTER device paths (`mc0:/`, `mc1:/`, `massN:/`, and `hdd`-style paths) in `bin/POPSLDR/system.lua`.
- Tightened `IsDefaultRelativePopstarterPath` and `IsLegacyDefaultPopstarterPath` to immediately return `false` when the input is an explicit absolute custom path or otherwise an absolute device path. 
- Updated `ResolvePopstarterPartitionContext` to gate HDD sidecar source auto-discovery behind a `can_sidecar_source_fallback` check so HDD sidecar lookup runs only for eligible non-absolute/default-like inputs. 
- Changes are localized to `bin/POPSLDR/system.lua` and are additive and reversible.

### Testing
- Inspected code paths and usages with `rg` and viewed modified hunks with `sed`/`nl`; these repository checks completed successfully. 
- Verified the working tree diff with `git diff` and created a commit via `git commit -m "Harden POPSTARTER default path checks for absolute custom paths"`, which succeeded. 
- No automated unit tests were run as part of this change. 
- Hardware/runtime behavior (HDD sidecar auto-discovery effects) was not executed on device and is `Unknown (verify on hardware)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33f6f224c832183f56c2fc0647a36)