### PR TITLE
Settings sidecar: support HDD installs via pfs1: RW mount

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1761,17 +1761,27 @@ local function ResolveBootContext()
     kind = c_hint
   end
 
-  -- Settings sidecar path: APP_DIR_LOCAL/.pldrs when on a non-HDD
-  -- device. HDD-backed APP_DIR returns nil here so settings fall back
-  -- to mc0:/POPSTARTER/.pldrs (avoids PFS RW remount complexity).
+  -- Settings sidecar path: APP_DIR_LOCAL/.pldrs.
+  --
+  -- HDD installs are supported via the pfs%d* mounted form. etc/boot.lua
+  -- mounts the boot partition at pfs1: with HDD.MountPartition's default
+  -- mode (FIO_MT_RDWR per src/luaHDD.cpp), so writing .pldrs at
+  -- pfs1:/POPSLOADER/.pldrs succeeds. ResolveAppDirLocal normalizes
+  -- HDD-booted APP_DIR to the pfs1:/ form (see line ~99), so this
+  -- branch covers HDD-only users without any explicit remount logic.
+  --
+  -- Raw hdd0:partition:pfs:/ paths (no live pfs%d* mount) and the
+  -- newer ata:/apa: forms are still excluded -- writing through those
+  -- prefixes requires an active mount that may not exist when settings
+  -- are accessed. These cases gracefully fall back to mc0 via the
+  -- doesFileExist check in LoadSettingsNonFatal.
   local sidecar = nil
   if type(APP_DIR_LOCAL) == "string" and APP_DIR_LOCAL ~= "" then
     local lower = string.lower(APP_DIR_LOCAL)
-    local is_hdd_backed = string.match(lower, "^hdd%d*:") ~= nil
-       or string.match(lower, "^pfs%d*:") ~= nil
+    local is_unmounted_hdd = string.match(lower, "^hdd%d*:") ~= nil
        or string.match(lower, "^ata%d*:") ~= nil
        or string.match(lower, "^apa%d*:") ~= nil
