### PR TITLE
DKWDRV: handle :pfs: form + non-reboot path for HDD launches

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1238,7 +1238,22 @@ UI = {
           if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
             pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
           end
-          local rc = System.loadELF(elf_path, 1, elf_path)
+          -- Pick the launch route based on where DKWDRV.ELF lives.
+          --   * mc / non-HDD: reboot_iop=1 -- full IOP reset, reload
+          --     SIO2MAN/MCMAN/MCSERV, ExecPS2. DKWDRV runs on a clean IOP
+          --     and reads its config from MC, which is still accessible.
+          --   * HDD: reboot_iop=0 -- the non-reboot path uses the
+          --     PrepareForExternalELFLaunch keep mask (set above) so the
+          --     DKWDRV partition's PFS slot stays mounted across
+          --     unmount_pfs_slots_for_exec. The full IOP reset path would
+          --     wipe that mount before ExecPS2, leaving DKWDRV unable to
+          --     read its own config / BIOS image (the empirical
+          --     black-screen mode users hit when DKWDRV_PATH is on HDD).
+          local lower_elf = string.lower(tostring(elf_path or ""))
+          local is_hdd_path = string.find(lower_elf, "^hdd%d:") ~= nil
+            or string.find(lower_elf, "^pfs%d*:/") ~= nil
+          local dkwdrv_reboot_iop = is_hdd_path and 0 or 1
+          local rc = System.loadELF(elf_path, dkwdrv_reboot_iop, elf_path)
           if type(PLDR) == "table" and type(PLDR.RestoreWorkingDirectory) == "function" then
             pcall(PLDR.RestoreWorkingDirectory, previous_cwd)
           end

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -151,11 +151,24 @@ static const char *extract_dkwdrv_pfs_path(const char *path) {
 		    (p[1] == 'p' || p[1] == 'P') &&
 		    (p[2] == 'f' || p[2] == 'F') &&
 		    (p[3] == 's' || p[3] == 'S')) {
-			const char *digit = p + 4;
-			if (*digit >= '0' && *digit <= '9') {
-				if (digit[1] == ':') {
-					return p + 1;
-				}
+			const char *after_pfs = p + 4;
+			/* Match ":pfs<digit>:" -- partition-scoped paths that name an
+			 * explicit slot, e.g. "hdd0:+OPL:pfs0:/APPS/DKWDRV/DKWDRV.ELF".
+			 * Return the embedded "pfs<digit>:/..." segment.
+			 */
+			if (*after_pfs >= '0' && *after_pfs <= '9' && after_pfs[1] == ':') {
+				return p + 1;
+			}
+			/* Match ":pfs:" with no slot digit -- the typical user-typed
+			 * shape "hdd0:+OPL:pfs:/APPS/DKWDRV/DKWDRV.ELF" from the path
+			 * editor, which the original V3 helper did not match. Return
+			 * the embedded "pfs:/..." segment so resolve_exec_path can
+			 * attempt the open and the launch either succeeds via an
+			 * already-mounted slot 0 or fails cleanly with rc=-1 instead
+			 * of black-screening past ExecPS2 on an unresolved path.
+			 */
+			if (*after_pfs == ':') {
+				return p + 1;
 			}
 		}
 		p++;


### PR DESCRIPTION
## Summary
Two coordinated changes that complete the DKWDRV-from-HDD launch contract:

1. **`src/elf_loader/src/elf.c`** -- `extract_dkwdrv_pfs_path` now matches BOTH `:pfs<digit>:` (V3's original case) AND `:pfs:` without a slot digit (the typical user-typed shape from the path editor, e.g. `hdd0:+OPL:pfs:/APPS/DKWDRV/DKWDRV.ELF`).

2. **`bin/POPSLDR/ui.lua`** `OpenDKWDRV` -- route HDD-resident DKWDRV through `reboot_iop=0` (non-reboot path). The non-reboot path honors the keep mask that `PrepareForExternalELFLaunch` set, so the DKWDRV partition's PFS slot stays mounted across `unmount_pfs_slots_for_exec`. DKWDRV inherits the still-mounted IOP and can read its config / BIOS from its install location.

   For mc/non-HDD DKWDRV the route is unchanged: `reboot_iop=1` -- full IOP reset, reload SIO2MAN/MCMAN/MCSERV, DKWDRV reads from MC.

## Hardware status (2026-05-24)
- mc DKWDRV (default path): PASS. This PR does not change that route.
- HDD DKWDRV (custom path): FAIL (black screen) on previous artifact. This PR is the new control.

## Why this isn't a D-10/U-10 regression risk
- D-10 / D-14 / D-15 launches live in `RunPOPStarterGame` -> `LaunchEngine` (system.lua), not in `OpenDKWDRV`. Not touched.
- BOOT.ELF (`U-10`) lives in `LaunchBootElf`. Not touched.
- The reboot_iop conditional only fires when `elf_path` matches `^hdd%d:` or `^pfs%d*:/`. mc-resident DKWDRV keeps the existing reboot_iop=1.

## Test plan
- [ ] CI green.
- [ ] D-15 regression guard (USB POPSTARTER + HDD game).
- [ ] D-10 regression guard (HDD POPSTARTER + HDD game).
- [ ] U-10 regression guard (BOOT.ELF after HDD page init -- PR #451's fix).
- [ ] **DKWDRV from mc** (default path) -- must still work.
- [ ] **DKWDRV from HDD** (custom path, e.g. `hdd0:+OPL:pfs:/APPS/PS1_DKWDRV/DKWDRV.ELF`) -- the actual target. Should now read its files from the still-mounted partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)