### PR TITLE
docs: resync BETA-12-PLAY source-truth audit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 # ARCHITECTURE
 
@@ -62,6 +62,10 @@ Last updated: 2026-03-29
 - `.github/workflows/compilation.yml` compiles in a `ps2dev/ps2dev` container and packages:
   - `PS1_POPSLOADER/*`
   - `POPS/PATCH_5.BIN`
+
+### 6) Repository automation
+- `.github/workflows/opencode.yml` runs comment-triggered AI assistance for issue and pull-request review comments.
+- It is outside the runtime boot/launch path and does not define build/package validation gates.
 
 ## Core Data Flows
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 # COMPONENTS
 
@@ -40,6 +40,10 @@ Current technical map of POPSLoader modules, ownership boundaries, and entry poi
 ### Build/package pipeline
 - `Makefile` builds and embeds the runtime.
 - `.github/workflows/compilation.yml` packages the release ZIP and verifies its exact contents.
+
+### Repository automation
+- `.github/workflows/opencode.yml` handles comment-triggered AI assistance.
+- It is not part of release packaging or runtime behavior.
 
 ## Runtime Functional Ownership
 
@@ -122,3 +126,5 @@ Current technical map of POPSLoader modules, ownership boundaries, and entry poi
 - Packaging/release issues:
   - `Makefile`
   - `.github/workflows/compilation.yml`
+- Repository automation issues:
+  - `.github/workflows/opencode.yml`

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 # DECISIONS
 
@@ -59,6 +59,12 @@ Each entry records:
 - Rationale: repeated experiment history had started drifting across the root docs and obscuring the actual current handoff state.
 - Implications: root docs should point to the matrix for detailed chronology instead of carrying their own competing mini-ledgers.
 - Evidence: repository documentation audit on 2026-03-29.
+
+### 2026-05-13 — Separate build/package CI from comment-triggered AI automation
+- Decision: treat `.github/workflows/compilation.yml` as the build/package validation source of truth, and document `.github/workflows/opencode.yml` separately as comment-triggered repository automation.
+- Rationale: the opencode workflow can affect repository collaboration but does not build artifacts, enforce the release ZIP contract, or prove runtime/hardware behavior.
+- Implications: source-truth audits should include both workflow files, while CI/package claims should continue to cite only the compilation workflow unless the automation contract changes.
+- Evidence: `.github/workflows/compilation.yml`, `.github/workflows/opencode.yml`.
 
 ## Open Investigations
 - HDD startup auto-init on HDD boot/configured paths:

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -1,6 +1,6 @@
 # POPSLoader Regression Matrix
 
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 Target line: current repository source
 
 ## Scope
@@ -16,11 +16,15 @@ This matrix tracks current behavior across:
 - cover art behavior,
 - exit handoff behavior,
 - currently unimplemented menu options (`HDD (exFAT)`, `SMB (v1)`),
-- release package validation gates.
+- release package validation gates,
+- repository automation workflows that are not runtime/hardware gates.
 
 This file is the authoritative detailed run ledger for CI and hardware outcomes. The other root docs should summarize the active state and point here for chronology.
 
 ## Automated CI Gates
+
+These gates are defined by `.github/workflows/compilation.yml`. The separate `.github/workflows/opencode.yml` workflow only runs comment-triggered AI assistance and is not a build, package, runtime, or hardware validation gate.
+
 | ID | Area | Source | Pass Criteria |
 |---|---|---|---|
 | CI-01 | Build | `.github/workflows/compilation.yml` | `make clean elfloader all` succeeds |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPSLoader
 
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 POPSLoader is a PlayStation 2 launcher for POPStarter, built on Enceladus runtime components and driven primarily by embedded Lua scripts.
 
@@ -9,7 +9,8 @@ This repository contains:
 - embedded runtime Lua and asset data,
 - embedded IOP modules,
 - the POPStarter packaging payload used by CI,
-- documentation for current code state and validation status.
+- documentation for current code state and validation status,
+- repository automation workflows for build/package CI and comment-triggered AI assistance.
 
 ## What This Repository Builds
 
@@ -32,6 +33,7 @@ POPS/
 
 That package contract is enforced by `.github/workflows/compilation.yml`.
 Current CI also verifies that the built `enceladus.elf` still contains the expected embedded Lua runtime markers and that the generated embedded-loader blob was regenerated before packaging.