-    if not is_hdd_backed then
+    if not is_unmounted_hdd then
       sidecar = JoinPath(APP_DIR_LOCAL, ".pldrs")
     end
   end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2464,11 +2464,11 @@ UI = {
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             elseif reason == "save_failed" then
-              UI.Notif_queue.add("Couldn't save settings\nmc0:/POPSTARTER/.pldrs may be read-only", "error")
+              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only", "error")
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             else
-              UI.Notif_queue.add("Couldn't save settings\nmc0:/POPSTARTER/.pldrs may be read-only", "error")
+              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only", "error")
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             end

--- a/docs/LAUNCH_HYGIENE.md
+++ b/docs/LAUNCH_HYGIENE.md
@@ -135,15 +135,17 @@ is in place; downstream UI code in `ui.lua` can pick up `PLDR.LAUNCH_ARGS`
 when ready to act on it. This avoids touching the existing initial-page
 selection logic until that's a focused follow-up.
 
-### Settings sidecar (landed 2026-05-25)
+### Settings sidecar (landed 2026-05-25, HDD support 2026-05-25)
 
 Replaces hardcoded `PLDR.SETTINGS_PATH = "mc0:/POPSTARTER/.pldrs"` with a
 per-device sidecar resolution + MC fallback. New constants:
 
 - `PLDR.SETTINGS_PATH_FALLBACK = "mc0:/POPSTARTER/.pldrs"` (legacy path)
-- `PLDR.SETTINGS_PATH_SIDECAR` -- computed from `APP_DIR_LOCAL/.pldrs`
-  when `APP_DIR_LOCAL` is NOT HDD-backed (avoid PFS RW remount). `nil`
-  for HDD-backed installs.
+- `PLDR.SETTINGS_PATH_SIDECAR` -- computed from `APP_DIR_LOCAL/.pldrs`.
+  Set for USB/MC/MMCE/MX4SIO installs AND for HDD installs reached via
+  the `pfs1:` boot mount (etc/boot.lua already mounts that partition
+  `FIO_MT_RDWR` by default via `HDD.MountPartition`, so writes succeed).
+  Only `nil` for raw `hdd0:`/`ata:`/`apa:` paths with no live mount.
 - `PLDR.SETTINGS_PATH` -- the *active* path; resolved at load time to
   whichever file exists first (sidecar preferred, fallback otherwise).
 
@@ -153,10 +155,12 @@ Behavior:
   (sidecar preferred so the first save lands per-device).
 - **Save**: write to `PLDR.SETTINGS_PATH`. Only fail on
   `EnsurePopstarterDir` if the target IS the MC fallback (sidecar saves
-  don't need `mc0:/POPSTARTER`).
-- **HDD installs**: `SETTINGS_PATH_SIDECAR == nil`, so settings continue
-  to use `mc0:/POPSTARTER/.pldrs`. Avoids the PFS-mounted-RW complexity
-  for HDD-resident POPSLoader.
+  don't need `mc0:/POPSTARTER`). UI error toast now reads the actual
+  active path instead of hardcoding the MC string.
+- **HDD installs**: `SETTINGS_PATH_SIDECAR` is `pfs1:/.../<.pldrs>` --
+  same partition POPSLOADER.ELF lives on. The boot mount is already RW,
+  so write-atomic-rename works. If the mount lapses for any reason, the
+  graceful fallback in LoadSettingsNonFatal sends us back to mc0.
 
 ### Layer C -- Lazy IRX loading (precursor; more queued)
 


### PR DESCRIPTION
## Summary

User pushback on PR #458's HDD-falls-back-to-MC decision was right. The original rationale ("avoid PFS RW remount complexity") was based on a wrong assumption.

\`etc/boot.lua\` line 45 already calls \`HDD.MountPartition(MNTPART, 1)\` for HDD-booted POPSLoader, and \`src/luaHDD.cpp:23\` shows the C-side default for that bind is \`FIO_MT_RDWR\`. So the boot partition is **already mounted RW at pfs1:** -- writing \`pfs1:/POPSLOADER/.pldrs\` just works, no remount needed.

## Changes

### \`bin/POPSLDR/system.lua\` \`ResolveBootContext\`
Drop the \`pfs%d*:\` exclusion from sidecar computation. HDD-booted POPSLoader gets a sidecar at \`pfs1:/POPSLOADER/.pldrs\` -- same partition POPSLOADER.ELF lives on.

Still excluded: raw \`hdd0:\` / \`ata:\` / \`apa:\` paths with no live \`pfs%d*\` mount. Those fall back to \`mc0:/POPSTARTER/.pldrs\` gracefully via the \`doesFileExist\` check in \`LoadSettingsNonFatal\`.

### \`bin/POPSLDR/ui.lua\`
Error toast now reads \`PLDR.SETTINGS_PATH\` instead of hardcoding the MC path. Previously a sidecar-using install would see \"mc0:/POPSTARTER/.pldrs may be read-only\" even when the failure was on the actual sidecar path.

### \`docs/LAUNCH_HYGIENE.md\`
Documents the HDD path and references \`src/luaHDD.cpp:23\` as the source of truth for the RW default.

## Safety audit

- **D-10 / D-15 / launch paths**: Not touched. Settings save/load is a separate code path from ELF handoff.
- **MC users**: Unchanged. \`PLDR.SETTINGS_PATH_FALLBACK\` is still \`mc0:/POPSTARTER/.pldrs\`.
- **USB / MX4SIO / MMCE users**: Unchanged. Their sidecar path was already enabled and stays the same.
- **HDD users (NEW)**: Get sidecar at \`pfs1:/POPSLOADER/.pldrs\`. On boot, settings load tries that first, then falls back to \`mc0:\`. On save, writes to whichever loaded.
- **Edge case: HDD boot partition not mounted RW**: Shouldn't happen because \`boot.lua\` mounts RW by default. If it ever does (mount lapse, FIO error), \`WriteAtomic\` returns false and the UI shows the failure with the actual path.

## Test plan

- [ ] Hardware: POPSLoader installed on HDD, change a setting, exit, reboot, verify setting persisted
- [ ] Hardware: POPSLoader on MC, settings still save/load (regression check)
- [ ] Hardware: POPSLoader on USB/MX4SIO, settings still save/load (regression check)
- [ ] Hardware: D-10 still PASS (HDD POPSTARTER + HDD game)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)