### PR TITLE
Launch hygiene: fix wLaunchELF/DKWDRV-HDD/BOOT.ELF-HDD via fileXio teardown

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1717,6 +1717,25 @@ local function DetectBootDevice()
   if prefix == "host" then
     return "HOST", boot_path, prefix
   end
+  -- Additive device-kind prefix recognition (2026-05-25).
+  -- Some homebrew launchers pass semantic device-kind prefixes that
+  -- aren't real ps2sdk mount points. Recognize them so downstream
+  -- DEVLOCK / boot_device_label / Layer-C lazy IRX loading have the
+  -- correct classification. None of these match the existing branches
+  -- above, so the mx4sio mass: fix (classify_mass_boot) and every
+  -- other working detection stays untouched.
+  --   usb / usb0 / usb1 / ... -> USB
+  --   ata / ata0 / ata1 / ... -> HDD (ATA-backed)
+  --   apa / apa0 / apa1 / ... -> HDD (APA partition system)
+  if string.match(prefix, "^usb%d*$") then
+    return "USB", boot_path, prefix
+  end
+  if string.match(prefix, "^ata%d*$") then
+    return "HDD", boot_path, prefix
+  end
+  if string.match(prefix, "^apa%d*$") then
+    return "HDD", boot_path, prefix
+  end
   return nil, boot_path, prefix
 end
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1672,9 +1672,37 @@ function PLDR.RestoreWorkingDirectory(path)
   return RestoreWorkingDirectory(path)
 end
 
-local function DetectBootDevice()
+-- Single source of truth for "where did POPSLoader come from?". Combines
+-- the C-side argv[0] classification hint (computed pre-IRX in main.cpp
+-- detectBootDeviceHintFromArgv0) with Lua-side refinement (the mx4sio
+-- mass:/ disambiguation via BDM driver lookup, plus the additive
+-- usb/ata/apa SDK prefix recognition).
+--
+-- Returns a table:
+--   kind         -- "USB"/"HDD"/"MC"/"MMCE"/"MX4SIO"/"SMB"/"HOST" or nil
+--   prefix       -- raw argv prefix (e.g. "mass0", "hdd0"), or nil
+--   boot_path    -- normalized BOOT_PATH_RAW (with trailing slash)
+--   sidecar_path -- per-device .pldrs path if appropriate, else nil
+--   c_hint       -- pre-IRX C-side classification (debug / fallback)
+--
+-- Robust to bad/missing argv: empty boot_path, nil prefix/kind, nil
+-- sidecar_path -- all callers degrade gracefully (settings -> MC,
+-- DetectBootDevice -> nil kind, UI -> default page).
+--
+-- Cheap enough to call per-invocation; classify_mass_boot's RPC is the
+-- only non-trivial cost and is only hit when prefix matches "mass%d*".
+local function ResolveBootContext()
   local boot_path = NormalizeDirPath(BOOT_PATH_RAW or "")
   local prefix = string.match(boot_path, "^([%a]+%d*):")
+
+  local c_hint = ""
+  if type(System) == "table" and type(System.getBootDeviceHint) == "function" then
+    local ok, hint = pcall(System.getBootDeviceHint)
+    if ok and type(hint) == "string" then
+      c_hint = hint
+    end
+  end
+
   local function classify_mass_boot(root)
     if type(System) == "table" and type(System.getMassMountDriver) == "function" then
       local ok, driver = pcall(System.getMassMountDriver, root)
@@ -1686,57 +1714,94 @@ local function DetectBootDevice()
         return "USB"
       end
     end
-    local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
-    local usb_marker = JoinPath(APP_DIR_LOCAL, ".boot_usb")
-    if doesFileExist(mx_marker) then
-      return "MX4SIO"
-    end
-    if doesFileExist(usb_marker) then
-      return "USB"
+    if type(APP_DIR_LOCAL) == "string" and APP_DIR_LOCAL ~= "" then
+      local mx_marker = JoinPath(APP_DIR_LOCAL, ".boot_mx4sio")
+      local usb_marker = JoinPath(APP_DIR_LOCAL, ".boot_usb")
+      if doesFileExist(mx_marker) then
+        return "MX4SIO"
+      end
+      if doesFileExist(usb_marker) then
+        return "USB"
+      end
     end
     return "USB"
   end
-  if prefix == nil then
-    return nil, boot_path, prefix
+
+  -- Lua-side prefix classification. Order preserves the historical
+  -- DetectBootDevice precedence (mmce/mx4sio/mass/pfs|hdd/smb/host
+  -- first; usb/ata/apa SDK additions below them so existing behavior
+  -- never changes for the legacy prefixes).
+  local kind = nil
+  if prefix ~= nil then
+    if string.match(prefix, "^mmce%d*$") then
+      kind = "MMCE"
+    elseif string.match(prefix, "^mx4sio%d*$") then
+      kind = "MX4SIO"
+    elseif string.match(prefix, "^mass%d*$") then
+      kind = classify_mass_boot(prefix..":/")
+    elseif string.match(prefix, "^pfs%d*$") or string.match(prefix, "^hdd%d*$") then
+      kind = "HDD"
+    elseif prefix == "smb" then
+      kind = "SMB"
+    elseif prefix == "host" then
+      kind = "HOST"
+    elseif string.match(prefix, "^usb%d*$") then
+      kind = "USB"
+    elseif string.match(prefix, "^ata%d*$") then
+      kind = "HDD"
+    elseif string.match(prefix, "^apa%d*$") then
+      kind = "HDD"
+    end
   end
-  if string.match(prefix, "^mmce%d*$") then
-    return "MMCE", boot_path, prefix
+
+  -- Fallback to C-side hint if Lua-side prefix classification yielded
+  -- nothing (e.g. boot_path is empty because argv[0] was NULL/garbage
+  -- but C saw enough to classify).
+  if kind == nil and c_hint ~= "" then
+    kind = c_hint
   end
-  if string.match(prefix, "^mx4sio%d*$") then
-    return "MX4SIO", boot_path, prefix
+
+  -- Settings sidecar path: APP_DIR_LOCAL/.pldrs when on a non-HDD
+  -- device. HDD-backed APP_DIR returns nil here so settings fall back
+  -- to mc0:/POPSTARTER/.pldrs (avoids PFS RW remount complexity).
+  local sidecar = nil
+  if type(APP_DIR_LOCAL) == "string" and APP_DIR_LOCAL ~= "" then
+    local lower = string.lower(APP_DIR_LOCAL)
+    local is_hdd_backed = string.match(lower, "^hdd%d*:") ~= nil
+       or string.match(lower, "^pfs%d*:") ~= nil
+       or string.match(lower, "^ata%d*:") ~= nil
+       or string.match(lower, "^apa%d*:") ~= nil
+    if not is_hdd_backed then
+      sidecar = JoinPath(APP_DIR_LOCAL, ".pldrs")
+    end
   end
-  if string.match(prefix, "^mass%d*$") then
-    return classify_mass_boot(prefix..":/"), boot_path, prefix
-  end
-  if string.match(prefix, "^pfs%d*$") or string.match(prefix, "^hdd%d*$") then
-    return "HDD", boot_path, prefix
-  end
-  if prefix == "smb" then
-    return "SMB", boot_path, prefix
-  end
-  if prefix == "host" then
-    return "HOST", boot_path, prefix
-  end
-  -- Additive device-kind prefix recognition (2026-05-25).
-  -- Some homebrew launchers pass semantic device-kind prefixes that
-  -- aren't real ps2sdk mount points. Recognize them so downstream
-  -- DEVLOCK / boot_device_label / Layer-C lazy IRX loading have the
-  -- correct classification. None of these match the existing branches
-  -- above, so the mx4sio mass: fix (classify_mass_boot) and every
-  -- other working detection stays untouched.
-  --   usb / usb0 / usb1 / ... -> USB
-  --   ata / ata0 / ata1 / ... -> HDD (ATA-backed)
-  --   apa / apa0 / apa1 / ... -> HDD (APA partition system)
-  if string.match(prefix, "^usb%d*$") then
-    return "USB", boot_path, prefix
-  end
-  if string.match(prefix, "^ata%d*$") then
-    return "HDD", boot_path, prefix
-  end
-  if string.match(prefix, "^apa%d*$") then
-    return "HDD", boot_path, prefix
-  end
-  return nil, boot_path, prefix
+
+  return {
+    kind = kind,
+    prefix = prefix,
+    boot_path = boot_path,
+    sidecar_path = sidecar,
+    c_hint = c_hint,
+  }
+end
+
+-- DetectBootDevice keeps its historical signature; thin wrapper around
+-- ResolveBootContext so the call sites scattered through system.lua and
+-- ui.lua continue to work unchanged.
+local function DetectBootDevice()
+  local ctx = ResolveBootContext()
+  return ctx.kind, ctx.boot_path, ctx.prefix
+end
+
+-- Public APIs for callers that want the full boot context (UI, future
+-- lazy-IRX consumers, telemetry, etc.) without having to glue three
+-- separate detection paths together.
+function PLDR.GetBootContext()
+  return ResolveBootContext()
+end
+
+function PLDR.GetBootKind()
+  return ResolveBootContext().kind
 end
 
 local function LoadIrxFromDir(dir)
@@ -1871,7 +1936,6 @@ PLDR.LAUNCH_ARGS = PLDR.LAUNCH_ARGS or {
   page = nil,
   page_raw = nil,
   game = nil,
-  noaudio = false,
   debug = false,
 }
 if type(System) == "table" and type(System.getLaunchArgs) == "function" then
