### PR TITLE
Document potential settings/path integrity risk for POPSTARTER saves

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-13
 
 # ROADMAP
 
@@ -11,7 +11,7 @@ Last updated: 2026-03-29
 - Current repo line uses the partition-aware HDD reboot contract, cold external-launch prep, separate exec-path reporting, and profile-path normalization while preserving the restored non-HDD POPSTARTER path.
 - The latest EE-side HDD direct-load workaround was reverted after it did not fix `D-10` and coincided with a reported HDD-game regression when POPSTARTER stayed on the non-HDD boot device.
 - `HDD (exFAT)` and `SMB (v1)` remain intentionally unimplemented menu entries.
-- Detailed experiment chronology lives in `QA_REGRESSION_MATRIX.md` and `DECISIONS.md`.
+- Detailed experiment chronology lives in `QA_REGRESSION_MATRIX.md` and `DECISIONS.md`; `STATE.md` also summarizes the source-inferred Settings/Profile POPSTARTER path save/load integrity risk as `Unknown (verify on hardware)` without attributing `D-10`, `D-14`, or `U-10` to it.
 
 ## Immediate Priorities
 

--- a/STATE.md
+++ b/STATE.md
@@ -41,9 +41,10 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - Repository automation also includes `.github/workflows/opencode.yml`, a comment-triggered AI-assistance workflow; it is not part of the build/package validation contract.
 
 ## Potential Settings/Path Integrity Risks
-- Source-inferred: editing the POPSTARTER path from the Settings/Profile path editor marks the POPSTARTER selection as custom during the settings commit. The saved `mc0:/POPSTARTER/.pldrs` state should therefore contain `POPSTARTER_MODE=CUSTOM` and the edited `POPSTARTER_PATH`, rather than allowing profile-default normalization to discard the edited path.
-- Source-inferred: profile-default POPSTARTER mode still persists an empty `POPSTARTER_PATH` and relies on the selected profile's configured ELF path at load time.
-- Hardware verification: the POPSTARTER path-editor custom-mode save/load path is `Unknown (verify on hardware)` until a real memory-card `.pldrs` write and reboot/load cycle is recorded in `QA_REGRESSION_MATRIX.md`.
+- Source-inferred: `bin/POPSLDR/ui.lua` stages the Settings/Profile POPSTARTER path editor draft, resolves it through the selected profile, and calls `PLDR.CommitSettingsChanges()` with `popstarter_mode = "CUSTOM"` only when `UI.PopPathDirty == true`; the local fallback save path also sets `PLDR.POPSTARTER_SELECTION_MODE = "CUSTOM"` before writing `PLDR.POPSTARTER_PATH`.
+- Source-inferred: `bin/POPSLDR/system.lua` `CommitSettingsChanges()` normalizes the incoming `popstarter_mode` with the previous mode as the fallback, applies the normalized state, and then `EncodeSettings()` persists `POPSTARTER_MODE=<mode>` plus `POPSTARTER_PATH=<path>`; when the normalized mode is profile-default, `EncodeSettings()` intentionally writes an empty `POPSTARTER_PATH` and relies on the selected profile path at load time.
+- Risk: if the UI dirty flag, selected-profile normalization, or `POPSTARTER_SELECTION_MODE` transition is wrong during a real settings save/load cycle, an edited POPSTARTER path could be persisted or reloaded differently than the user expects. This is source-inferred only and is `Unknown (verify on hardware)` until a memory-card `.pldrs` write plus reboot/load cycle is recorded in `QA_REGRESSION_MATRIX.md`.
+- Scope guard: this potential settings/path integrity risk is not claimed as the cause of `D-10`, `D-14`, or `U-10`; those remain tracked through the detailed hardware chronology in `QA_REGRESSION_MATRIX.md` and the decision notes in `DECISIONS.md`.
 
 ## Main Menu Feature Status
 - `MMCE`: implemented in code.


### PR DESCRIPTION
### Motivation
- Capture a source-inferred risk in the summary docs about how the Settings/Profile POPSTARTER path save/load flow could persist or normalize a path unexpectedly. 
- Surface the investigation scope (UI staging, settings commit, and encode/write behavior) for visibility while keeping experiment chronology in the detailed run ledger files.

### Description
- Add a `Potential Settings/Path Integrity Risks` summary in `STATE.md` describing `bin/POPSLDR/ui.lua` staging, `PLDR.CommitSettingsChanges()` normalization in `bin/POPSLDR/system.lua`, and how `EncodeSettings()` writes `POPSTARTER_MODE`/`POPSTARTER_PATH` (profile-default writes an empty path). 
- Record the resulting risk as `Unknown (verify on hardware)` and explicitly state this is not being claimed as the cause of `D-10`, `D-14`, or `U-10`. 
- Add a short cross-reference in `ROADMAP.md` (and update its date) pointing readers to `STATE.md` while keeping detailed chronology in `QA_REGRESSION_MATRIX.md` and `DECISIONS.md`.

### Testing
- Verified the documentation diff with `git diff --check` and inspected the changed fragments using `sed -n` to ensure the intended text replaced the previous block. 
- Confirmed the new `STATE.md` bullets and the `ROADMAP.md` cross-reference render in the file excerpts shown by the `sed` checks. 
- No unit or runtime tests were applicable because this is a docs-only change; hardware verification is explicitly marked `Unknown (verify on hardware)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0442c28a008321bcbe3975e2e19ab7)