### PR TITLE
Add explicit launch-failure reason codes for config and partition context

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3980,9 +3980,12 @@ local function BuildLaunchDiagnosticsLines(diag)
   local lines = {
     "Diag prf="..v(diag.selected_profile_id).." route="..v(diag.route).." src="..v(diag.source_pfs_slot),
     "Diag cfg="..v(diag.configured_path),
+    "Diag cfg_reason="..v(diag.configured_path_reason),
     "Diag eff="..v(diag.normalized_profile_selected_path),
+    "Diag eff_reason="..v(diag.normalized_profile_selected_path_reason),
     "Diag exec="..v(diag.final_resolved_exec_path),
-    "Diag partctx="..v(diag.derived_partition_context)
+    "Diag partctx="..v(diag.derived_partition_context),
+    "Diag part_reason="..v(diag.derived_partition_context_reason)
   }
   return table.concat(lines, "\n")
 end
@@ -4000,7 +4003,7 @@ local function BlockLaunchFailure(rc, popstarter, device_page, argv0, game_path,
     diag_block = "\n"..diag_lines
   end
   local body = string.format(
-    "LAUNCH RETURNED\nrc=%s\nDev:%s Prf:%s Rt:%s\nGate:%s Open:%s/%s\nPOP:%s\nCfg:%s\nEff:%s\nExec:%s\nAPP:%s\nArg0:%s\nGame:%s%s\nPress X/O to continue.",
+    "LAUNCH RETURNED\nrc=%s\nDev:%s Prf:%s Rt:%s\nGate:%s Open:%s/%s\nPOP:%s\nCfg:%s (%s)\nEff:%s (%s)\nExec:%s\nAPP:%s\nArg0:%s\nGame:%s%s\nPress X/O to continue.",
     tostring(rc),
     tostring(device_page),
     tostring(context and context.launch_diagnostics and context.launch_diagnostics.selected_profile_id or nil),
@@ -4010,7 +4013,9 @@ local function BlockLaunchFailure(rc, popstarter, device_page, argv0, game_path,
     tostring(open_api),
     tostring(popstarter),
     tostring(context and context.launch_diagnostics and context.launch_diagnostics.configured_path or nil),
+    tostring(context and context.launch_diagnostics and context.launch_diagnostics.configured_path_reason or nil),
     tostring(context and context.launch_diagnostics and context.launch_diagnostics.normalized_profile_selected_path or nil),
+    tostring(context and context.launch_diagnostics and context.launch_diagnostics.normalized_profile_selected_path_reason or nil),
     tostring(context and context.launch_diagnostics and context.launch_diagnostics.final_resolved_exec_path or display_exec_path),
     tostring(app_dir),
     tostring(argv0),
@@ -4255,16 +4260,21 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   end
   local selected_profile_id = tonumber(PLDR.SELECTED_PROFILE) or tonumber(PLDR.DEFAULT_PROFILE) or 1
   local persisted_popstarter_path = PLDR and PLDR.POPSTARTER_PATH or nil
+  local persisted_popstarter_path_reason = persisted_popstarter_path == nil and "cfg_nil" or nil
   local configured_popstarter = NormalizeSelectedProfilePopstarterPath(selected_profile_id, persisted_popstarter_path)
+  local configured_popstarter_reason = configured_popstarter == "" and "eff_nil" or nil
   local launch_diagnostics = {
     selected_profile_id = selected_profile_id,
     route = nil,
     persisted_popstarter_path = persisted_popstarter_path,
     normalized_profile_selected_path = configured_popstarter,
+    normalized_profile_selected_path_reason = configured_popstarter_reason,
     configured_path = persisted_popstarter_path,
+    configured_path_reason = persisted_popstarter_path_reason,
     effective_path = nil,
     final_resolved_exec_path = nil,
     derived_partition_context = nil,
+    derived_partition_context_reason = nil,
     source_pfs_slot = nil
   }
   local failure_context = {
@@ -4279,6 +4289,9 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   end
   if configured_partition_context ~= nil and configured_partition_context ~= "" then
     popstarter_partition_context = configured_partition_context
+  end
+  if popstarter_partition_context == nil and IsHddExecContextPath(popstarter) then
+    launch_diagnostics.derived_partition_context_reason = "partition_unresolved"
   end
   local popstarter_on_hdd = IsHddExecContextPath(popstarter)
   local popstarter_exec_path = popstarter
@@ -4517,6 +4530,9 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   end
   launch_diagnostics.final_resolved_exec_path = popstarter_exec_path
   launch_diagnostics.derived_partition_context = popstarter_partition_context
+  if popstarter_partition_context ~= nil and popstarter_partition_context ~= "" then
+    launch_diagnostics.derived_partition_context_reason = nil
+  end
   launch_diagnostics.source_pfs_slot = popstarter_source_slot
 
   local keep_slots = {}


### PR DESCRIPTION
### Motivation
- Improve failure diagnostics displayed on the launch-failure UI so operators can see why configured/effective POPSTARTER paths or HDD partition context are missing or unresolved. 
- Distinguish missing persisted config from an empty normalized effective path and explicitly mark unresolved HDD partition context for faster triage. 
- Preserve existing route/gate correlation (such as `fallback-mounted-pfs`) so existing logs and workflows remain useful.

### Description
- Added new diagnostic reason fields to `launch_diagnostics`: `configured_path_reason`, `normalized_profile_selected_path_reason`, and `derived_partition_context_reason` in `bin/POPSLDR/system.lua`.
- Emit discrete reason codes: `cfg_nil` when `PLDR.POPSTARTER_PATH` is `nil`, `eff_nil` when the normalized selected POPSTARTER resolves to empty, and `partition_unresolved` when an HDD exec context is detected but partition context could not be derived (set near `ResolvePopstarterPartitionContext`).
- Surface the new reason fields in the failure UI by extending `BuildLaunchDiagnosticsLines` to include `cfg_reason`, `eff_reason`, and `part_reason`, and update `BlockLaunchFailure` to print the `Cfg` and `Eff` values alongside their reason strings.
- Change is localized to `bin/POPSLDR/system.lua` and does not alter existing route/gate strings or fallback logic (e.g. `fallback-mounted-pfs`).

### Testing
- Ran a repository diff inspection with `git diff -- bin/POPSLDR/system.lua` to verify the localized changes, which succeeded and shows the inserted fields and format string updates. (succeeded)
- Attempted a Lua syntax check with `luac -p bin/POPSLDR/system.lua`, but `luac` is not available in this environment so syntax validation could not be performed here. (not run)
- Committed the changes and reviewed the resulting file excerpts via line-numbered prints to confirm inserted assignments and UI string formatting. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37f71e4148321b599e58bfe71abc2)