@@ -1886,7 +1950,6 @@ if type(System) == "table" and type(System.getLaunchArgs) == "function" then
     if game_raw ~= "" then
       PLDR.LAUNCH_ARGS.game = game_raw
     end
-    PLDR.LAUNCH_ARGS.noaudio = (args.noaudio == true)
     PLDR.LAUNCH_ARGS.debug = (args.debug == true)
   end
 end
@@ -2051,31 +2114,17 @@ PLDR.POPSTARTER_DIR = "mc0:/POPSTARTER"
 -- for first-run migration AND for HDD-backed boots (where writing into
 -- the PFS partition would require an RW remount).
 --
+-- The sidecar path comes from the unified boot-context resolver above
+-- (ResolveBootContext().sidecar_path), so settings/IRX/UI navigation
+-- all derive from the same argv[0]-rooted detection pipeline.
+--
 -- The actual PLDR.SETTINGS_PATH is decided at load time in
 -- LoadSettingsNonFatal: whichever path's settings file is opened first
 -- becomes the path subsequent saves use, so saves go back where loads
 -- came from. If neither file exists yet, sidecar wins (or fallback if
 -- no sidecar is computable, e.g. HDD-backed APP_DIR).
 PLDR.SETTINGS_PATH_FALLBACK = "mc0:/POPSTARTER/.pldrs"
-
-local function ComputeSettingsSidecarPath()
-  local dir = APP_DIR_LOCAL
-  if type(dir) ~= "string" or dir == "" then
-    return nil
-  end
-  -- HDD-backed APP_DIR means the PFS partition would need RW; avoid the
-  -- mount complexity and let HDD installs keep using mc0 sidecar.
-  local lower = string.lower(dir)
-  if string.match(lower, "^hdd%d*:") ~= nil
-     or string.match(lower, "^pfs%d*:") ~= nil
-     or string.match(lower, "^ata%d*:") ~= nil
-     or string.match(lower, "^apa%d*:") ~= nil then
-    return nil
-  end
-  return JoinPath(dir, ".pldrs")
-end
-
-PLDR.SETTINGS_PATH_SIDECAR = ComputeSettingsSidecarPath()
+PLDR.SETTINGS_PATH_SIDECAR = ResolveBootContext().sidecar_path
 PLDR.SETTINGS_PATH = PLDR.SETTINGS_PATH_SIDECAR or PLDR.SETTINGS_PATH_FALLBACK
 PLDR.BDMA_MODE_KEY = "FAT32"
 PLDR.SELECTED_PROFILE = tonumber(PLDR.DEFAULT_PROFILE) or 1

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1834,6 +1834,63 @@ if type(PLDR.HDD.POPS_PARTITIONS) ~= "table" or #PLDR.HDD.POPS_PARTITIONS < 1 th
 end
 PLDR.HDD.GAMEPARTS = PLDR.HDD.GAMEPARTS or {}
 
+-- Launch arguments (NHDDL-style) parsed in main.cpp parseLaunchArgs().
+-- Exposed via System.getLaunchArgs() and normalized here into a single
+-- PLDR.LAUNCH_ARGS table. Downstream code (UI navigation, IRX deferral)
+-- can read this to auto-route the boot.
+local function NormalizeLaunchPage(value)
+  if type(value) ~= "string" or value == "" then
+    return nil
+  end
+  local key = string.lower(value)
+  if key == "hdd" or key == "ata" or key == "pfs" or key == "apa" then
+    return "HDD"
+  end
+  if key == "usb" or key == "mass" then
+    return "USB"
+  end
+  if key == "mc" or key == "memcard" then
+    return "MC"
+  end
+  if key == "mmce" then
+    return "MMCE"
+  end
+  if key == "mx4sio" or key == "mx4" or key == "sdc" then
+    return "MX4SIO"
+  end
+  if key == "smb" then
+    return "SMB"
+  end
+  if key == "bdma" then
+    return "BDMA"
+  end
+  return nil
+end
+
+PLDR.LAUNCH_ARGS = PLDR.LAUNCH_ARGS or {
+  page = nil,
+  page_raw = nil,
+  game = nil,
+  noaudio = false,
+  debug = false,
+}
+if type(System) == "table" and type(System.getLaunchArgs) == "function" then
+  local ok, args = pcall(System.getLaunchArgs)
+  if ok and type(args) == "table" then
+    local page_raw = tostring(args.page or "")
+    if page_raw ~= "" then
+      PLDR.LAUNCH_ARGS.page_raw = page_raw
+      PLDR.LAUNCH_ARGS.page = NormalizeLaunchPage(page_raw)
+    end
+    local game_raw = tostring(args.game or "")
+    if game_raw ~= "" then
+      PLDR.LAUNCH_ARGS.game = game_raw
+    end
+    PLDR.LAUNCH_ARGS.noaudio = (args.noaudio == true)
+    PLDR.LAUNCH_ARGS.debug = (args.debug == true)
+  end
+end
+
 PLDR.VIDEO_STANDARD_NTSC = "NTSC"
 PLDR.VIDEO_STANDARD_PAL = "PAL"
 PLDR.KEYBOARD_LAYOUT_ABC = "ABC"
@@ -1987,7 +2044,39 @@ end
 require("images")
 
 PLDR.POPSTARTER_DIR = "mc0:/POPSTARTER"
-PLDR.SETTINGS_PATH = "mc0:/POPSTARTER/.pldrs"
+
+-- Settings path resolution: prefer a per-device sidecar at
+-- APP_DIR_LOCAL/.pldrs so a POPSLoader installed on USB / MX4SIO / MMCE
+-- keeps its own settings. Fall back to the legacy mc0:/POPSTARTER/.pldrs
+-- for first-run migration AND for HDD-backed boots (where writing into
+-- the PFS partition would require an RW remount).
+--
+-- The actual PLDR.SETTINGS_PATH is decided at load time in
+-- LoadSettingsNonFatal: whichever path's settings file is opened first
+-- becomes the path subsequent saves use, so saves go back where loads
+-- came from. If neither file exists yet, sidecar wins (or fallback if
+-- no sidecar is computable, e.g. HDD-backed APP_DIR).
+PLDR.SETTINGS_PATH_FALLBACK = "mc0:/POPSTARTER/.pldrs"
+
+local function ComputeSettingsSidecarPath()
+  local dir = APP_DIR_LOCAL
+  if type(dir) ~= "string" or dir == "" then
+    return nil
+  end
+  -- HDD-backed APP_DIR means the PFS partition would need RW; avoid the
+  -- mount complexity and let HDD installs keep using mc0 sidecar.
+  local lower = string.lower(dir)
+  if string.match(lower, "^hdd%d*:") ~= nil
+     or string.match(lower, "^pfs%d*:") ~= nil
+     or string.match(lower, "^ata%d*:") ~= nil
+     or string.match(lower, "^apa%d*:") ~= nil then
+    return nil
+  end
+  return JoinPath(dir, ".pldrs")
+end
+
+PLDR.SETTINGS_PATH_SIDECAR = ComputeSettingsSidecarPath()
+PLDR.SETTINGS_PATH = PLDR.SETTINGS_PATH_SIDECAR or PLDR.SETTINGS_PATH_FALLBACK
 PLDR.BDMA_MODE_KEY = "FAT32"
 PLDR.SELECTED_PROFILE = tonumber(PLDR.DEFAULT_PROFILE) or 1
 PLDR.DKWDRV_DEFAULT_PATH = "mc0:/PS1_DKWDRV/DKWDRV.ELF"
@@ -2490,14 +2579,22 @@ function PLDR.ReconcileBdmaModeWithEffectiveState()
 end
 
 function PLDR.SaveSettingsAtomic()
-  if not PLDR.EnsurePopstarterDir() then
+  local target = PLDR.SETTINGS_PATH or PLDR.SETTINGS_PATH_FALLBACK
+  local target_is_mc = (target == PLDR.SETTINGS_PATH_FALLBACK)
+  -- Always best-effort the MC POPSTARTER pack dir so the BDMA OSD icon
+  -- assets remain valid regardless of where settings actually live.
+  local mc_dir_ok = PLDR.EnsurePopstarterDir()
+  -- Only treat the MC pack failure as fatal when our target IS the MC
+  -- fallback. Per-device sidecar saves (mass:/.pldrs, usb:/.pldrs, etc.)
+  -- don't depend on mc0:/POPSTARTER existing.
+  if target_is_mc and not mc_dir_ok then
     if UI ~= nil and UI.Notif_queue ~= nil then
       UI.Notif_queue.add("Cannot access mc0:/POPSTARTER")
     end
     return false
   end
   local data = EncodeSettings()
-  local ok = WriteAtomic(PLDR.SETTINGS_PATH, data)
+  local ok = WriteAtomic(target, data)
   if not ok and UI ~= nil and UI.Notif_queue ~= nil then
     UI.Notif_queue.add("Failed to save settings")
   end
@@ -2524,11 +2621,27 @@ function PLDR.LoadSettingsNonFatal()
   if PLDR.PROFILES ~= nil and PLDR.PROFILES[defaults_profile] ~= nil then
     PLDR.POPSTARTER_PATH = PLDR.PROFILES[defaults_profile].ELF
   end