+The separate `.github/workflows/opencode.yml` workflow is repository automation for comment-triggered AI assistance; it is not a build/package validation gate.
 
 ## Current Status At A Glance
 
@@ -147,7 +149,7 @@ Reported hardware issues currently being tracked are:
   - `hdd0:__common/POPS/ART/GAME.png`
 
 ### HDD (PFS) notes
-- HDD scan code currently looks for POPS game partitions in the configured POPS partition set (`__.POPS`, `__.POPS1` ...).
+- HDD scan code currently looks for POPS game partitions in the configured POPS partition set (`__.POPS`, `__.POPS0`, `__.POPS1` ... `__.POPS9`).
 - HDD dependency checks look for runtime files under `hdd0:__common/POPS/`.
 
 ## Build From Source
@@ -159,7 +161,7 @@ Use the same environment as CI:
 make clean elfloader all
 ```
 
-The workflow uses the `ps2dev/ps2dev` container and validates packaging after build.
+The build/package workflow uses the `ps2dev/ps2dev` container and validates packaging after build.
 
 ### Local build prerequisites
 - PS2 toolchain environment (`PS2DEV`, `PS2SDK`, gsKit/ports libs)

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 # STATE
 
@@ -37,7 +37,8 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
   - sidecar PNG next to the selected `.VCD`,
   - `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
 - Release packaging policy in CI is `PS1_POPSLOADER/*` + `POPS/PATCH_5.BIN` with strict manifest validation.
-- Current CI package also includes `PS1_POPSLOADER/BUILD_INFO.txt`, and the workflow fails if the built ELF is missing key embedded runtime markers or if the generated embedded-loader blob was not regenerated.
+- Current CI package also includes `PS1_POPSLOADER/BUILD_INFO.txt`, and the build/package workflow fails if the built ELF is missing key embedded runtime markers or if the generated embedded-loader blob was not regenerated.
+- Repository automation also includes `.github/workflows/opencode.yml`, a comment-triggered AI-assistance workflow; it is not part of the build/package validation contract.
 
 ## Main Menu Feature Status
 - `MMCE`: implemented in code.


### PR DESCRIPTION
### Motivation
- Keep repository source-truth docs synchronized with the current workflow surface and recorded source evidence, and explicitly separate build/package CI from comment-triggered repository automation. 
- Correct an out-of-date HDD POPS partition summary so docs match the runtime `PLDR.HDD.POPS_PARTITIONS` source list. 

### Description
- Documented the comment-triggered AI assistance workflow by adding notes about `.github/workflows/opencode.yml` and clarifying it is not a build/package validation gate in `README.md`, `QA_REGRESSION_MATRIX.md`, `ARCHITECTURE.md`, and `COMPONENTS.md`. 
- Added a decision entry `2026-05-13 — Separate build/package CI from comment-triggered AI automation` to `DECISIONS.md` explaining the rationale and implications. 
- Updated the HDD POPS partition summary in `README.md` to list `__.POPS`, `__.POPS0`..`__.POPS9` to match `bin/POPSLDR/system.lua`. 
- Minor wording syncs to emphasize that `.github/workflows/compilation.yml` remains the authoritative build/package CI gate and to update `Last updated:` timestamps. 
- Files changed: `README.md`, `STATE.md`, `QA_REGRESSION_MATRIX.md`, `ARCHITECTURE.md`, `COMPONENTS.md`, `DECISIONS.md` (docs-only change; no Lua/C/C++ runtime behavior modified). 

### Testing
- Ran `git diff --check` and committed the docs-only patch as `docs: resync BETA-12-PLAY source truth audit`, which produced the branch `docs/beta-12-play-source-truth-audit`. (succeeded) 
- Executed custom Python static audits that verified the CI package tree mentions (`PS1_POPSLOADER/BUILD_INFO.txt`, `POPS/PATCH_5.BIN`), presence of `opencode.yml` notes in `README.md` and `QA_REGRESSION_MATRIX.md`, and that the README HDD partition summary matches the in-repo `bin/POPSLDR/system.lua` evidence (all checks passed). 
- Verified changed files are UTF-8 text and contain no embedded NULs (passed). 
- Note: one environment `file` invocation was unavailable earlier; this did not block the docs audit and all Python checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043e2bf224832182494addfb5a963c)