### PR TITLE
Preserve custom POPSTARTER path commits

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -40,6 +40,11 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - Current CI package also includes `PS1_POPSLOADER/BUILD_INFO.txt`, and the build/package workflow fails if the built ELF is missing key embedded runtime markers or if the generated embedded-loader blob was not regenerated.
 - Repository automation also includes `.github/workflows/opencode.yml`, a comment-triggered AI-assistance workflow; it is not part of the build/package validation contract.
 
+## Potential Settings/Path Integrity Risks
+- Source-inferred: editing the POPSTARTER path from the Settings/Profile path editor marks the POPSTARTER selection as custom during the settings commit. The saved `mc0:/POPSTARTER/.pldrs` state should therefore contain `POPSTARTER_MODE=CUSTOM` and the edited `POPSTARTER_PATH`, rather than allowing profile-default normalization to discard the edited path.
+- Source-inferred: profile-default POPSTARTER mode still persists an empty `POPSTARTER_PATH` and relies on the selected profile's configured ELF path at load time.
+- Hardware verification: the POPSTARTER path-editor custom-mode save/load path is `Unknown (verify on hardware)` until a real memory-card `.pldrs` write and reboot/load cycle is recorded in `QA_REGRESSION_MATRIX.md`.
+
 ## Main Menu Feature Status
 - `MMCE`: implemented in code.
 - `MX4SIO`: implemented in code.

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2257,10 +2257,8 @@ local function EncodeSettings()
   local selected_profile = tonumber(PLDR.SELECTED_PROFILE) or 1
   local selection_mode = NormalizePopstarterSelectionMode(PLDR.POPSTARTER_SELECTION_MODE)
   local configured_popstarter = NormalizeSelectedProfilePopstarterPath(selected_profile, PLDR.POPSTARTER_PATH, selection_mode)
-  local profile_popstarter = GetProfilePopstarterPath(selected_profile)
   local persisted_popstarter = configured_popstarter
-  if selection_mode == POPSTARTER_MODE_PROFILE_DEFAULT or
-     (configured_popstarter ~= "" and NormalizeFsPathRaw(configured_popstarter) == NormalizeFsPathRaw(profile_popstarter)) then
+  if selection_mode == POPSTARTER_MODE_PROFILE_DEFAULT then
     persisted_popstarter = ""
   end
   local lines = {
@@ -2512,9 +2510,12 @@ function PLDR.CommitSettingsChanges(opts)
   if type(opts.prev_hide_text) == "boolean" then
     prev.hide_text = opts.prev_hide_text
   end
+  local next_profile = tonumber(opts.profile) or prev.profile
+  local next_popstarter_mode = NormalizePopstarterSelectionMode(opts.popstarter_mode or prev.popstarter_mode)
   local next_state = {
-    profile = tonumber(opts.profile) or prev.profile,
-    popstarter_path = NormalizeSelectedProfilePopstarterPath(tonumber(opts.profile) or prev.profile, opts.popstarter_path or prev.popstarter_path),
+    profile = next_profile,
+    popstarter_path = NormalizeSelectedProfilePopstarterPath(next_profile, opts.popstarter_path or prev.popstarter_path, next_popstarter_mode),
+    popstarter_mode = next_popstarter_mode,
     bdma_mode = NormalizeBdmaModeKey(opts.bdma_mode) or prev.bdma_mode,
     dkwdrv_path = opts.dkwdrv_path or prev.dkwdrv_path,
     video_standard = NormalizeVideoStandard(opts.video_standard or prev.video_standard),
@@ -2544,6 +2545,7 @@ function PLDR.CommitSettingsChanges(opts)
       ApplySettingsState({
         profile = next_state.profile,
         popstarter_path = next_state.popstarter_path,
+        popstarter_mode = next_state.popstarter_mode,
         bdma_mode = prev.bdma_mode,
         dkwdrv_path = next_state.dkwdrv_path,
         video_standard = next_state.video_standard

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2267,6 +2267,7 @@ UI = {
               return PLDR.CommitSettingsChanges({
                 profile = profile_index,
                 popstarter_path = pop_path,
+                popstarter_mode = (UI.PopPathDirty == true) and "CUSTOM" or nil,
                 dkwdrv_path = dkwdrv_path,
                 bdma_mode = mode_key,
                 video_standard = video_key,
@@ -2280,6 +2281,9 @@ UI = {
             end
 
             PLDR.SELECTED_PROFILE = profile_index
+            if UI.PopPathDirty == true then
+              PLDR.POPSTARTER_SELECTION_MODE = "CUSTOM"
+            end
             PLDR.POPSTARTER_PATH = pop_path
             PLDR.DKWDRV_PATH = dkwdrv_path
             PLDR.BDMA_MODE_KEY = mode_key


### PR DESCRIPTION
### Motivation
- Ensure that editing the POPSTARTER path from the Settings/Profile path editor is treated as an explicit custom selection so an edited path is not lost by profile-default normalization and the saved memory-card settings file records the explicit mode and path.
- Make the settings commit flow compute and preserve the POPSTARTER selection mode before path normalization so mode and path are committed together and preserved across BDMA rollback.
- Record the source-inferred behavior and hardware-verification gap so the team knows the save/load behavior is `Unknown (verify on hardware)` until a real `.pldrs` write/reboot cycle is observed.

### Description
- UI: when committing settings from `UI.ProfileQuery.Play` the UI now passes `popstarter_mode = (UI.PopPathDirty == true) and "CUSTOM" or nil` to `PLDR.CommitSettingsChanges`, and the legacy fallback also sets `PLDR.POPSTARTER_SELECTION_MODE = "CUSTOM"` when `UI.PopPathDirty` is true (file: `bin/POPSLDR/ui.lua`).
- System: `PLDR.CommitSettingsChanges` now computes `next_popstarter_mode` before normalizing the popstarter path, includes `popstarter_mode` in the `next_state`, and uses that mode when calling `NormalizeSelectedProfilePopstarterPath`; the BDMA-failure rollback path also restores `popstarter_mode` (file: `bin/POPSLDR/system.lua`).
- Encoding: `EncodeSettings` was simplified so only `PROFILE_DEFAULT` blanks the persisted `POPSTARTER_PATH`, ensuring custom mode preserves the configured path in the saved `mc0:/POPSTARTER/.pldrs` file (file: `bin/POPSLDR/system.lua`).
- Docs: added a `Potential Settings/Path Integrity Risks` section to `STATE.md` documenting the source-inferred behavior and marking hardware verification as `Unknown (verify on hardware)`.

### Testing
- Ran `git diff --check` and basic workspace diffs to ensure there were no obvious whitespace/errors; this succeeded.
- Ran targeted Python assertions that verify the UI insertion, `next_popstarter_mode` computation, mode preservation in `CommitSettingsChanges`, changes to `EncodeSettings`, and presence of the new `STATE.md` section; all assertions passed.
- Checked for Lua bytecode tooling with `command -v luac` and inspected `PS2SDK/PS2DEV` environment; `luac` was not available and `PS2SDK/PS2DEV` are unset so a full PS2 toolchain build was not attempted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04404cafc883219cf646090b015ace)