-  if not doesFileExist(PLDR.SETTINGS_PATH) then
+  -- Resolve actual settings source: prefer per-device sidecar
+  -- (APP_DIR/.pldrs), fall back to legacy mc0:/POPSTARTER/.pldrs.
+  -- Whichever file is found first wins -- PLDR.SETTINGS_PATH is then
+  -- pinned to that path so subsequent saves go to the same place.
+  local sidecar = PLDR.SETTINGS_PATH_SIDECAR
+  local fallback = PLDR.SETTINGS_PATH_FALLBACK
+  local loaded_path = nil
+  if sidecar ~= nil and sidecar ~= "" and doesFileExist(sidecar) then
+    loaded_path = sidecar
+  elseif fallback ~= nil and fallback ~= "" and doesFileExist(fallback) then
+    loaded_path = fallback
+  end
+  if loaded_path == nil then
+    -- No settings yet on either path. Leave PLDR.SETTINGS_PATH at its
+    -- init default (sidecar preferred, fallback if no sidecar) so the
+    -- first save lands on the right device.
     PLDR.ReconcileBdmaModeWithEffectiveState()
     PLDR.ApplyVideoStandardRuntime(PLDR.VIDEO_STANDARD)
     return false
   end
+  PLDR.SETTINGS_PATH = loaded_path
   local data = ReadWholeFile(PLDR.SETTINGS_PATH)
   if data == nil then
     PLDR.ReconcileBdmaModeWithEffectiveState()

