### PR TITLE
ui.lua: honor reboot_iop in LaunchBootElf (U-10 candidate)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1323,7 +1323,14 @@ UI = {
         if hdd_loaded then
           reboot_iop = 1
         end
-        local rc = System.loadELF(elf_path, 0)
+        -- Pass the computed reboot_iop. Previously this was hard-coded to 0,
+        -- which silently discarded the HDD-aware conditional reboot logic
+        -- above and meant BOOT.ELF after HDD page init always went down the
+        -- non-reboot LoadExecPS2 path even though the surrounding code was
+        -- intentionally selecting a full IOP reset. wLaunchELF / BOOT.ELF
+        -- typically expects a clean IOP state when HDD has been used in the
+        -- current session, so honor the computed value here.
+        local rc = System.loadELF(elf_path, reboot_iop)
         UI.LAUNCHING = false
         UI.Notify("BOOT.ELF failed to launch\nreturn code: "..tostring(rc), 150, "error")
         return


### PR DESCRIPTION
## Summary
`LaunchBootElf` in `bin/POPSLDR/ui.lua` computed `reboot_iop` (1 when HDD runtime is loaded, 0 otherwise) but then hard-coded `0` into the `System.loadELF(elf_path, 0)` call. The conditional-reboot logic was effectively dead code -- BOOT.ELF always went down the non-reboot LoadExecPS2 path even when the surrounding code was intentionally selecting a full IOP reset.

`docs/HIGH_LEVEL_CODE_AUDIT.md` flagged this as the only remaining source defect in BOOT.ELF exit handling.

## What this changes for the HDD POPSTARTER flow
**Nothing.** D-10 / D-14 / D-15 launch path lives in `bin/POPSLDR/system.lua`'s `RunPOPStarterGame` / `LaunchEngine` and the embedded loader; this commit only touches the BOOT.ELF exit handler. The 2026-05-22 PASS results for D-10/D-14/D-15 are not affected.

## Hardware status
**U-10: Unknown (verify on hardware).** This makes the reboot-IOP route the launcher was always trying to invoke actually reachable, which is a new control to test. If U-10 still fails after this, the next investigation candidate is the non-HDD reboot-IOP branch in `src/elf_loader/src/elf.c` `LoadELFFromFileExecPS2RebootIOPWithPartition` (~line 600).

## Test plan
- [ ] CI build green.
- [ ] D-15 regression guard (USB POPSTARTER + HDD game) -- must still pass after this.
- [ ] D-10 regression guard (HDD POPSTARTER) -- must still pass after this.
- [ ] U-10: open HDD page so HDD runtime loads, return to main menu, choose Exit -> BOOT.ELF. Expected: BOOT.ELF launches cleanly. (Old behavior on this code path: black screen.)
- [ ] U-10 alt: cold boot, do not open HDD page, then Exit -> BOOT.ELF. `reboot_iop` should be 0 and behavior should match the historically working path. Expected: BOOT.ELF launches cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)