### PR TITLE
ui.lua: pass argv0 to BOOT.ELF on the reboot-IOP path (U-10 v2)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1323,14 +1323,26 @@ UI = {
         if hdd_loaded then
           reboot_iop = 1
         end
-        -- Pass the computed reboot_iop. Previously this was hard-coded to 0,
-        -- which silently discarded the HDD-aware conditional reboot logic
-        -- above and meant BOOT.ELF after HDD page init always went down the
-        -- non-reboot LoadExecPS2 path even though the surrounding code was
-        -- intentionally selecting a full IOP reset. wLaunchELF / BOOT.ELF
-        -- typically expects a clean IOP state when HDD has been used in the
-        -- current session, so honor the computed value here.
-        local rc = System.loadELF(elf_path, reboot_iop)
+        -- Routing rules below match what's actually wired in the C side:
+        --   * Non-reboot, no selector: System.loadELF(path, 0) lands in
+        --     LoadELFFromFile -> LoadELFFromFileWithPartition, which has
+        --     a hard-coded special case that routes mc?:/BOOT/BOOT.ELF
+        --     through the BRAM child loader with argv[0] = resolved_path.
+        --     This is the historically-working path for USB-boot exit.
+        --   * Reboot path: LoadELFFromFileExecPS2RebootIOPWithPartition
+        --     does NOT have the same special case, so we must supply
+        --     argv[0] explicitly. wLaunchELF reads argv[0] to determine
+        --     its own boot path; passing nothing results in argc=0/argv=NULL
+        --     at ExecPS2 and a black screen.
+        --   * Either way, the cwd we run in must NOT be a stale HDD mount;
+        --     PrepareForColdExternalELFLaunch above already unmounts every
+        --     tracked HDD slot when HDD was loaded.
+        local rc
+        if reboot_iop ~= 0 then
+          rc = System.loadELF(elf_path, reboot_iop, elf_path)
+        else
+          rc = System.loadELF(elf_path, 0)
+        end
         UI.LAUNCHING = false
         UI.Notify("BOOT.ELF failed to launch\nreturn code: "..tostring(rc), 150, "error")
         return


### PR DESCRIPTION
## Hardware report on previous attempt (PR #450)
User reported: USB boot -> Exit BOOT.ELF works ✓; HDD boot -> Exit BOOT.ELF still black-screens.

## Root cause identified
The non-reboot path `LoadELFFromFileWithPartition` has a hard-coded special case (src/elf_loader/src/elf.c lines 491-494) that routes `mc?:/BOOT/BOOT.ELF` through the BRAM child loader with `argv[0] = resolved_path`. That's the path USB-boot uses, and it works.

The reboot path `LoadELFFromFileExecPS2RebootIOPWithPartition` has **no equivalent special case**. So when my previous fix routed HDD-loaded BOOT.ELF through the reboot path, it landed in the standard `SifLoadElf -> SifIopReset -> reload MC -> ExecPS2(epc, gp, 0, NULL)` sequence. With `argv = NULL`, wLaunchELF can't read its boot path and black-screens.

## Fix
Conditionally pass `elf_path` as the selector argument so the reboot path has a valid argv[0]. Preserve the working 2-arg call for the no-reboot case (still falls through to the BRAM-child-loader special case).

```lua
if reboot_iop ~= 0 then
  rc = System.loadELF(elf_path, reboot_iop, elf_path)
else
  rc = System.loadELF(elf_path, 0)
end
```

## Test plan
- [ ] CI green.
- [ ] D-15 regression guard (USB POPSTARTER + HDD game).
- [ ] D-10 regression guard (HDD POPSTARTER + HDD game).
- [ ] **USB boot -> Exit -> BOOT.ELF** -- must still work (unchanged path).
- [ ] **HDD boot -> Exit -> BOOT.ELF** -- the actual target.
- [ ] **Boot from any device -> open HDD page -> back out -> Exit -> BOOT.ELF** -- HDD-loaded variant of the cold-boot HDD test.

## Out of scope
DKWDRV with custom HDD path black-screen is a separate issue. The DKWDRV V3 helper `extract_dkwdrv_pfs_path` in src/elf_loader/src/elf.c only matches `:pfs<digit>:` patterns; the typical user format is `hdd0:PART:pfs:/...` (no digit between `pfs` and `:`), which is not matched. That needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)