--- a/docs/LAUNCH_HYGIENE.md
+++ b/docs/LAUNCH_HYGIENE.md
@@ -1,0 +1,115 @@
+# POPSLoader Launch Hygiene
+
+Date: 2026-05-25
+Author: Claude (with NathanNeurotic direction; user thesis on hang/deinit problem confirmed)
+
+## TL;DR
+
+Four launch-related symptoms reported across recent hardware testing share a
+single root cause: **POPSLoader does not survive an IOP that has `fileXio`
+loaded from a parent process**. The `fileXio` IRX module holds threads and RPC
+locks on the IOP that cause `SifIopReset` to hang silently. This bug is
+documented upstream in [ps2sdk issue #425](https://github.com/ps2dev/ps2sdk/issues/425)
+and partly addressed by [ps2sdk PR #426](https://github.com/ps2dev/ps2sdk/pull/426).
+The fix family in this document covers the EE-side workaround (detach the RPC
+client before resetting) and the resulting unification of three previously
+unrelated-looking bugs.
+
+## Symptoms
+
+| Symptom | Reporter | Root cause |
+|---|---|---|
+| Launching POPSLoader from wLaunchELF black-screens (only for non-HDD targets) | CosmicScale 2026-05-25 | `_ps2sdk_memory_init` hangs on `SifIopReset` because wLaunchELF left `fileXio` loaded |
+| DKWDRV from a custom HDD path black-screens | Nuno 2026-05-25 | Child loader's `SifIopReset` hangs because POPSLoader's `fileXio` (used to mount the partition) is still alive on the IOP |
+| BOOT.ELF from HDD-booted POPSLoader black-screens | Nuno 2026-05-25 | Same hang shape as DKWDRV; the reset never completes |
+| Atrocious boot times | NathanNeurotic | Sequential pre-Lua load of 11+ IRX modules in `main()`; unrelated to fileXio bug, but tracked as Layer C below |
+
+## Why each "clean" parent works
+
+PSBBN, Browser, HOSDMenu, OSDMenu either reset the IOP themselves before
+handing off, or never loaded `fileXio` in the first place. wLaunchELF
+[only resets the IOP when launching HDD targets](https://github.com/ps2homebrew/wLaunchELF/blob/master/loader/loader.c)
+for backward compatibility with older homebrew; that's the asymmetry that
+makes wLaunchELF-from-USB break while wLaunchELF-from-HDD works.
+
+## The teardown contract
+
+The robust pre-reset sequence is:
+
+```c
+SifExitRpc();        /* drop any inherited RPC client binding */
+SifInitRpc(0);       /* fresh RPC handshake */
+fileXioExit();       /* restore libc fio fn pointers if hijacked (PR #426) */
+SifIopReset("", 0);  /* now succeeds */
+SifIopSync();
+SifInitRpc(0);       /* ready for module loads */
+```
+
+`SifExitRpc()` and `fileXioExit()` are both safe to call on uninitialized
+state -- they're guarded. Clean parents see no behavior change; polluted
+parents now reset cleanly.
+
+## Fix layers
+
+### Layer A -- EE bootstrap (`src/main.cpp` `_ps2sdk_memory_init`)
+
+Adds the teardown contract above before the existing reset. Runs once, before
+`main()`, as a ps2sdk weak-function override. Effectively a defensive prelude
+for any future parent that leaves `fileXio` loaded.
+
+### Layer B -- Child loader DKWDRV/BOOT.ELF reset branches (`src/elf_loader/src/loader/src/loader.c`)
+
+PR #458 added new reset branches in the BRAM child loader's `main()` for
+DKWDRV and BOOT.ELF targets. Without Layer B, those resets are subject to the
+same hang because POPSLoader's own `fileXio` is alive on the IOP at hand-off
+time. Layer B prepends `SifExitRpc(); SifInitRpc(0);` before each
+`SifIopReset` to detach the RPC client cleanly.
+
+### Layer C -- Lazy IRX loading (future PR)
+
+`main()` currently loads 11 IRX modules sequentially before `boot.lua`
+starts. Most aren't needed until the user navigates to a specific page.
+Strategy:
+
+- **Always at startup (core):** iomanX, fileXio, sio2man, mcman, mcserv,
+  padman. These are needed for settings I/O, MC, controllers, RPC plumbing.
+- **Lazy on device-page entry:** usbd + usbhdfsd (USB page), mmceman (MMCE
+  page), mx4sio (MX4SIO page), ps2dev9 + ps2atad + ps2hdd + ps2fs (HDD pages,
+  already lazy via `luaHDD.cpp`).
+- **Lazy on first use:** audsrv + libsd (only when audio plays),
+  ds34usb + ds34bt (only when user enables bluetooth pads in Settings).
+
+Device detection: peek at `argv[0]` device prefix (`mass:`, `mc?:`, `hdd0:`,
+`mmce?:`, `mx4sio?:`) in `setLuaBootPath()` to know which device the user
+launched from. Settings sidecar resolution (cwd-anchored) stays unchanged.
+
+Expected improvement: 30-50% reduction in pre-Lua startup time, possibly
+more on cold boots where IRX loads dominate the budget.
+
+### Layer D -- NHDDL-style launch arguments (future PR)
+
+CosmicScale requested `-mode=ata` style boot arguments to skip directly to
+a device page. Parse `argv` in `main()` before `runScript("boot.lua")` and
+expose to Lua as a `LaunchArgs` global table. Candidate arguments:
+
+- `-page=hdd` / `-page=usb` / `-page=mmce` / `-page=mx4sio` / `-page=smb` / `-page=bdma`
+- `-game=<selector>` (auto-launch a specific game on boot)
+- `-noaudio` (skip audio init for fastest possible boot)
+- `-debug` (enable on-screen diagnostics)
+
+## Safety audit (Layers A and B)
+
+| Path | Layer A impact | Layer B impact |
+|---|---|---|
+| D-10 (HDD POPSTARTER + HDD game) | New teardown runs at POPSLoader boot; child loader HDD partition branch unchanged | Unchanged -- POPSTARTER target matches neither `is_dkwdrv_target` nor `is_boot_elf_target` |
+| D-15 (USB POPSTARTER + HDD game) | New teardown runs at POPSLoader boot; direct path in elf.c unchanged | Not reached (POPSTARTER doesn't trigger child loader reset branches) |
+| DKWDRV from MC (working baseline) | Boot teardown runs once | Not reached (MC DKWDRV uses direct path, not child loader) |
+| BOOT.ELF from USB-booted POPSLoader | Boot teardown runs once | Routed through child loader (PR #458 change); now also gets the SifExitRpc pre-teardown |
+| All clean-parent launches | SifExitRpc + fileXioExit are guarded no-ops; same effective state as before | N/A |
+
+## References
+
+- [ps2sdk issue #425 -- "`fileXio` somehow blocks `IOP` to reset"](https://github.com/ps2dev/ps2sdk/issues/425)
+- [ps2sdk PR #426 -- libc fio pointer backup/restore in fileXioInit/Exit](https://github.com/ps2dev/ps2sdk/pull/426)
+- [wLaunchELF loader source -- conditional IOP reset for HDD targets only](https://github.com/ps2homebrew/wLaunchELF/blob/master/loader/loader.c)
+- [OPL ee_core/src/iopmgr.c -- gold-standard reset sequence with `SifSetReg` patches](https://github.com/ps2homebrew/Open-PS2-Loader/blob/master/ee_core/src/iopmgr.c)

--- a/docs/LAUNCH_HYGIENE.md
+++ b/docs/LAUNCH_HYGIENE.md
@@ -79,12 +79,32 @@ Strategy:
 - **Lazy on first use:** audsrv + libsd (only when audio plays),
   ds34usb + ds34bt (only when user enables bluetooth pads in Settings).
 
-Device detection: peek at `argv[0]` device prefix (`mass:`, `mc?:`, `hdd0:`,
-`mmce?:`, `mx4sio?:`) in `setLuaBootPath()` to know which device the user
-launched from. Settings sidecar resolution (cwd-anchored) stays unchanged.
+Device detection: peek at `argv[0]` device prefix in `setLuaBootPath()` to
+know which device the user launched from. Settings sidecar resolution
+(cwd-anchored) stays unchanged.
 
-Expected improvement: 30-50% reduction in pre-Lua startup time, possibly
-more on cold boots where IRX loads dominate the budget.
+#### Layer C precursor (landed 2026-05-25)
+
+`bin/POPSLDR/system.lua` `DetectBootDevice()` now recognizes additional
+semantic device-kind prefixes that some homebrew launchers pass. These are
+**additive** -- the existing detection chain (mmce, mx4sio, mass with the
+mx4sio classify_mass_boot fix, pfs, hdd, smb, host) is unchanged. The new
+branches are placed just before the `return nil` fallback so they only
+catch what would otherwise be unclassified:
+
+| Prefix pattern | Maps to | Rationale |
+|---|---|---|
+| `usb`, `usb0`, `usb1`, ... | USB | Some launchers use `usb:` instead of the SDK-standard `mass:` |
+| `ata`, `ata0`, `ata1`, ... | HDD | ATA-backed HDD semantic prefix |
+| `apa`, `apa0`, `apa1`, ... | HDD | APA partition system semantic prefix |
+
+`mx4sio` was already in the existing detection (line 1705); the user's
+"mx4sio's mass fix" lives entirely inside the `mass%d*` branch and is
+not touched.
+
+Expected improvement (when Layer C lazy IRX loading lands): 30-50%
+reduction in pre-Lua startup time, possibly more on cold boots where
+IRX loads dominate the budget.
 
 ### Layer D -- NHDDL-style launch arguments (future PR)
 
@@ -106,6 +126,30 @@ expose to Lua as a `LaunchArgs` global table. Candidate arguments:
 | DKWDRV from MC (working baseline) | Boot teardown runs once | Not reached (MC DKWDRV uses direct path, not child loader) |
 | BOOT.ELF from USB-booted POPSLoader | Boot teardown runs once | Routed through child loader (PR #458 change); now also gets the SifExitRpc pre-teardown |
 | All clean-parent launches | SifExitRpc + fileXioExit are guarded no-ops; same effective state as before | N/A |
+
+## Flagged separately: settings sidecar is not currently implemented
+
+User raised the concern that "settings sidecar may not be working" while
+discussing Layer C. Confirmed during the 2026-05-25 audit:
+
+- `PLDR.SETTINGS_PATH` is hardcoded to `"mc0:/POPSTARTER/.pldrs"` at
+  `bin/POPSLDR/system.lua` line 1971.
+- `PLDR.SaveSettingsAtomic()` writes to that exact path (no fallback).
+- `PLDR.LoadSettingsNonFatal()` reads from that exact path (no fallback).
+- The "sidecar" functions that DO exist (`BuildPopstarterSidecarCandidate`,
+  `CollectHddBootSidecarCandidates`, `ResolveHddBootSidecarPopstarter`) are
+  for resolving the **POPSTARTER.ELF** path -- not for settings.
+
+So a POPSLoader running off USB/HDD/MX4SIO still writes settings to
+`mc0:/POPSTARTER/.pldrs`. There is currently no per-device settings
+sidecar, despite naming that suggests otherwise.
+
+This is **not in scope of the launch hygiene fix**. A separate PR
+should:
+1. Add per-device settings sidecar resolution: try `<APP_DIR>.pldrs`
+   first, fall back to `mc0:/POPSTARTER/.pldrs`.
+2. Migrate write-side similarly (write to wherever it was loaded from).
+3. Consider whether to copy from MC to sidecar on first run.
 
 ## References
 

--- a/docs/LAUNCH_HYGIENE.md
+++ b/docs/LAUNCH_HYGIENE.md
@@ -65,28 +65,81 @@ same hang because POPSLoader's own `fileXio` is alive on the IOP at hand-off
 time. Layer B prepends `SifExitRpc(); SifInitRpc(0);` before each
 `SifIopReset` to detach the RPC client cleanly.
 
-### Layer C -- Lazy IRX loading (future PR)
+### Layer D -- NHDDL-style launch arguments (landed 2026-05-25)
 
-`main()` currently loads 11 IRX modules sequentially before `boot.lua`
-starts. Most aren't needed until the user navigates to a specific page.
-Strategy:
+CosmicScale requested `-mode=ata` style boot arguments to skip directly to
+a device page. Shipped infrastructure:
 
-- **Always at startup (core):** iomanX, fileXio, sio2man, mcman, mcserv,
-  padman. These are needed for settings I/O, MC, controllers, RPC plumbing.
-- **Lazy on device-page entry:** usbd + usbhdfsd (USB page), mmceman (MMCE
-  page), mx4sio (MX4SIO page), ps2dev9 + ps2atad + ps2hdd + ps2fs (HDD pages,
-  already lazy via `luaHDD.cpp`).
-- **Lazy on first use:** audsrv + libsd (only when audio plays),
-  ds34usb + ds34bt (only when user enables bluetooth pads in Settings).
+**`src/main.cpp` `parseLaunchArgs()`** runs immediately after `argv[0]`
+capture, before any IRX loads. Recognized flags:
 
-Device detection: peek at `argv[0]` device prefix in `setLuaBootPath()` to
-know which device the user launched from. Settings sidecar resolution
-(cwd-anchored) stays unchanged.
+| Flag | Effect |
+|---|---|
+| `-page=hdd|usb|mc|mmce|mx4sio|smb|bdma` | Auto-navigate hint for the UI |
+| `-mode=<value>` | NHDDL-compatible alias for `-page` (e.g. `-mode=ata` maps to HDD) |
+| `-game=<selector>` | Auto-launch hint (game selector / profile / path) |
+| `-noaudio` | Skip `audsrv_irx` + `libsd_irx` at boot |
+| `-debug` | Enable diagnostic output |
+
+**Lua exposure**: `System.getLaunchArgs()` returns `{page, game, noaudio,
+debug}`. `system.lua` reads this at init and stores normalized values in
+`PLDR.LAUNCH_ARGS = {page, page_raw, game, noaudio, debug}`. Page values
+are normalized via `NormalizeLaunchPage()` so `ata`/`pfs`/`apa`/`hdd` all
+map to `"HDD"`, `usb`/`mass` to `"USB"`, etc.
+
+**Auto-navigation wiring** is intentionally deferred. The infrastructure
+is in place; downstream UI code in `ui.lua` can pick up `PLDR.LAUNCH_ARGS`
+when ready to act on it. This avoids touching the existing initial-page
+selection logic until that's a focused follow-up.
+
+### Settings sidecar (landed 2026-05-25)
+
+Replaces hardcoded `PLDR.SETTINGS_PATH = "mc0:/POPSTARTER/.pldrs"` with a
+per-device sidecar resolution + MC fallback. New constants:
+
+- `PLDR.SETTINGS_PATH_FALLBACK = "mc0:/POPSTARTER/.pldrs"` (legacy path)
+- `PLDR.SETTINGS_PATH_SIDECAR` -- computed from `APP_DIR_LOCAL/.pldrs`
+  when `APP_DIR_LOCAL` is NOT HDD-backed (avoid PFS RW remount). `nil`
+  for HDD-backed installs.
+- `PLDR.SETTINGS_PATH` -- the *active* path; resolved at load time to
+  whichever file exists first (sidecar preferred, fallback otherwise).
+
+Behavior:
+- **Load**: try sidecar first, then fallback. Pin `PLDR.SETTINGS_PATH`
+  to whichever loaded. If neither exists, leave it at the init default
+  (sidecar preferred so the first save lands per-device).
+- **Save**: write to `PLDR.SETTINGS_PATH`. Only fail on
+  `EnsurePopstarterDir` if the target IS the MC fallback (sidecar saves
+  don't need `mc0:/POPSTARTER`).
+- **HDD installs**: `SETTINGS_PATH_SIDECAR == nil`, so settings continue
+  to use `mc0:/POPSTARTER/.pldrs`. Avoids the PFS-mounted-RW complexity
+  for HDD-resident POPSLoader.
+
+### Layer C -- Lazy IRX loading (partial; landed 2026-05-25, more queued)
+
+Shipped in this PR:
+- **Pre-Lua device classification hint**: `main.cpp`
+  `detectBootDeviceHintFromArgv0()` returns the device-kind label for
+  argv[0]. Stored in `boot_device_hint` global, exposed via
+  `System.getBootDeviceHint()`. Used by `system.lua` for early decisions
+  before `DetectBootDevice` runs full authoritative resolution.
+- **`-noaudio` deferral**: skips `libsd_irx` and `audsrv_irx` IRX loads
+  at boot when the flag is present. Lua sound code should check
+  `PLDR.LAUNCH_ARGS.noaudio` before calling sound APIs (TODO: audit
+  sound call sites).
+
+Still queued for a focused follow-up (intentionally NOT in this PR
+because aggressive deferral changes module load order which is high-
+risk for input/controller availability):
+- Defer `mmceman_irx` unless boot device is MMCE (saves ~1 module load)
+- Defer `ds34bt_irx` unless user has BT pads enabled
+- Defer `usbd_irx` unless boot device is USB / MX4SIO / DS3-4 USB
+- Add `EnsureAudio()`, `EnsureBluetoothPad()` Lua-callable helpers
 
 #### Layer C precursor (landed 2026-05-25)
 
 `bin/POPSLDR/system.lua` `DetectBootDevice()` now recognizes additional
-semantic device-kind prefixes that some homebrew launchers pass. These are
+SDK device-kind prefixes that some homebrew launchers pass. These are
 **additive** -- the existing detection chain (mmce, mx4sio, mass with the
 mx4sio classify_mass_boot fix, pfs, hdd, smb, host) is unchanged. The new
 branches are placed just before the `return nil` fallback so they only
@@ -94,28 +147,18 @@ catch what would otherwise be unclassified:
 
 | Prefix pattern | Maps to | Rationale |
 |---|---|---|
-| `usb`, `usb0`, `usb1`, ... | USB | Some launchers use `usb:` instead of the SDK-standard `mass:` |
+| `usb`, `usb0`, `usb1`, ... | USB | Newer ps2sdk SDK USB prefix (was `mass:` only) |
 | `ata`, `ata0`, `ata1`, ... | HDD | ATA-backed HDD semantic prefix |
 | `apa`, `apa0`, `apa1`, ... | HDD | APA partition system semantic prefix |
 
 `mx4sio` was already in the existing detection (line 1705); the user's
 "mx4sio's mass fix" lives entirely inside the `mass%d*` branch and is
-not touched.
+not touched. Both old launchers (using `mass:`) and new launchers (using
+`usb:`/`ata:`/`apa:`) now resolve to the correct device classification.
 
-Expected improvement (when Layer C lazy IRX loading lands): 30-50%
+Expected improvement (when full Layer C lazy IRX loading lands): 30-50%
 reduction in pre-Lua startup time, possibly more on cold boots where
 IRX loads dominate the budget.
-
-### Layer D -- NHDDL-style launch arguments (future PR)
-
-CosmicScale requested `-mode=ata` style boot arguments to skip directly to
-a device page. Parse `argv` in `main()` before `runScript("boot.lua")` and
-expose to Lua as a `LaunchArgs` global table. Candidate arguments:
-
-- `-page=hdd` / `-page=usb` / `-page=mmce` / `-page=mx4sio` / `-page=smb` / `-page=bdma`
-- `-game=<selector>` (auto-launch a specific game on boot)
-- `-noaudio` (skip audio init for fastest possible boot)
-- `-debug` (enable on-screen diagnostics)
 
 ## Safety audit (Layers A and B)
 

--- a/docs/LAUNCH_HYGIENE.md
+++ b/docs/LAUNCH_HYGIENE.md
@@ -65,6 +65,45 @@ same hang because POPSLoader's own `fileXio` is alive on the IOP at hand-off
 time. Layer B prepends `SifExitRpc(); SifInitRpc(0);` before each
 `SifIopReset` to detach the RPC client cleanly.
 
+### Unified boot-context resolver (landed 2026-05-25)
+
+User insight: argv[0] tells us where POPSLoader came from. From that one
+fact, three things follow -- which IRX stack to prefer, where settings
+should live, which page to land on. The three features should share one
+detection pipeline, not have three near-copies.
+
+`bin/POPSLDR/system.lua` `ResolveBootContext()` is now the single source
+of truth. It returns:
+
+```
+{
+  kind         = "USB" / "HDD" / "MC" / "MMCE" / "MX4SIO" / "SMB" / "HOST" or nil,
+  prefix       = raw argv prefix (e.g. "mass0", "hdd0") or nil,
+  boot_path    = normalized BOOT_PATH_RAW (with trailing slash),
+  sidecar_path = per-device .pldrs path or nil,
+  c_hint       = pre-IRX C-side classification (debug / fallback),
+}
+```
+
+Inputs (all derived from argv[0]):
+- `BOOT_PATH_RAW` (set by main.cpp `setLuaBootPath`)
+- `APP_DIR_LOCAL` (set by main.cpp `setAppDirFromPath`)
+- `boot_device_hint` (set by main.cpp `detectBootDeviceHintFromArgv0`,
+  exposed via `System.getBootDeviceHint()`)
+
+Outputs (all consumed via this one resolver):
+- `DetectBootDevice()` is a thin wrapper returning `kind, boot_path, prefix`.
+- `PLDR.SETTINGS_PATH_SIDECAR` is `ResolveBootContext().sidecar_path`.
+- `PLDR.GetBootContext()` / `PLDR.GetBootKind()` are public APIs for any
+  downstream consumer (UI auto-nav, future lazy-IRX deferrals, telemetry).
+
+Robust to bad/missing argv:
+- argv[0] NULL/empty -> boot_path empty -> prefix nil -> Lua kind nil ->
+  fall back to C hint (also empty) -> kind stays nil
+- nil kind -> DetectBootDevice returns nil first; UI shows default page
+- HDD-backed APP_DIR -> sidecar_path is nil -> settings use mc0 fallback
+- non-HDD APP_DIR with no prior .pldrs -> sidecar wins on first save
+
 ### Layer D -- NHDDL-style launch arguments (landed 2026-05-25)
 
 CosmicScale requested `-mode=ata` style boot arguments to skip directly to
@@ -78,13 +117,17 @@ capture, before any IRX loads. Recognized flags:
 | `-page=hdd|usb|mc|mmce|mx4sio|smb|bdma` | Auto-navigate hint for the UI |
 | `-mode=<value>` | NHDDL-compatible alias for `-page` (e.g. `-mode=ata` maps to HDD) |
 | `-game=<selector>` | Auto-launch hint (game selector / profile / path) |
-| `-noaudio` | Skip `audsrv_irx` + `libsd_irx` at boot |
 | `-debug` | Enable diagnostic output |
 
-**Lua exposure**: `System.getLaunchArgs()` returns `{page, game, noaudio,
-debug}`. `system.lua` reads this at init and stores normalized values in
-`PLDR.LAUNCH_ARGS = {page, page_raw, game, noaudio, debug}`. Page values
-are normalized via `NormalizeLaunchPage()` so `ata`/`pfs`/`apa`/`hdd` all
+`-noaudio` was considered and dropped on review: audio IRX is embedded
+in the ELF, loads in a few hundred ms, and POPSLoader uses sound for UI
+feedback (menu beeps, toast notifications). Skipping it would be a
+footgun for negligible savings.
+
+**Lua exposure**: `System.getLaunchArgs()` returns `{page, game, debug}`.
+`system.lua` reads this at init and stores normalized values in
+`PLDR.LAUNCH_ARGS = {page, page_raw, game, debug}`. Page values are
+normalized via `NormalizeLaunchPage()` so `ata`/`pfs`/`apa`/`hdd` all
 map to `"HDD"`, `usb`/`mass` to `"USB"`, etc.
 
 **Auto-navigation wiring** is intentionally deferred. The infrastructure
@@ -115,18 +158,32 @@ Behavior:
   to use `mc0:/POPSTARTER/.pldrs`. Avoids the PFS-mounted-RW complexity
   for HDD-resident POPSLoader.
 
-### Layer C -- Lazy IRX loading (partial; landed 2026-05-25, more queued)
+### Layer C -- Lazy IRX loading (precursor; more queued)
 
 Shipped in this PR:
 - **Pre-Lua device classification hint**: `main.cpp`
   `detectBootDeviceHintFromArgv0()` returns the device-kind label for
   argv[0]. Stored in `boot_device_hint` global, exposed via
-  `System.getBootDeviceHint()`. Used by `system.lua` for early decisions
-  before `DetectBootDevice` runs full authoritative resolution.
-- **`-noaudio` deferral**: skips `libsd_irx` and `audsrv_irx` IRX loads
-  at boot when the flag is present. Lua sound code should check
-  `PLDR.LAUNCH_ARGS.noaudio` before calling sound APIs (TODO: audit
-  sound call sites).
+  `System.getBootDeviceHint()`. Consumed by the unified
+  `ResolveBootContext` resolver above as a fallback when Lua-side
+  prefix parsing yields nothing.
+
+Audit of which IRX is loaded when (confirming nothing critical is
+deferred by mistake):
+
+| Module | When | Notes |
+|---|---|---|
+| iomanX, fileXio | Always at boot | Filesystem base; required |
+| sio2man, mcman, mcserv | Always at boot | MC + controller base |
+| mmceman | Always at boot (if fileXio OK) | MMCE memcard |
+| padman | Always at boot | Standard PS2 controllers (UI input) |
+| libsd, audsrv | Always at boot | Audio (UI feedback) |
+| usbd | Always at boot | USB driver base (incl. DS3/4 USB) |
+| ds34usb, ds34bt | Always at boot | DS3/4 over USB / Bluetooth |
+| bdm, bdmfs_fatfs, usbmass_bd | Lazy (`EnsureBDM*` in luasystem.cpp) | BDM stack for USB mass storage |
+| mx4sio_bd | Lazy (`initMX4SIO()`) | MX4SIO BDM driver |
+| cdfs | Lazy (`EnsureCDFS()`) | CD/DVD |
+| ps2dev9, ps2atad, ps2hdd-osd, ps2fs | Lazy (`luaHDD.cpp`) | HDD stack |
 
 Still queued for a focused follow-up (intentionally NOT in this PR
 because aggressive deferral changes module load order which is high-

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -625,6 +625,25 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
+	/* BOOT.ELF on MC: route through the BRAM child loader. Mirrors the
+	 * BOOT.ELF special-case in LoadELFFromFileWithPartition (this file,
+	 * non-reboot variant). The child loader runs wipeUserMem() before
+	 * SifLoadElf'ing BOOT.ELF, which clears EE-RAM residue left behind
+	 * by HDD-booted POPSLoader, and the child loader's BOOT.ELF branch
+	 * does its own IOP reset + minimum-IRX reload before ExecPS2.
+	 *
+	 * Without this routing, LaunchBootElf with reboot_iop=1 fell through
+	 * to the direct SifIopReset path below. That path black-screens when
+	 * POPSLoader was booted from HDD (Nuno 2026-05-25) -- the IOP reset
+	 * alone wasn't enough; we also needed the EE-RAM wipe.
+	 */
+	if (strcmp(resolved_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
+	    strcmp(resolved_path, "mc1:/BOOT/BOOT.ELF") == 0) {
+		char *boot_argv[1];
+		boot_argv[0] = (char *)resolved_path;
+		return ExecuteViaEmbeddedLoader("", resolved_path, 1, boot_argv);
+	}
+
 	SifInitRpc(0);
 	SifLoadFileInit();
 	ret = SifLoadElf(resolved_path, &elfdata);

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -430,6 +430,17 @@ int main(int argc, char *argv[])
 		 * B2 fix -- DO NOT MERGE the two paths.
 		 */
 		if (is_dkwdrv_target(load_path, target_argv[0])) {
+			/* Drop POPSLoader's RPC binding before the IOP reset to
+			 * avoid the fileXio-blocks-reset hang (ps2sdk #425). The
+			 * parent (POPSLoader main app) initialized fileXio for HDD
+			 * access; its IOP-side server thread holds RPC locks that
+			 * keep SifIopReset from completing. SifExitRpc tears down
+			 * the EE-side RPC client cleanly, SifInitRpc re-establishes
+			 * a fresh handshake, then the reset proceeds.
+			 */
+			SifExitRpc();
+			SifInitRpc(0);
+
 			FlushCache(0);
 
 			while (!SifIopReset("", 0)) {}
@@ -464,6 +475,14 @@ int main(int argc, char *argv[])
 		 * IOP regardless of whether POPSLoader was on USB or HDD.
 		 */
 		if (is_boot_elf_target(load_path)) {
+			/* Same fileXio-block defense as the DKWDRV branch above.
+			 * POPSLoader's parent fileXio is holding IOP RPC locks; we
+			 * have to detach the RPC client before SifIopReset or the
+			 * reset hangs (ps2sdk #425).
+			 */
+			SifExitRpc();
+			SifInitRpc(0);
+
 			FlushCache(0);
 
 			while (!SifIopReset("", 0)) {}

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -83,6 +83,45 @@ static int is_hdd_partition_context(const char *partition_context)
 	        partition_context[4] == ':');
 }
 
+/* Detects DKWDRV.ELF as the launch target. Used to gate the IOP reset
+ * branch in main(): DKWDRV doesn't self-bootstrap the way POPSTARTER
+ * does, so leaving the parent's HDD/DEV9 IOP state alive across the
+ * hand-off causes a hang. The fix is hdd -> ram -> reset -> load.
+ */
+static int is_dkwdrv_target(const char *load_path, const char *argv0)
+{
+	if (load_path != NULL &&
+	    (strstr(load_path, "DKWDRV.ELF") != NULL ||
+	     strstr(load_path, "dkwdrv.elf") != NULL)) {
+		return 1;
+	}
+	if (argv0 != NULL &&
+	    (strstr(argv0, "DKWDRV.ELF") != NULL ||
+	     strstr(argv0, "dkwdrv.elf") != NULL)) {
+		return 1;
+	}
+	return 0;
+}
+
+/* Detects mc?:/BOOT/BOOT.ELF as the launch target. Same rationale as
+ * is_dkwdrv_target: BOOT.ELF leaving an HDD-booted POPSLoader hangs
+ * because the IOP carries DEV9/HDD state. The reset branch gives BOOT
+ * .ELF a clean IOP, and routing through the child loader also wipes EE
+ * RAM via wipeUserMem before reload (cleaner than the parent's direct
+ * path).
+ */
+static int is_boot_elf_target(const char *load_path)
+{
+	if (load_path == NULL) {
+		return 0;
+	}
+	if (strcmp(load_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
+	    strcmp(load_path, "mc1:/BOOT/BOOT.ELF") == 0) {
+		return 1;
+	}
+	return 0;
+}
+
 static int should_use_filexio_direct_load(const char *partition_context, const char *load_path)
 {
 	if (is_hdd_partition_context(partition_context)) {
@@ -371,6 +410,82 @@ int main(int argc, char *argv[])
 			FlushCache(2);
 			ret = ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, target_argc, target_argv);
 			return (ret != 0) ? ret : -3500;
+		}
+
+		/* DKWDRV-specific IOP reset path.
+		 *
+		 * DKWDRV does not bring its own DEV9/HDD/PFS bootstrap (unlike
+		 * POPSTARTER), so it cannot inherit POPSLoader's polluted IOP
+		 * state across ExecPS2 -- the symptom is a black screen on
+		 * hardware (Nuno 2026-05-25). The fix is "hdd -> ram -> reset
+		 * -> load": target was just SifLoadElf'd into EE RAM above, so
+		 * now reset the IOP cleanly and reload only the minimum IRX
+		 * surface (SIO2MAN/MCMAN/MCSERV) before ExecPS2. This mirrors
+		 * the parent's non-HDD direct path in elf.c
+		 * LoadELFFromFileExecPS2RebootIOPWithPartition (the route MC
+		 * DKWDRV already takes successfully).
+		 *
+		 * POPSTARTER takes the is_hdd_partition_context branch below,
+		 * which is byte-identical to D-10's hardware-passing 2026-05-22
+		 * B2 fix -- DO NOT MERGE the two paths.
+		 */
+		if (is_dkwdrv_target(load_path, target_argv[0])) {
+			FlushCache(0);
+
+			while (!SifIopReset("", 0)) {}
+			while (!SifIopSync()) {}
+
+			SifInitRpc(0);
+			SifLoadFileInit();
+			SifLoadModule("rom0:SIO2MAN", 0, NULL);
+			SifLoadModule("rom0:MCMAN", 0, NULL);
+			SifLoadModule("rom0:MCSERV", 0, NULL);
+			SifLoadFileExit();
+			SifExitRpc();
+
+			FlushCache(0);
+			FlushCache(2);
+
+			DPRINTF("DKWDRV EXEC: argc=%d\n", target_argc);
+			for (i = 0; i < target_argc; i++) {
+				DPRINTF("DKWDRV EXEC: argv[%d] = %s\n", i, target_argv[i]);
+			}
+			ret = ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, target_argc, target_argv);
+			return (ret != 0) ? ret : -3550;
+		}
+
+		/* BOOT.ELF on MC: same hdd -> ram -> reset -> load contract as
+		 * DKWDRV. The parent's direct path with IOP reset worked when
+		 * launched from USB-booted POPSLoader but not from HDD-booted
+		 * (Nuno 2026-05-25). Routing through the child loader adds the
+		 * wipeUserMem() EE-RAM scrub before the SifLoadElf above; this
+		 * branch then performs the IOP reset and minimum-IRX reload
+		 * before ExecPS2. Net effect: BOOT.ELF inherits a clean EE +
+		 * IOP regardless of whether POPSLoader was on USB or HDD.
+		 */
+		if (is_boot_elf_target(load_path)) {
+			FlushCache(0);
+
+			while (!SifIopReset("", 0)) {}
+			while (!SifIopSync()) {}
+
+			SifInitRpc(0);
+			SifLoadFileInit();
+			SifLoadModule("rom0:SIO2MAN", 0, NULL);
+			SifLoadModule("rom0:MCMAN", 0, NULL);
+			SifLoadModule("rom0:MCSERV", 0, NULL);
+			SifLoadFileExit();
+			SifExitRpc();
+
+			FlushCache(0);
+			FlushCache(2);
+
+			DPRINTF("BOOT.ELF EXEC: argc=%d\n", target_argc);
+			for (i = 0; i < target_argc; i++) {
+				DPRINTF("BOOT.ELF EXEC: argv[%d] = %s\n", i, target_argv[i]);
+			}
+			ret = ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, target_argc, target_argv);
+			return (ret != 0) ? ret : -3560;
 		}
 
 		if (is_hdd_partition_context(partition_context)) {

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -13,6 +13,16 @@ extern "C" {
 extern char boot_path[255];
 extern char app_dir[255];
 
+/* NHDDL-style launch arguments + pre-Lua boot-device classification.
+ * Definitions live in main.cpp; consumers (luasystem.cpp Lua bindings)
+ * read these via the System.* binding layer. See parseLaunchArgs() and
+ * detectBootDeviceHintFromArgv0() in main.cpp. */
+extern char launch_arg_page[64];
+extern char launch_arg_game[256];
+extern int  launch_arg_noaudio;
+extern int  launch_arg_debug;
+extern char boot_device_hint[16];
+
 typedef enum AssetKind {
 	ASSET_GENERIC = 0,
 	ASSET_IMG = 1,

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -19,7 +19,6 @@ extern char app_dir[255];
  * detectBootDeviceHintFromArgv0() in main.cpp. */
 extern char launch_arg_page[64];
 extern char launch_arg_game[256];
-extern int  launch_arg_noaudio;
 extern int  launch_arg_debug;
 extern char boot_device_hint[16];
 

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1299,8 +1299,6 @@ static int lua_getLaunchArgs(lua_State *L) {
 	lua_setfield(L, -2, "page");
 	lua_pushstring(L, launch_arg_game);
 	lua_setfield(L, -2, "game");
-	lua_pushboolean(L, launch_arg_noaudio != 0);
-	lua_setfield(L, -2, "noaudio");
 	lua_pushboolean(L, launch_arg_debug != 0);
 	lua_setfield(L, -2, "debug");
 	return 1;

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1291,6 +1291,31 @@ static int lua_getAppDir(lua_State *L) {
 	return 1;
 }
 
+/* NHDDL-style launch arguments parsed in main.cpp parseLaunchArgs().
+ * Externs declared in include/luaplayer.h. */
+static int lua_getLaunchArgs(lua_State *L) {
+	lua_newtable(L);
+	lua_pushstring(L, launch_arg_page);
+	lua_setfield(L, -2, "page");
+	lua_pushstring(L, launch_arg_game);
+	lua_setfield(L, -2, "game");
+	lua_pushboolean(L, launch_arg_noaudio != 0);
+	lua_setfield(L, -2, "noaudio");
+	lua_pushboolean(L, launch_arg_debug != 0);
+	lua_setfield(L, -2, "debug");
+	return 1;
+}
+
+/* Pre-Lua C-side device classification hint (from argv[0]). The
+ * authoritative boot device is still resolved in system.lua
+ * DetectBootDevice (it handles the mass:/ MX4SIO disambiguation via
+ * BDM driver lookup). This hint is for early decisions only.
+ * Extern declared in include/luaplayer.h. */
+static int lua_getBootDeviceHint(lua_State *L) {
+	lua_pushstring(L, boot_device_hint);
+	return 1;
+}
+
 static int lua_resolveAsset(lua_State *L) {
 	int argc = lua_gettop(L);
 	if (argc != 1) return luaL_error(L, "Argument error: System.resolveAsset(relativeName) takes one argument.");
@@ -1402,6 +1427,8 @@ static const luaL_Reg System_functions[] = {
 	{"checkDiscTray",         lua_checkDiscTray},
 	{"GetArgv0",                   lua_popargv0},
 	{"getAppDir",                 lua_getAppDir},
+	{"getLaunchArgs",         lua_getLaunchArgs},
+	{"getBootDeviceHint", lua_getBootDeviceHint},
 	{"getEmbeddedAsset",      lua_getEmbeddedAsset},
 	{"resolveAsset",           lua_resolveAsset},
 	{"resolveAssetType",   lua_resolveAssetType},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -433,8 +433,47 @@ int main(int argc, char * argv[])
 }
 
 extern "C" void _ps2sdk_memory_init() {
-#ifdef RESET_IOP  
+#ifdef RESET_IOP
+    /* Bootstrap IOP hygiene for parent launchers that do NOT reset the
+     * IOP before handing control to POPSLoader. The canonical offender
+     * is wLaunchELF, which only resets the IOP for HDD targets (per
+     * wLaunchELF/loader/loader.c). When POPSLoader is launched from
+     * wLaunchELF off USB, MC, MX4SIO, or any non-HDD device, we inherit
+     * wLaunchELF's fileXio + iomanX IOP modules. fileXio holds threads
+     * and semaphores that BLOCK a plain SifIopReset (documented:
+     * https://github.com/ps2dev/ps2sdk/issues/425). The symptom is a
+     * silent hang here -> black screen for the user (CosmicScale report
+     * 2026-05-25).
+     *
+     * The teardown contract below survives both clean and polluted
+     * parents:
+     *
+     *   SifExitRpc()    -- drop any inherited RPC client binding so the
+     *                      next SifInitRpc starts from a known state.
+     *                      Safe on uninitialized RPC (graceful no-op).
+     *   SifInitRpc(0)   -- fresh RPC handshake; required before
+     *                      fileXioExit can issue any RPC.
+     *   fileXioExit()   -- guarded by __fileXioInited internally
+     *                      (ps2sdk PR #426 contract): restores libc fio
+     *                      function pointers (open/read/close/...)
+     *                      that fileXioInit would have hijacked, and
+     *                      releases its EE-side semaphores. No-op on
+     *                      clean parents because __fileXioInited == 0
+     *                      in a fresh EE process; meaningful only if
+     *                      newlib startup happens to have entered the
+     *                      hijacked state.
+     *   SifIopReset     -- now succeeds; no fileXio RPC channel pinned.
+     *   SifIopSync      -- wait for IOP boot.
+     *   SifInitRpc(0)   -- ready for main() to load our own IRX stack.
+     *
+     * Existing clean-parent paths (PSBBN, Browser, HOSDMenu, OSDMenu,
+     * MC autoboot) are unaffected: each new call has a "not
+     * initialized" guard. The only behavioral delta is that the IOP
+     * reset now completes instead of hanging when fileXio was alive.
+     */
+    SifExitRpc();
     SifInitRpc(0);
+    fileXioExit();
     while (!SifIopReset("", 0)){};
     while (!SifIopSync()){};
     SifInitRpc(0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,17 +93,19 @@ static clock_t boot_start = 0;
  * code (IRX loading, Lua boot) can act on the requested mode.
  *
  *   -page=hdd|usb|mc|mmce|mx4sio|smb|bdma   auto-navigate to that page
+ *   -mode=<value>                            NHDDL-compatible alias
  *   -game=<selector>                         auto-launch that game
- *   -noaudio                                 skip audsrv/libsd at boot
- *                                            (consumed by Layer C lazy IRX)
  *   -debug                                   enable on-screen diagnostics
+ *
+ * (-noaudio was considered and dropped: audio modules are embedded in
+ *  the ELF, load in ~few hundred ms, and POPSLoader uses sound for UI
+ *  feedback. The skip-audio path was a footgun for negligible savings.)
  *
  * Empty strings / zero ints mean "not specified". Exported via the
  * System.getLaunchArgs() Lua binding (see luasystem.cpp).
  */
 char launch_arg_page[64] = "";
 char launch_arg_game[256] = "";
-int  launch_arg_noaudio = 0;
 int  launch_arg_debug   = 0;
 
 /* C-side mirror of system.lua DetectBootDevice. Returns the canonical
@@ -173,14 +175,12 @@ static void parseLaunchArgs(int argc, char ** argv)
             snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", a + 6);
         } else if (strncmp(a, "-game=", 6) == 0) {
             snprintf(launch_arg_game, sizeof(launch_arg_game), "%s", a + 6);
-        } else if (strcmp(a, "-noaudio") == 0) {
-            launch_arg_noaudio = 1;
         } else if (strcmp(a, "-debug") == 0) {
             launch_arg_debug = 1;
         }
     }
-    DPRINTF("LaunchArgs: page=\"%s\" game=\"%s\" noaudio=%d debug=%d\n",
-            launch_arg_page, launch_arg_game, launch_arg_noaudio, launch_arg_debug);
+    DPRINTF("LaunchArgs: page=\"%s\" game=\"%s\" debug=%d\n",
+            launch_arg_page, launch_arg_game, launch_arg_debug);
 }
 
 static unsigned int boot_ms(void)
@@ -469,16 +469,8 @@ int main(int argc, char * argv[])
     initMC();
     LOAD_IRX_NARG(padman_irx);
 
-    /* libsd + audsrv: SDK SPU2 lib + audio mixer. Skipped when -noaudio
-     * was passed (NHDDL-style launch arg) to shave the audio stack
-     * out of the boot path. Audio-dependent Lua code is responsible
-     * for either checking PLDR.LAUNCH_ARGS.noaudio or no-oping if the
-     * IRX wasn't loaded. */
-    if (!launch_arg_noaudio) {
-        LOAD_IRX_NARG(libsd_irx);
-    } else {
-        DPRINTF("LaunchArgs: skipping libsd (-noaudio)\n");
-    }
+    LOAD_IRX_NARG(libsd_irx);
+
 
     // load USB modules
     LOAD_IRX_NARG(usbd_irx);
@@ -490,11 +482,7 @@ int main(int argc, char * argv[])
     ds34usb_init();
     ds34bt_init();
 
-    if (!launch_arg_noaudio) {
-        LOAD_IRX_NARG(audsrv_irx);
-    } else {
-        DPRINTF("LaunchArgs: skipping audsrv (-noaudio)\n");
-    }
+    LOAD_IRX_NARG(audsrv_irx);
 	
         setLuaBootPath (argc, argv, 0);
         if (argc > 0 && argv[0]) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,6 +89,100 @@ int mmce_slot0_ready = -1;
 int mmce_slot1_ready = -1;
 static clock_t boot_start = 0;
 
+/* NHDDL-style launch arguments. Parsed early in main() so downstream
+ * code (IRX loading, Lua boot) can act on the requested mode.
+ *
+ *   -page=hdd|usb|mc|mmce|mx4sio|smb|bdma   auto-navigate to that page
+ *   -game=<selector>                         auto-launch that game
+ *   -noaudio                                 skip audsrv/libsd at boot
+ *                                            (consumed by Layer C lazy IRX)
+ *   -debug                                   enable on-screen diagnostics
+ *
+ * Empty strings / zero ints mean "not specified". Exported via the
+ * System.getLaunchArgs() Lua binding (see luasystem.cpp).
+ */
+char launch_arg_page[64] = "";
+char launch_arg_game[256] = "";
+int  launch_arg_noaudio = 0;
+int  launch_arg_debug   = 0;
+
+/* C-side mirror of system.lua DetectBootDevice. Returns the canonical
+ * device-kind label (USB / HDD / MC / MMCE / MX4SIO / SMB / HOST) for a
+ * given argv[0]-style path, or "" when unrecognized. This is consulted
+ * by main() to decide whether device-specific IRX loads can be deferred
+ * (Layer C lazy loading) and by the Lua binding System.getBootDeviceHint().
+ *
+ * IMPORTANT: this returns a CLASSIFICATION HINT, not the authoritative
+ * boot device. The authoritative device is still resolved later in
+ * system.lua DetectBootDevice() which handles the mass:/ MX4SIO fix
+ * (BDM driver lookup + .boot_mx4sio marker). Use this hint only for
+ * pre-Lua, pre-IRX-load decisions.
+ */
+char boot_device_hint[16] = "";
+
+static const char * detectBootDeviceHintFromArgv0(const char * argv0)
+{
+    if (argv0 == NULL || argv0[0] == '\0') {
+        return "";
+    }
+    if (strncmp(argv0, "mass", 4) == 0) {
+        return "USB";    /* could be MX4SIO; classify_mass_boot refines later */
+    }
+    if (strncmp(argv0, "usb", 3) == 0) {
+        return "USB";
+    }
+    if (strncmp(argv0, "mx4sio", 6) == 0) {
+        return "MX4SIO";
+    }
+    if (strncmp(argv0, "mmce", 4) == 0) {
+        return "MMCE";
+    }
+    if (strncmp(argv0, "mc", 2) == 0 && argv0[2] != 'm') {
+        /* "mc0:" / "mc1:" but not "mcm" (mcman would never appear in argv0) */
+        return "MC";
+    }
+    if (strncmp(argv0, "hdd", 3) == 0 ||
+        strncmp(argv0, "pfs", 3) == 0 ||
+        strncmp(argv0, "ata", 3) == 0 ||
+        strncmp(argv0, "apa", 3) == 0) {
+        return "HDD";
+    }
+    if (strncmp(argv0, "smb", 3) == 0) {
+        return "SMB";
+    }
+    if (strncmp(argv0, "host", 4) == 0) {
+        return "HOST";
+    }
+    return "";
+}
+
+static void parseLaunchArgs(int argc, char ** argv)
+{
+    if (argc <= 1 || argv == NULL) {
+        return;
+    }
+    for (int i = 1; i < argc; i++) {
+        const char * a = argv[i];
+        if (a == NULL || a[0] == '\0') {
+            continue;
+        }
+        if (strncmp(a, "-page=", 6) == 0) {
+            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", a + 6);
+        } else if (strncmp(a, "-mode=", 6) == 0) {
+            /* NHDDL-compat alias: -mode=ata maps to our -page=ata/hdd flow */
+            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", a + 6);
+        } else if (strncmp(a, "-game=", 6) == 0) {
+            snprintf(launch_arg_game, sizeof(launch_arg_game), "%s", a + 6);
+        } else if (strcmp(a, "-noaudio") == 0) {
+            launch_arg_noaudio = 1;
+        } else if (strcmp(a, "-debug") == 0) {
+            launch_arg_debug = 1;
+        }
+    }
+    DPRINTF("LaunchArgs: page=\"%s\" game=\"%s\" noaudio=%d debug=%d\n",
+            launch_arg_page, launch_arg_game, launch_arg_noaudio, launch_arg_debug);
+}
+
 static unsigned int boot_ms(void)
 {
     if (boot_start == 0) {
@@ -298,7 +392,19 @@ int main(int argc, char * argv[])
     boot_start = clock();
     BootStamp("EE init start");
 
-    
+    /* Parse NHDDL-style launch arguments early so Lua and any
+     * conditional IRX loading paths can read them. Argv parsing has
+     * no SDK dependencies so it's safe at this point. */
+    parseLaunchArgs(argc, argv);
+
+    /* Pre-IRX classification hint. Used by the conditional audsrv/libsd
+     * load below and exposed to Lua via System.getBootDeviceHint(). */
+    {
+        const char * hint = detectBootDeviceHintFromArgv0(argc > 0 ? argv[0] : NULL);
+        snprintf(boot_device_hint, sizeof(boot_device_hint), "%s", hint != NULL ? hint : "");
+        DPRINTF("BootDeviceHint: \"%s\"\n", boot_device_hint);
+    }
+
     // install sbv patch fix
     DPRINTF("Installing SBV Patches...\n");
     sbv_patch_enable_lmb();
@@ -363,20 +469,32 @@ int main(int argc, char * argv[])
     initMC();
     LOAD_IRX_NARG(padman_irx);
 
-    LOAD_IRX_NARG(libsd_irx);
+    /* libsd + audsrv: SDK SPU2 lib + audio mixer. Skipped when -noaudio
+     * was passed (NHDDL-style launch arg) to shave the audio stack
+     * out of the boot path. Audio-dependent Lua code is responsible
+     * for either checking PLDR.LAUNCH_ARGS.noaudio or no-oping if the
+     * IRX wasn't loaded. */
+    if (!launch_arg_noaudio) {
+        LOAD_IRX_NARG(libsd_irx);
+    } else {
+        DPRINTF("LaunchArgs: skipping libsd (-noaudio)\n");
+    }
 
-
-    // load USB modules    
+    // load USB modules
     LOAD_IRX_NARG(usbd_irx);
 
-    
+
     int ds3pads = 1;
     LOAD_IRX(ds34usb_irx, 4, (char *)&ds3pads);
     LOAD_IRX(ds34bt_irx, 4, (char *)&ds3pads);
     ds34usb_init();
     ds34bt_init();
 
-    LOAD_IRX_NARG(audsrv_irx);
+    if (!launch_arg_noaudio) {
+        LOAD_IRX_NARG(audsrv_irx);
+    } else {
+        DPRINTF("LaunchArgs: skipping audsrv (-noaudio)\n");
+    }
 	
         setLuaBootPath (argc, argv, 0);
         if (argc > 0 && argv[0]) {


### PR DESCRIPTION
## Summary
- Nuno's 2026-05-25 hardware result: DKWDRV-on-HDD (PR #457 BRAM child loader path) and BOOT.ELF-from-HDD-boot **both still black-screen**. D-10 still PASS.
- User thesis: DKWDRV doesn't need HDD at runtime — it's a hang/deinit problem on the hand-off. Contract should be **hdd → ram → reset → load**. POPSTARTER survives the missing reset because it carries its own IRX bootstrap; DKWDRV doesn't.
- Same root cause likely applies to BOOT.ELF-from-HDD-boot: parent's direct path resets IOP but never wipes EE-RAM residue left by HDD-booted POPSLoader.

## Changes

### Child loader (\`src/elf_loader/src/loader/src/loader.c\`)
- Added \`is_dkwdrv_target(load_path, argv0)\` and \`is_boot_elf_target(load_path)\` helpers.
- New **DKWDRV branch** in \`main()\` (placed before \`is_hdd_partition_context\`): after \`SifLoadElf\` of the target into EE RAM, do \`FlushCache\` → \`SifIopReset\` → reload \`SIO2MAN\`/\`MCMAN\`/\`MCSERV\` → \`SifExitRpc\` → \`FlushCache\` → \`ExecPS2\`. Mirrors the parent's non-HDD direct path that already works for MC DKWDRV.
- New **BOOT.ELF branch**: same reset shape. Combined with the child loader's existing \`wipeUserMem()\` (which runs before \`SifLoadElf\`), this scrubs EE-RAM residue from HDD-booted POPSLoader before BOOT.ELF reloads into a clean slate.

### Parent (\`src/elf_loader/src/elf.c\` \`LoadELFFromFileExecPS2RebootIOPWithPartition\`)
- Route \`mc?:/BOOT/BOOT.ELF\` through \`ExecuteViaEmbeddedLoader\`, mirroring the BOOT.ELF special-case already present in \`LoadELFFromFileWithPartition\` (line 485, this file, non-reboot variant). Without this routing, \`LaunchBootElf\` with \`reboot_iop=1\` fell through to the direct path — fine from USB-boot, but black-screen from HDD-boot because EE wasn't wiped.

## D-10 safety audit
- \`is_dkwdrv_target\` returns 0 for POPSTARTER targets ("POPSTARTER.ELF" ≠ "DKWDRV.ELF").
- \`is_boot_elf_target\` returns 0 for POPSTARTER targets (load_path is \`pfs0:/POPSTARTER/POPSTARTER.ELF\`, not \`mc?:/BOOT/BOOT.ELF\`).
- POPSTARTER-on-HDD still falls through to the existing \`is_hdd_partition_context\` branch — **byte-identical** to D-10's hardware-passing 2026-05-22 B2 fix.
- D-15 (USB POPSTARTER + HDD game) bypasses both branches the same way.
- DKWDRV-on-MC and non-HDD BOOT.ELF launches now also get the reset+wipe contract, which is a **strict superset** of what they had before — should not regress.

## Test plan
- [ ] Hardware: D-10 (HDD POPSTARTER + HDD game) — must still PASS
- [ ] Hardware: D-15 (USB POPSTARTER + HDD game) — must still PASS
- [ ] Hardware: DKWDRV from default (MC) path — must still PASS
- [ ] Hardware: DKWDRV from custom HDD path — **new control: target is PASS**
- [ ] Hardware: BOOT.ELF from USB-booted POPSLoader — must still PASS
- [ ] Hardware: BOOT.ELF from HDD-booted POPSLoader — **new control: target is PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)