### PR TITLE
Audit cleanup + doc refresh

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -45,18 +45,31 @@ jobs:
           printf "%s\n%s\n" "$COMMIT_SHORT" "$BUILD_UTC" > bin/POPSLDR/BUILD_INFO.txt
           cat bin/POPSLDR/BUILD_INFO.txt
 
-      - name: Validate etc/boot.lua (syntax/newline)
+      - name: Validate bundled Lua sources (syntax/newline)
         shell: bash
         run: |
           set -eu
-          BOOT_LUA="etc/boot.lua"
-          [ -f "$BOOT_LUA" ] || { echo "ERROR: $BOOT_LUA not found" >&2; exit 1; }
-          LAST_BYTE_HEX="$(tail -c 1 "$BOOT_LUA" | od -An -tx1 | tr -d '[:space:]')"
-          [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: $BOOT_LUA must end with newline (0x0A)" >&2; exit 1; }
+          # etc/boot.lua is the bootstrap that runs on POPSLoader EE init.
+          # bin/POPSLDR/*.lua are embedded into POPSLOADER.ELF via bin2c and
+          # require()'d at runtime. All are embedded as raw bytes, so syntax
+          # errors otherwise only surface on real hardware at boot time.
+          LUA_FILES="etc/boot.lua bin/POPSLDR/system.lua bin/POPSLDR/ui.lua bin/POPSLDR/images.lua bin/POPSLDR/pops_profiles.lua"
+          for f in $LUA_FILES; do
+            [ -f "$f" ] || { echo "ERROR: $f not found" >&2; exit 1; }
+          done
+          # Trailing-newline check is critical only for etc/boot.lua because
+          # bin2c-embedded files don't depend on file termination, but the
+          # boot.lua runner is fussier about it.
+          LAST_BYTE_HEX="$(tail -c 1 etc/boot.lua | od -An -tx1 | tr -d '[:space:]')"
+          [ "$LAST_BYTE_HEX" = "0a" ] || { echo "ERROR: etc/boot.lua must end with newline (0x0A)" >&2; exit 1; }
           if command -v luac >/dev/null 2>&1; then
-            luac -p "$BOOT_LUA"
+            for f in $LUA_FILES; do
+              luac -p "$f" || { echo "ERROR: luac -p failed for $f" >&2; exit 1; }
+            done
           elif command -v lua >/dev/null 2>&1; then
-            lua -e "assert(loadfile('$BOOT_LUA'))"
+            for f in $LUA_FILES; do
+              lua -e "assert(loadfile('$f'))" || { echo "ERROR: loadfile failed for $f" >&2; exit 1; }
+            done
           else
             echo "NOTE: luac/lua not found; skipped Lua syntax validation"
           fi

--- a/HDD_POPSTARTER_HANDOFF.md
+++ b/HDD_POPSTARTER_HANDOFF.md
@@ -1,12 +1,18 @@
 # HDD POPSTARTER Handoff Audit
 
-Last updated: 2026-05-20
+> **STATUS 2026-05-25: RESOLVED.** D-10, D-14, and D-15 are all hardware-PASS as of 2026-05-22 (Nuno). The fix that resolved them is the B2 contract at commit `4ae6679` — unmounting the target PFS slot before `ExecPS2` on the HDD-POPSTARTER handoff. This contract is preserved through PRs #455-#460 and must be preserved by any future launch-path change.
+>
+> This document is archived. The historical analysis below is kept as a reference for the diagnostic trail; the contents do NOT describe current behavior. See `STATE.md`, `ROADMAP.md`, and `QA_REGRESSION_MATRIX.md` for the current ledger and `docs/LAUNCH_HYGIENE.md` for the current launch-path architecture.
+
+---
+
+Last updated: 2026-05-20 (historical content below this point)
 
 Branch audited: `BETA-12-PLAY`
 
-Purpose: source-backed handoff notes for the remaining HDD-backed `POPSTARTER.ELF` failure. This is intended for a fresh Codex session so the same failed attempts and misleading diagnoses are not repeated.
+Purpose: source-backed handoff notes for the remaining HDD-backed `POPSTARTER.ELF` failure. This was intended for a fresh Codex session so the same failed attempts and misleading diagnoses were not repeated. The actual fix that closed D-10/D-14 was the B2 contract (PFS unmount before ExecPS2) at commit `4ae6679`, applied after this document was written.
 
-## Bottom Line
+## Bottom Line (historical 2026-05-20)
 
 - Do not frame the active bug as "HDD games fail." Current hardware history says HDD games launch when `POPSTARTER.ELF` is on a non-HDD device (`D-15` pass).
 - The active blocker is narrower: if `POPSTARTER.ELF` itself resolves from HDD, games fail regardless of whether the game is HDD (`D-10`) or non-HDD (`D-14`).

--- a/QA_REGRESSION_MATRIX.md
+++ b/QA_REGRESSION_MATRIX.md
@@ -1,7 +1,7 @@
 # POPSLoader Regression Matrix
 
-Last updated: 2026-05-20
-Target line: current repository source
+Last updated: 2026-05-25
+Target line: current repository source (BETA-12-PLAY head, commit `740fa87`)
 
 ## Scope
 This matrix tracks current behavior across:
@@ -162,6 +162,12 @@ These gates are defined by `.github/workflows/compilation.yml`. The separate `.g
 | 2026-05-24 | DKWDRV Hardware | DKWDRV_PATH set to custom HDD path; Production POPSLOADER at dabfe96 (PR #452 merged: V4 :pfs:/ + reboot_iop=0 for HDD DKWDRV) | DKWDRV / D-10 paired | FAIL: black screen. Conclusion: routing HDD DKWDRV through LoadELFFromFileExecPS2 (no-reboot) with HDD keep-mask preservation also does not unblock the launch. The SifExitIopHeap/SifExitRpc/SifExitCmd teardown in the HDD-backed branch may be incompatible with DKWDRV's startup, OR the keep mask isn't actually retaining the partition slot on the way to ExecPS2. PR #452 reverted on 2026-05-24. Next angle: route HDD DKWDRV through the BRAM child loader (same path as POPSTARTER on HDD, since that passes), or copy DKWDRV.ELF to EE RAM before ExecPS2 so it has no HDD dependency at runtime. |
 | 2026-05-24 | BOOT.ELF / DKWDRV | Production POPSLOADER at baed871 with PRs #451 + #452 reverted (current source returns to b725464-equivalent behavior for these two flows; PR #450 reboot_iop-dead-code-fix retained as a clean source defect repair even though it does not unblock BOOT.ELF on hardware) | U-10 / DKWDRV | Unknown (verify on hardware). Treat the rolled-back state as the next baseline. |
 | 2026-05-24 | DKWDRV Hardware | DKWDRV_PATH set to custom HDD path; Production POPSLOADER with `LoadELFFromFileExecPS2RebootIOPWithPartition` updated to route HDD DKWDRV through `ExecuteHddBackedViaEmbeddedLoader` (the BRAM child-loader path POPSTARTER uses successfully on D-10). Removes the V3 `!is_dkwdrv_elf_path` exclusions; HDD DKWDRV now inherits the same B2-fix IOP-state contract as D-10. Non-HDD DKWDRV (e.g. `mc0:/PS1_DKWDRV/DKWDRV.ELF`) is unchanged: falls through to standard direct-launch + V3 argv0 synthesis. | DKWDRV | Unknown (verify on hardware). |
+| 2026-05-25 | DKWDRV Hardware | Production POPSLOADER at PR #457 (commit `de6da75`): DKWDRV-HDD routed through BRAM child loader, no IOP reset. Test path: `hdd0:/__common:pfs1:/APPS/PS1_DKWDRV/DKWDRV.ELF` | DKWDRV-HDD | FAIL (Nuno): black screen. POPSTARTER-on-HDD still PASS (no regression). Conclusion: same BRAM-loader path POPSTARTER uses doesn't automatically work for DKWDRV; DKWDRV needs additional state. |
+| 2026-05-25 | BOOT.ELF Hardware | Production POPSLOADER at PR #457 (commit `de6da75`): BOOT.ELF exit after HDD-boot | U-10 | FAIL (Nuno): black screen. U-10 unchanged from prior tests. |
+| 2026-05-25 | DKWDRV Hardware | Production POPSLOADER at PR #458 (commit `dff091c`): added fileXio teardown to `_ps2sdk_memory_init` AND new IOP-reset branches in child loader for DKWDRV + BOOT.ELF (`is_dkwdrv_target`, `is_boot_elf_target`). Test path: `hdd0:/__common:pfs1:/APPS/PS1_DKWDRV/DKWDRV.ELF` | DKWDRV-HDD | FAIL (Nuno): black screen. POPSTARTER-on-HDD still PASS. |
+| 2026-05-25 | BOOT.ELF Hardware | Production POPSLOADER at PR #458 (commit `dff091c`): BOOT.ELF exit after HDD-boot through new `is_boot_elf_target` reset branch | U-10 | FAIL (Nuno): black screen. **Worse: PR #458's `is_boot_elf_target` branch ALSO regressed V2's working USB-boot-exit-to-BOOT.ELF case** (intercepted before non-HDD branch, forced IOP reset BOOT.ELF doesn't tolerate). PR #460 reverts the regression. |
+| 2026-05-25 | wLaunchELF Report | POPSLoader launched from wLaunchELF on some wLE builds (CosmicScale). PSBBN / Browser / HOSDMenu / OSDMenu launches all work. | (new) | FAIL on certain wLE builds, regardless of POPSLoader source device. PR #458 Layer A (`SifExitRpc + SifInitRpc + fileXioExit` in `_ps2sdk_memory_init` per ps2sdk #425) targets this. Hardware pending. |
+| 2026-05-25 | PR #460 Source-verified | V2 mimicry: revert PR #458's `is_dkwdrv_target` and `is_boot_elf_target` child-loader branches and the reboot-variant BOOT.ELF route. Add DKWDRV special-case in `LoadELFFromFileWithPartition` mirroring V2 BOOT.ELF route (d23520a). `ui.lua OpenDKWDRV` uses `reboot_iop=0` for HDD paths. Completes the V2 contract V4 (PR #452) missed. Commit `740fa87` (BETA-12-PLAY head). | DKWDRV-HDD / L-07 | Source-verified only. Hardware pending. CI green: https://github.com/NathanNeurotic/POPSLoader/actions/runs/26416917597 |
 | YYYY-MM-DD | SCPH-xxxxx | USB/MMCE/MX4SIO/HDD details | e.g. S-01,S-02,D-02 | PASS/FAIL + notes |
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,89 +1,83 @@
-Last updated: 2026-05-20
+Last updated: 2026-05-25
 
 # ROADMAP
 
 ## Status Snapshot
-- Core launcher functionality is present in code for MMCE, MX4SIO, HDD (PFS), USB, Disc (`DKWDRV`), settings persistence, cover preview, path editing, startup backend auto-init, and exit flows.
-- The shared default/Profile 1 local POPSTARTER baseline was restored by rolling back to the `BETA-10-play-CHECKPOINT2` resolver behavior; user hardware confirmed that fix.
-- Recorded hardware previously confirmed `D-12` startup/Profile lookup is restored, `D-16` first-entry USB discovery is restored, and `D-15` non-HDD-POPSTARTER HDD-game launch was restored; a 2026-05-20 latest-artifact report regressed `D-15` again with USB boot + USB sidecar `POPSTARTER.ELF` + HDD game black-screening.
-- A follow-up 2026-05-20 report narrowed the non-HDD sidecar regression to default/cwd POPSTARTER resolution: explicit `mass:/POPS/POPSTARTER.ELF` launches, while default `POPSTARTER.ELF` can stop at `Cant find POPSTARTER ELF`; current source expands the sidecar search and remains `Unknown (verify on hardware)`.
-- The main stabilization blocker is still HDD-backed `POPSTARTER.ELF` execution when the launcher, sidecar/CWD, or configured POPSTARTER path lives on HDD (`D-10`, `D-14`).
-- One 2026-03-29 artifact briefly moved `D-10` to a returned `rc=-1`, but later artifacts returned to black screen, so that was not a stable new boundary.
-- Current repo line now uses the direct non-reboot legacy selector handoff as the default for HDD-backed POPSTARTER too: keep the resolved executable path, avoid Lua partition-context/generic-`pfs:/` rewriting on normal `X`, avoid HDD-only parent cleanup immediately before `ExecPS2`, and preserve the partition-aware/embedded-loader code only as a non-default fallback surface until hardware proves it is needed.
-- The latest EE-side HDD direct-load workaround was reverted after it did not fix `D-10` and coincided with a reported HDD-game regression when POPSTARTER stayed on the non-HDD boot device.
-- `HDD_POPSTARTER_HANDOFF.md` is the current source-audit handoff for this blocker. It separates source-confirmed defects from hardware-only unknowns and should be read before new `D-10` / `D-14` fix attempts.
-- `HDD (exFAT)`, `SMB (v1)`, and `ILINK` remain intentionally unimplemented menu entries.
-- Detailed experiment chronology lives in `QA_REGRESSION_MATRIX.md` and `DECISIONS.md`; `STATE.md` also summarizes the source-inferred Settings/Profile POPSTARTER path save/load integrity risk as `Unknown (verify on hardware)` without attributing `D-10`, `D-14`, or `U-10` to it.
+
+- D-10, D-14, D-15 are hardware-PASS as of 2026-05-22 (B2 fix at commit `4ae6679`). The partition-aware HDD POPSTARTER route is the load-bearing fix to preserve through any new work.
+- DKWDRV from MC is hardware-PASS as of 2026-05-25 (Nuno).
+- DKWDRV from custom HDD path is **awaiting hardware** on PR #460 (commit `740fa87`, BETA-12-PLAY head). PR #460 completes the V2-mimicry that PR #452 (V4) missed: Lua `reboot_iop=0` + a new DKWDRV special-case route in `LoadELFFromFileWithPartition` mirroring the BOOT.ELF V2 contract.
+- BOOT.ELF from USB-booted POPSLoader (L-07) was working in V2 (commit `d23520a`, 2026-05-23). PR #458 regressed it by adding an `is_boot_elf_target` IOP-reset branch in the child loader; PR #460 reverted that. Source-verified back at the V2 working route; hardware re-verification pending.
+- BOOT.ELF from HDD-booted POPSLoader (U-10) is **still broken** and was never solved by V2 either. Pursued only after PR #460 hardware verdict settles.
+- POPSLoader launched from wLaunchELF (CosmicScale 2026-05-25) fails on some wLE builds. PR #458's `_ps2sdk_memory_init` fileXio-teardown (Layer A) targets this. Hardware pending.
+- Backend infrastructure added in PR #458/459/460: per-device settings sidecar (`PLDR.SETTINGS_PATH` resolves at load time with `APP_DIR_LOCAL/.pldrs` preferred and `mc0:/POPSTARTER/.pldrs` fallback), unified `ResolveBootContext` resolver feeding settings/UI/IRX decisions, NHDDL-style launch arg parsing (`-page=`, `-mode=`, `-game=`, `-debug`).
+- `docs/LAUNCH_HYGIENE.md` documents the launch-path architecture and the V2 mimicry rationale.
+- `HDD (exFAT)`, `SMB (v1)`, `ILINK` remain intentionally unimplemented menu entries.
 
 ## Immediate Priorities
 
-### 1) HDD-backed POPSTARTER exec
-- Reproduce and resolve `D-10`:
-  - POPSLoader booted from HDD,
-  - HDD game launched from HDD (PFS),
-  - `POPSTARTER.ELF` resolved from HDD sidecar/CWD or configured HDD path,
-  - current reported result: black-screen hang, or on recent readable-diagnostic artifacts returned pre-exec gate popups for partition-context resolution and generic `pfs:/...` accessibility.
-  - restore and preserve `D-15`, `D-12`, `D-16`, `U-05`, and shared Profile 1/default sidecar behavior while iterating.
-  - treat `D-14` as the paired non-HDD-game repro for the same HDD-backed POPSTARTER blocker.
-  - fix source-confirmed handoff defects before broader experiments: stale Lua fallback context, plain-label fallback partition parsing, over-broad fallback gate skip, partition-context argv leakage, embedded-loader contract drift, mounted-PFS source-partition recovery, failure-popup diagnostic argument order, and generic-`pfs:/` gate probing.
-  - use `QA_REGRESSION_MATRIX.md` for the full experiment chronology instead of rebuilding that ledger here.
+### 1) Resolve DKWDRV-on-HDD on hardware
+- Test PR #460 artifact: https://github.com/NathanNeurotic/POPSLoader/actions/runs/26416917597
+- If DKWDRV-on-HDD PASSES, that closes the V4 saga (PR #452 reverted, PR #458 reverted, PR #460 completes the V2 mimicry).
+- If FAILS, escalate to a diagnostic build: enable `LOADER_ENABLE_DEBUG_COLORS` in the child loader, ship to Nuno, identify the exact stage at which the black-screen happens. The hooks already exist in `src/elf_loader/src/loader/src/loader.c` lines 24-43; just need to define the macro at build time.
+- Regression checks on the same artifact: D-10, D-15, DKWDRV-MC, BOOT.ELF from USB-booted POPSLoader.
 
-### 2) External exit/launch re-validation
-- Re-run `U-05` (`OSDSYS`) and `U-10` (`BOOT.ELF after HDD page init`) on current source after the BOOT.ELF-specific conditional-reboot/cold-prep change for HDD-initialized sessions.
-- Treat `U-10` as potentially sharing the same underlying handoff/state-poisoning boundary as `D-10`, but do not assume a `D-10` fix automatically resolves `U-10` without hardware confirmation.
-- Record exact run results in `QA_REGRESSION_MATRIX.md` instead of carrying them only in chat history.
+### 2) wLaunchELF launch (CosmicScale)
+- Same artifact as priority 1.
+- PR #458 added `SifExitRpc() + SifInitRpc(0) + fileXioExit()` before `SifIopReset` in `_ps2sdk_memory_init`, per the documented ps2sdk #425 workaround.
+- If still failing, the next angles are: pin a specific ps2dev/ps2dev image tag in CI to rule out toolchain drift, or investigate whether `SifIopReset(NULL, 0x80000000)` (verbose-mode flag) has a different IOP-reset path than `("", 0)`.
 
-### 3) Startup/page split re-validation
-- Re-run HDD boot with a large HDD library on current source.
-- Expected:
-  - boot-time HDD auto-init should make the device runtime ready without building the HDD games list,
-  - first HDD page entry should still perform partition scan and game-list build normally.
+### 3) U-10 BOOT.ELF from HDD-booted POPSLoader
+- Long-standing, predates this session.
+- V2 didn't solve it. PR #458's attempts didn't solve it. Reverted.
+- Investigation candidates: explicit `dev9Shutdown()` before exec (the network/HDD expansion module retains hardware state across `SifIopReset` — BOOT.ELF inheriting that may be the culprit), or routing through the child loader with a specifically-crafted IOP teardown.
+- Worth a focused investigation PR (no code) before another fix attempt.
 
-### 4) Display and UX verification
+### 4) `PLDR.LAUNCH_ARGS` UI auto-navigation
+- Infrastructure landed in PR #458. Parsing, normalization, and a `PLDR.LAUNCH_ARGS = {page, page_raw, game, debug}` table all work.
+- Need to wire the consumer: `ui.lua` initial page selection should check `PLDR.LAUNCH_ARGS.page` and jump to the named carousel target on boot.
+- Smallest risk: gate on `PLDR.LAUNCH_ARGS.page ~= nil` only; existing flows unchanged when no flag passed.
+
+### 5) Display and UX verification
 - Re-run `U-06` to confirm PAL/NTSC menu asset proportions on hardware.
-- Re-run `U-08` and `U-09` on slower/large libraries to judge whether busy overlays communicate activity clearly enough.
+- Re-run `U-08` / `U-09` on slower/large libraries to judge whether busy overlays communicate activity clearly enough.
 
-### 5) Coverage and documentation
-- Add concrete run logs for:
-  - device switching without runtime locks (`D-13`),
-  - keyboard layout persistence (`S-09`),
-  - boot-device label display (`U-11`).
-- Keep `README.md`, `STATE.md`, `DECISIONS.md`, and `QA_REGRESSION_MATRIX.md` synchronized.
+### 6) Coverage and documentation
+- `STATE.md`, `TRUTHSHEET.md`, `QA_REGRESSION_MATRIX.md`, `HDD_POPSTARTER_HANDOFF.md` were all updated to current reality on 2026-05-25 alongside this file (PR #461).
+- Add concrete run logs for: D-13 device switching without runtime locks, S-09 keyboard layout persistence, U-11 boot-device label display.
 
 ## Secondary Work
 
 ### 1) Unimplemented menu paths
-- Implement `HDD (exFAT)` flow.
-- Implement `SMB (v1)` flow.
-- Implement `ILINK` flow.
+- `HDD (exFAT)`, `SMB (v1)`, `ILINK` — intentionally not implemented; surface "not supported" if entered.
 
 ### 2) Art/asset behavior
-- Keep current cover behavior stable:
-  - sidecar PNG beside the selected `.VCD`,
-  - HDD common art from `hdd0:__common/POPS/ART/<title>.png`.
-- Keep `default.png` optional in CI artifacts; missing default-cover builds must fall back to embedded `MISSING.png`.
-- Decide whether a broader ART system still needs to exist beyond those current code paths.
+- Keep current cover behavior stable: sidecar PNG beside the selected `.VCD`, plus `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
+- Keep `default.png` optional in CI artifacts; missing default-cover builds fall back to embedded `MISSING.png`.
 
 ### 3) Install/build clarity
 - Keep CI package layout and docs synchronized.
-- Keep GitHub-built hardware artifacts self-identifying: package `BUILD_INFO.txt` and fail CI when expected embedded runtime markers are missing.
-- Keep README installation steps explicit enough for users who are not familiar with PS2 launcher layouts.
+- Pin `ps2dev/ps2dev` image tag in `.github/workflows/compilation.yml` to a specific version instead of `:latest` (toolchain drift mitigation).
+- Lua syntax check now covers `bin/POPSLDR/*.lua` plus `etc/boot.lua` (extended in PR #461, was previously only boot.lua).
 
-### 4) Settings page UI redesign
-- 2026-05-19: first pass, single-page label/hint/value layout grouped into three sections with consistent metrics and a dirty indicator.
-- 2026-05-20: second pass moves to an OPL-style focused-list model. D-pad Up/Down moves a highlight bar between rows (skipping section headers and spacers); D-pad Left/Right cycles the focused value; X activates the focused row (cycles a cycle row, opens the path editor for a path row, or fires the menu action for an action row); O discards and exits; Start still resets defaults; Select still toggles hide-text. Adds Keyboard Layout as its own cycle row and surfaces Save Changes / Reset Defaults / Cancel as menu items at the bottom. The Square / L1 / R1 / Triangle one-button-per-field shortcuts are gone -- the whole interaction is D-pad-driven.
-- Hardware verification pending alongside the D-10/D-14/U-10 retest sequence. Walk the S-01..S-09 and U-01..U-11 rows on the next artifact to confirm parity (Square no longer toggles Video Standard; cycle it via Left/Right or X on the focused row).
-- Future polish (deferred, optional):
-  - If we grow Settings beyond ~14 visible rows, add scrolling.
-  - Consider grouping into category sub-pages (OPL pattern: top-level lists categories, each opens a child page) once there are more settings to justify the navigation cost.
+### 4) Settings UI redesign
+- 2026-05-19/20 OPL-style focused-list shipped (Settings page rewrite). Hardware verification deferred per the launch-path retest sequence.
+- Berion-mockup-driven GUI overhaul is queued (see #5 below). The OPL focused list is intended to be replaced when that overhaul lands, so further iteration on the focused list is paused unless a specific bug appears.
 
 ### 5) Full GUI overhaul (Berion mockups)
-- 2026-05-24: graphics-team mockups by Berion and the matching PNG asset set landed (`f8fec64`). The full implementation prompt and per-screen pixel specs live in `docs/GUI_OVERHAUL_PROMPT.md`.
-- Scope: Context menu, Settings (restructured as main page + per-category pages, superseding the current OPL focused-list), Joypad configuration, On-screen keyboard. Boot/splash and game list are explicitly out of scope.
-- Prereq: do not start until D-10/D-14/U-10 hardware verification settles. The category-page Settings model in the prompt replaces the OPL focused-list currently in production, so coordinate hardware retest sequencing.
-- Mockup HTML/JSX wrapper from Berion's package (`app/screens.jsx` + `app/styles.css` + `index.html`) is referenced by the prompt but is NOT yet committed to this repo -- only the PNG assets are. Commit the mockup files (or substitute a screenshot/hosted-mockup oracle) before starting the Lua port.
+- 2026-05-24: graphics-team mockups by Berion and the matching PNG asset set landed (`f8fec64`). Full implementation prompt and per-screen pixel specs live in `docs/GUI_OVERHAUL_PROMPT.md`.
+- Scope: Context menu, Settings (per-category pages superseding the OPL focused-list), Joypad configuration, On-screen keyboard. Boot/splash and game list are out of scope.
+- Prereq: hardware verification of DKWDRV-on-HDD + wLaunchELF + U-10 settles. The category-page Settings model in the prompt replaces the OPL focused-list, so coordinate retest sequencing.
+- Mockup HTML/JSX wrapper from Berion's package is referenced by the prompt but not yet committed; either commit the mockup files or use a screenshot/hosted-mockup oracle before starting the Lua port.
+
+### 6) Layer C full lazy IRX loading
+- Precursor landed in PR #458: pre-IRX device classification (`detectBootDeviceHintFromArgv0` / `System.getBootDeviceHint`).
+- Deferred (high risk for input/controllers): defer `mmceman` unless boot device is MMCE, `ds34bt` unless user has BT pads enabled, `usbd` unless boot device is USB/MX4SIO/DS3-4 USB.
+- Tackle only after current launch-path PRs (#458/459/460) are hardware-confirmed.
 
 ## Deferred Ideas
+
 - Additional themes/skins.
 - Broader network/backend support after SMB and ILINK have defined baselines.
 - More ambitious artwork cache policy after current launch/runtime issues are stable.
+- First-run MC-to-sidecar settings migration: if user moves POPSLoader to a new device, optionally copy `mc0:/POPSTARTER/.pldrs` to the new sidecar on first save.

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-05-20
+Last updated: 2026-05-25
 
 # STATE
 
@@ -8,154 +8,97 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 `QA_REGRESSION_MATRIX.md` is the detailed run ledger. This file summarizes the stable current repo state and the latest materially relevant hardware outcomes.
 
 ## Repo-Verified Runtime State
-- Boot/runtime uses embedded Lua scripts.
+
+### Boot and runtime
+- Boot/runtime uses embedded Lua scripts (`etc/boot.lua` → `system.lua` → `ui.lua`).
 - `bin/POPSLDR/IMG/default.png` is optional for GitHub Actions artifact builds; if it is absent, `IMG.default` falls back to the required embedded `MISSING.png` asset.
-- Settings are persisted at `mc0:/POPSTARTER/.pldrs`.
+- `_ps2sdk_memory_init()` in `src/main.cpp` performs an IOP reset before `main()` runs (`RESET_IOP=1` Makefile default). As of PR #458 (2026-05-25), this also runs `SifExitRpc()`, fresh `SifInitRpc(0)`, and `fileXioExit()` before the reset to detach any inherited RPC client from a parent that left `fileXio` loaded (e.g. wLaunchELF) — see `docs/LAUNCH_HYGIENE.md`.
+
+### Settings
+- Settings persist at `PLDR.SETTINGS_PATH`, which is resolved at load time by `LoadSettingsNonFatal`:
+  - **Sidecar preferred**: `APP_DIR_LOCAL/.pldrs` (the directory POPSLOADER.ELF lives in). HDD installs use `pfs1:/<install dir>/.pldrs` because `etc/boot.lua` mounts the boot partition `FIO_MT_RDWR` at `pfs1:` by default.
+  - **Fallback**: `mc0:/POPSTARTER/.pldrs` (the legacy path). Used when no sidecar can be computed (raw `hdd0:`/`ata:`/`apa:` paths with no live mount) or when the sidecar file doesn't exist yet.
+  - **Save**: writes to whichever path was loaded from, so settings stay where they were found.
 - Settings edits are staged and committed on Settings/Profile confirm/leave.
-- Persisted settings include:
-  - POPSTARTER path,
-  - DKWDRV path,
-  - video standard,
-  - hide-text mode,
-  - keyboard layout,
-  - BDMA mode.
-- Startup backend auto-init exists and uses:
-  - boot path information,
-  - configured executable paths,
-  - selected profile path.
-- HDD startup targets now run the same `PLDR.LoadHDDModules()` path used by the HDD page instead of only the lower-level exec helper.
-- USB vs MX4SIO split is based on mount-driver identity, not path-prefix guessing.
-- Runtime device access is not gated by the old device-lock system.
-- Main menu can show a boot-device label.
-- Exit modal exposes:
-  - `OSDSYS`
-  - `Cancel`
-  - `BOOT.ELF`
-- `BOOT.ELF` lookup order is:
-  - `mc0:/BOOT/BOOT.ELF`
-  - `mc1:/BOOT/BOOT.ELF`
-- Current cover sources are:
-  - sidecar PNG next to the selected `.VCD`,
-  - `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
-- Release packaging policy in CI is `PS1_POPSLOADER/*` + `POPS/PATCH_5.BIN` with strict manifest validation.
-- Current CI package also includes `PS1_POPSLOADER/BUILD_INFO.txt`, and the build/package workflow fails if the built ELF is missing key embedded runtime markers or if the generated embedded-loader blob was not regenerated.
-- Repository automation also includes `.github/workflows/opencode.yml`, a comment-triggered AI-assistance workflow; it is not part of the build/package validation contract.
+- Persisted settings include POPSTARTER path, DKWDRV path, video standard, hide-text mode, keyboard layout, BDMA mode.
 
-## Potential Settings/Path Integrity Risks
-- Repo-verified: `bin/POPSLDR/ui.lua` stages the Settings/Profile POPSTARTER path editor draft and now carries an explicit POPSTARTER mode into `PLDR.CommitSettingsChanges()`: manual path edits use `CUSTOM`, while explicit profile/default selection uses `PROFILE_DEFAULT`.
-- Repo-verified: `bin/POPSLDR/system.lua` `CommitSettingsChanges()` normalizes the incoming `popstarter_mode`, applies the normalized state, and then `EncodeSettings()` persists `POPSTARTER_MODE=<mode>` plus `POPSTARTER_PATH=<path>`; when the normalized mode is profile-default, `EncodeSettings()` intentionally writes an empty `POPSTARTER_PATH` and relies on the selected profile path at load time.
-- Hardware status: the settings/path mode correction is source-verified only until a memory-card `.pldrs` write plus reboot/load cycle is recorded in `QA_REGRESSION_MATRIX.md`; it is not a hardware claim for HDD-backed ELF execution.
-- Scope guard: this potential settings/path integrity risk is not claimed as the cause of `D-10`, `D-14`, or `U-10`; those remain tracked through the detailed hardware chronology in `QA_REGRESSION_MATRIX.md` and the decision notes in `DECISIONS.md`.
+### Boot-context resolution (PR #458 unification)
+- Single canonical resolver `ResolveBootContext()` in `system.lua` combines:
+  - The C-side argv[0] classification hint (`main.cpp` `detectBootDeviceHintFromArgv0()`, exposed via `System.getBootDeviceHint()`)
+  - Lua-side prefix matching (existing `mass`/`mmce`/`mx4sio`/`pfs`/`hdd`/`smb`/`host` plus new `usb`/`ata`/`apa` for newer ps2sdk prefixes)
+  - The mx4sio mass: fix (`classify_mass_boot` via BDM driver lookup + `.boot_mx4sio`/`.boot_usb` markers)
+- `DetectBootDevice()`, `PLDR.GetBootContext()`, `PLDR.GetBootKind()`, `ComputeSettingsSidecarPath` all read from this one resolver. No more three-way duplicate detection.
 
-## Main Menu Feature Status
-- `MMCE`: implemented in code.
-- `MX4SIO`: implemented in code.
-- `HDD (PFS)`: implemented in code.
-- `USB`: implemented in code.
-- `Disc (DKWDRV)`: implemented in code.
-- `HDD (exFAT)`: not implemented.
-- `SMB (v1)`: not implemented.
-- `ILINK`: not implemented.
+### Launch arguments (NHDDL-style, PR #458)
+- `parseLaunchArgs()` in `main.cpp` recognizes `-page=*`, `-mode=*` (NHDDL alias for `-page`), `-game=*`, `-debug`.
+- `System.getLaunchArgs()` exposes parsed values to Lua.
+- `PLDR.LAUNCH_ARGS = {page, page_raw, game, debug}` normalized in `system.lua`.
+- Auto-navigation wiring not yet consumed by `ui.lua`; the infrastructure is in place but a downstream PR is needed to wire `-page=hdd` into the initial page selection.
+
+### Backend init / runtime
+- Startup backend auto-init exists and uses boot path information, configured executable paths, and selected profile path.
+- HDD startup targets run `PLDR.LoadHDDModules()` (same as HDD page entry).
+- USB vs MX4SIO classification is via mount-driver identity (`System.getMassMountDriver` -> `sdc`/`mx4` -> MX4SIO; else USB).
+- Runtime device access is not gated by the old device-lock system; `canEnterDevice()` always returns true.
+
+### Launch paths (current routing)
+- **HDD POPSTARTER on HDD partition** (D-10): `LoadELFFromFileExecPS2RebootIOPWithPartition` → `ExecuteHddBackedViaEmbeddedLoader` → child loader `is_hdd_partition_context` branch (fileXioUmount + SifExitRpc/Cmd + ExecPS2, no IOP reset). Byte-identical to the 2026-05-22 B2 hardware-passing fix at commit `4ae6679`.
+- **Non-HDD POPSTARTER + HDD game** (D-15): same `ExecuteHddBackedViaEmbeddedLoader` route with the boot partition's PFS slot preserved via keep_mask.
+- **DKWDRV from MC** (Nuno 2026-05-25 confirmed PASS): reboot variant direct path, IOP reset + reload `SIO2MAN/MCMAN/MCSERV` + ExecPS2 with synthesized argv0.
+- **DKWDRV from HDD** (PR #460, source-verified, hardware pending): non-reboot variant → new DKWDRV special-case in `LoadELFFromFileWithPartition` → `ExecuteViaEmbeddedLoader` → child loader's filexio-direct-load branch (`SifExitRpc + FlushCache + ExecPS2`, no IOP reset). Mirrors V2 BOOT.ELF contract exactly.
+- **BOOT.ELF from USB-booted POPSLoader** (V2 working route): non-reboot variant → BOOT.ELF special-case in `LoadELFFromFileWithPartition` (line 485) → `ExecuteViaEmbeddedLoader` → child loader non-HDD branch (no IOP reset).
+- **BOOT.ELF from HDD-booted POPSLoader** (U-10, **known broken**): reboot variant direct path with IOP reset. Has never worked; V2 didn't solve it either. Treated as separate problem.
+
+### Main menu feature status
+- `MMCE`, `MX4SIO`, `HDD (PFS)`, `USB`, `Disc (DKWDRV)`: implemented in code.
+- `HDD (exFAT)`, `SMB (v1)`, `ILINK`: not implemented.
+
+### Exit handoff
+- Exit modal exposes OSDSYS, Cancel, BOOT.ELF.
+- BOOT.ELF lookup order: `mc0:/BOOT/BOOT.ELF`, `mc1:/BOOT/BOOT.ELF`.
+
+### Cover art
+- Sidecar PNG next to selected `.VCD`, or `hdd0:__common/POPS/ART/<title>.png` for HDD titles.
+
+### CI/release
+- Release packaging policy is `PS1_POPSLOADER/*` + `POPS/PATCH_5.BIN` with strict manifest validation.
+- Build is gated on embedded build identity markers (`Exec path:`, `PrepareForColdExternalELFLaunch`, `BOOT.ELF launch failed`) being present in `bin/enceladus.elf`.
+- Embedded loader blob staleness check runs when timestamp suggests `src/elf_loader/loader.c` is older than its source.
+- As of 2026-05-25, Lua syntax check covers all bundled `bin/POPSLDR/*.lua` plus `etc/boot.lua`; previously only `boot.lua` was validated.
 
 ## Reported Hardware Status
-- Shared default/Profile 1 local POPSTARTER baseline:
-  - 2026-03-27 hardware report initially failed with `Cant find POPSTARTER ELF` when booted from USB with USB `POPSTARTER.ELF` sidecar/cwd/Profile 1.
-  - comparison against `BETA-10-play-CHECKPOINT2` showed that branch's shared POPSTARTER resolution path worked without the later unverified common-path resolver/settings changes.
-  - current source was rolled back to the checkpoint branch's shared resolver behavior for this path.
-  - user confirmed that rolled-back source restored the shared baseline on hardware.
-- `U-05` OSDSYS exit:
-  - reported fixed on hardware.
-- `D-12` startup backend auto-init:
-  - a 2026-03-27 hardware report said booting from HDD did not auto-init the HDD driver stack.
-  - current source now routes HDD startup targets through `PLDR.LoadHDDModules()` instead of only `EnsureHddRuntimeReadyForExec()`.
-  - current source now keeps that startup HDD path limited to runtime readiness; it no longer scans HDD POPS partitions or builds the HDD game list during boot.
-  - HDD page entry still performs the partition scan and game-list build, and optional HDD cache writing now reuses the page-built list instead of rebuilding at startup.
-  - user previously confirmed the earlier HDD startup auto-init correction on hardware, but later 2026-03-28 reports on the narrowed boot-time split sources said HDD-backed startup/Profile POPSTARTER could still not be found after entering the USB page before the HDD page.
-  - the raw boot `APP_DIR` fallback alone did not restore that case.
-  - current source now also pre-resolves any HDD-backed startup/configured exec paths immediately after `PLDR.LoadHDDModules()` so HDD POPSTARTER/Profile paths are mounted and recorded without reintroducing HDD page work at boot.
-  - current source also routes on-demand HDD path mounts through `PLDR.LoadHDDModules()` instead of only the lower-level `EnsureHddRuntimeReadyForExec()` gate, so HDD POPSTARTER/Profile probes from USB or other pages use the same runtime init path as HDD page entry.
-  - current source also fixes the startup warm-path classification for Profile 1/default relative `POPSTARTER.ELF`, which had previously been skipped because only explicit `hdd:` / `pfs:` paths were being marked for HDD warm-up.
-  - because `etc/boot.lua` establishes HDD boot on a dedicated `pfs1:` mount before `system.lua` runs, current source now also carries that exact boot partition/slot metadata into `system.lua`, seeds the HDD mount tracker from it, and rebuilds HDD sidecar/partition context from mounted `pfs1:` candidates instead of relying only on later rediscovery.
-  - user later confirmed on 2026-03-28 that the exact-boot-mount/source-context source restored the USB-before-HDD-page startup/Profile repro on hardware.
-  - latest recorded hardware on this line is therefore `PASS`; preserve that behavior through further `D-10` work.
-- `D-16` first-entry USB backend discovery:
-  - a 2026-03-27 hardware report said the first USB page entry reported no backend, but backing out and re-entering then worked.
-  - current source now adds a bounded wait between failed USB root probes in `BuildUsbIdentityDeferred()`.
-  - MX4SIO discovery code was not changed by this correction.
-  - user later confirmed that corrected source fixed the first-entry USB issue on hardware.
-- `D-10` HDD POPSTARTER on HDD:
-  - reported failing on hardware.
-  - repro: boot from HDD, launch HDD title with HDD `POPSTARTER.ELF` sidecar/CWD.
-  - result: black-screen hang.
-  - 2026-03-27 re-test of the current source still failed when booted from HDD with default/Profile 1/cwd/sidecar `POPSTARTER.ELF` on HDD and game device HDD.
-  - current source also exposes an `R2` alternate HDD launch path for HDD-resident `POPSTARTER.ELF` that swaps only the selector contract to `hdd0:PART:pfs0:/GAME.ELF`.
-  - later 2026-03-27 experimental sources also black-screened after direct-load, Memory Card staging, and stripped-handoff changes.
-  - user later confirmed on 2026-03-28 that the narrowed source restored `D-15`, so this remaining blocker is again isolated to HDD-backed `POPSTARTER.ELF`.
-  - a later 2026-03-28 re-test still black-screened on the narrowed Lua-side HDD-backed source with no visible positive change.
-  - a later 2026-03-28 re-test on the loader-side no-auto-exec-slot-preserve source still black-screened on both `X` and `R2`.
-  - a later 2026-03-28 re-test on the forced-`reboot_iop = 1` source still black-screened on both `X` and `R2`.
-  - a later 2026-03-28 re-test on the direct-`hdd0:PART:pfsN:/POPSTARTER.ELF` preference source still black-screened on `X`.
-  - a later 2026-03-28 re-test on the mounted-`pfs0:` embedded-loader source still black-screened on `X`.
-  - follow-up repo comparison showed that earlier source-context work had still been incomplete because Lua had usually already normalized HDD POPSTARTER to mounted `pfs1:` / `pfs3:` paths before the reboot loader saw it.
-  - a later 2026-03-28 re-test on that exact-boot-mount/source-context source still black-screened on `X`.
-  - current source now replaces the earlier ad hoc HDD source-context reboot handoff with an explicit partition-aware contract across Lua, `src/luasystem.cpp`, `src/elf_loader/src/elf.c`, and the embedded loader.
-  - on that contract, the parent passes exact HDD partition context separately from the mounted load path, normalizes the partition-aware exec filename to generic `pfs:/...`, remounts `pfs0:` from that partition while reusing the mounted relpath Lua already resolved, and no longer preserves the old tracked `pfsN:` mount into exec.
-  - a 2026-03-29 `D-10` run on the prior partition-aware source no longer black-screened, but the launcher regained control with `rc=-1 (returned after 22618 ms)`, which narrowed the remaining failure to the embedded-loader or target-`ExecPS2` handoff instead of HDD path discovery on that specific artifact.
-  - a later 2026-03-29 GitHub artifact re-test on that broader partition-aware/current-source line black-screened again, so the returned-rc boundary is not yet stable enough to treat as the new steady state.
-  - current source also reports the actual exec filename separately from the probed/opened POPSTARTER path in the launcher popup so mounted-slot probe paths do not masquerade as the real load target.
-  - current source now restores more of the original parent-side embedded-loader jump contract in `src/elf_loader/src/elf.c`: BRAM wipe plus `SifInitRpc`/`SifLoadFileInit`/`SifLoadFileExit` before the copy, and `SifExitIopHeap`/`SifExitRpc`/`SifExitCmd` before the final `ExecPS2`.
-  - current source also returns the actual embedded-loader `ExecPS2` result instead of collapsing it to `-1`, keeps legacy `System.loadELF(path, reboot_iop, selector)` on POPSTARTER's normal one-argument selector contract, routes partition-aware HDD launches through the explicit `System.loadELFWithPartition(path, reboot_iop, partition_context, selector)` API and mounted-`pfs0:` `SifLoadElf` in the embedded loader so they match the reference loaders more closely once the parent has already remounted the target partition, normalizes stale canonical profile-path state so Profile 1/default no longer silently keeps another profile's HDD path, and keeps the older iomanX-aware `fileXio` load path only as the fallback for direct `pfs:` / `hdd:` loads with no HDD partition context.
-  - 2026-05-19 source audit found remaining handoff defects before new hardware retests: Lua mounted-PFS fallback can leave stale launch context, normal HDD game labels can fail fallback partition parsing, the fallback path can skip the pre-exec gate even when reconstruction failed, `System.loadELF(..., args..., partition_context)` can leak the partition context into target argv, and the child loader still uses `snprintf`/`strncat` despite older docs claiming that risk was avoided. See `HDD_POPSTARTER_HANDOFF.md`.
-  - 2026-05-19 source change addresses the audit defects (excluding child-loader `snprintf` cleanup which would require regenerating the embedded loader blob): `ResolveFallbackMountedPfsExecPath` now accepts bare partition labels via `NormalizeHddPartitionLabelForMount`, `RunPOPStarterGame` syncs `context.exec_path`/`exec_partition_context`/`exec_*_slot`/`cold_external_launch`/`keep_hdd_slots*` and `launch_diagnostics` after a successful fallback, the HDD pre-exec gate is skipped only when the fallback actually reconstructed a path, `src/luasystem.cpp` exposes a dedicated `System.loadELFWithPartition(path, reboot_iop, partition_context, args...)` binding instead of overloading `System.loadELF` with a trailing partition_context (the trailing detection was removed so partition_context can no longer leak into target argv), `LaunchEngine` calls the new binding when `context.exec_partition_context` is set, and `ExecuteViaEmbeddedLoader` no longer rejects `argc == 0` so the child loader's documented default-argv synthesis is reachable. The POPSTARTER-specific `argv[0]` guard in `ExecuteHddBackedViaEmbeddedLoader` is unchanged.
-  - 2026-05-20 hardware screenshot from the latest `BETA-12-PLAY` artifact returned to the launcher with `POPSTARTER HDD pre-exec gate failed: Cannot resolve HDD partition context` for `POP:pfs3:/POPS/POPSTARTER.ELF` and `APP:hdd0:+OPL:pfs:/APPS/PS1_POPSLOADER/`.
-  - 2026-05-20 source follow-up keeps the selector `argv[0]` contract unchanged, fixes argument-shifted failure-popup route/gate diagnostics, lets Lua parse `hdd0:PART:` partition-context strings, allows safe bare HDD partition labels in the shared recovery candidate builder, and makes mounted-PFS fallback recover the actual POPSTARTER source partition before falling back to the selected HDD game partition.
-  - a later readable 2026-05-20 screenshot showed the next pre-exec gate failure: the gate checked generic `pfs:/POPS/POPSTARTER.ELF` even though the real mounted path was `pfs3:/POPS/POPSTARTER.ELF`. Current source now probes a real mounted path in the gate while preserving the generic exec path for the partition-aware C loader.
-  - current source now makes that partition-aware path non-default for normal HDD-backed POPSTARTER attempts. Normal `X` uses the real resolved executable path, clears Lua partition context, skips the Lua HDD pre-exec gate/remount fallback, and calls the direct non-reboot legacy `System.loadELF(path, 0, selector)` contract.
-  - after the direct non-reboot artifact still black-screened before POPSTARTER debug screens, current source removes the HDD-only parent cleanup immediately before `ExecPS2` in `LoadELFFromFileExecPS2()` so the direct HDD handoff no longer exits SIF heap/RPC/CMD or unmounts PFS slots differently from the working non-HDD POPSTARTER path.
-  - latest recorded hardware result on this `D-10` line is still FAIL on the previous artifact; the 2026-05-20 source follow-up is repo-verified only and `D-10` remains `Unknown (verify on hardware)` for the next artifact.
-- `D-14` HDD-backed POPSTARTER with non-HDD game:
-  - reported failing on hardware.
-  - repro: launch a non-HDD title while `POPSTARTER.ELF` itself is configured on HDD.
-  - 2026-03-27 user hardware also black-screened when launching a USB game with Profile 2 pointing `POPSTARTER.ELF` to HDD.
-  - the user later clarified that the other same-day 2026-03-28 success report referred to `D-15`, not this case.
-  - a later 2026-03-28 re-test on the forced-`reboot_iop = 1` source still black-screened on `X`; `R2` produced no response in that non-HDD-game repro.
-  - a later 2026-03-28 re-test on the direct-`hdd0:PART:pfsN:/POPSTARTER.ELF` preference source still black-screened on `X`.
-  - current source now uses the same partition-aware HDD reboot contract as `D-10`, rather than the earlier ad hoc source-context handoff or whichever mounted `pfsN:` path Lua happened to resolve first.
-  - latest recorded hardware remains `FAIL`; current exact-line result is still `Unknown (verify on hardware)`.
-- `D-15` HDD game with non-HDD sidecar POPSTARTER:
-  - reported as a regression on hardware.
-  - repro: boot from a non-HDD device with sidecar `POPSTARTER.ELF` on that same device, then launch an HDD title.
-  - 2026-03-27 user hardware reported a black screen on the EE-side HDD direct-load attempt.
-  - a later 2026-03-27 hardware report also black-screened on the broader stripped-handoff HDD-game path.
-  - current source now removes Lua-side HDD game pre-mount/CWD preservation from this path and passes only the normal selector handoff unless `POPSTARTER.ELF` itself is HDD/PFS-backed.
-  - user later confirmed on 2026-03-28 that USB boot + USB sidecar/cwd `POPSTARTER.ELF` + HDD game passes on hardware.
-  - user reported a 2026-05-20 latest-artifact regression: USB boot with USB sidecar/cwd `POPSTARTER.ELF`, then launching an HDD title, black-screened.
-  - current source follow-up restores legacy `System.loadELF(path, reboot_iop, selector)` one-argument selector behavior for normal/non-HDD POPSTARTER launches and keeps partition context on the explicit HDD API; hardware result is `Unknown (verify on hardware)`.
-  - user then reported the narrowed default/cwd sidecar failure: explicit `mass:/POPS/POPSTARTER.ELF` launches, but default `POPSTARTER.ELF` can stop at `Cant find POPSTARTER ELF`. Current source expands default sidecar lookup to include the live current directory plus boot/app directories; hardware result is `Unknown (verify on hardware)`.
-- `U-10` BOOT.ELF after HDD page init:
-  - one prior artifact was reported good,
-  - repo history shows the BOOT.ELF modal later moved from its older non-reboot direct `System.loadELF(elf_path, 0, elf_path)` path to a reboot-I/O path with launch-CWD setup.
-  - a later 2026-03-29 hardware report said BOOT.ELF still behaved incorrectly after HDD runtime had been initialized.
-  - current working inference is that `U-10` may share the same underlying handoff/state-poisoning boundary as `D-10`, but that remains unproven and `U-10` still requires separate hardware confirmation.
-  - current source now keeps the no-launch-CWD rollback, re-enables `reboot_iop = 1` for BOOT.ELF only when HDD runtime has already been loaded, and uses a BOOT.ELF-specific cold external-launch prep that clears the exec keep mask and unmounts tracked HDD slots instead of preserving boot PFS state.
-  - current-source hardware status on this conditional-reboot/cold-prep line is `Unknown (verify on hardware)`.
-- `U-06` PAL asset aspect:
-  - current code compensates for PAL UI layout,
-  - hardware result is still `Unknown (verify on hardware)`.
+
+| Case | Last result | Date | Notes |
+|---|---|---|---|
+| **D-10** HDD POPSTARTER + HDD game | **PASS** | 2026-05-22 | B2 fix at commit `4ae6679` (PFS unmount before ExecPS2). Preserved through all subsequent PRs. |
+| **D-14** HDD POPSTARTER + non-HDD game | **PASS** | 2026-05-22 | Same partition-aware route as D-10. |
+| **D-15** non-HDD POPSTARTER + HDD game | **PASS** | 2026-05-22 | Keep-mask preserves boot partition's PFS slot across exec. |
+| **DKWDRV from MC** | **PASS** | 2026-05-25 | Reboot variant direct path with argv0 synthesis. Confirmed by Nuno on PR #458 artifact. |
+| **DKWDRV from HDD custom path** | **FAIL** | 2026-05-25 (PR #458) | Confirmed by Nuno. PR #460 ships V2-mimicry fix (non-reboot variant + new DKWDRV embedded-loader route). Hardware pending. |
+| **BOOT.ELF from USB-booted POPSLoader** (L-07) | Source-verified | (V2 working state d23520a 2026-05-23) | PR #458 regressed this by adding an `is_boot_elf_target` IOP-reset branch in the child loader. PR #460 reverts that revert; expected back to V2-working behavior on next hardware test. |
+| **BOOT.ELF from HDD-booted POPSLoader** (U-10) | **FAIL** | 2026-05-25 | Long-standing. V2 didn't solve this either. Not addressed by PR #460. Separate problem; pursued only after PR #460 hardware verdict. |
+| **POPSLoader launched from wLaunchELF** | **FAIL** (CosmicScale 2026-05-25) | 2026-05-25 | Some wLaunchELF builds. PR #458's `_ps2sdk_memory_init` fileXio teardown (Layer A) targets this. Hardware pending. |
+| **POPSLoader launched from PSBBN / Browser / HOSDMenu / OSDMenu** | **PASS** | (ongoing) | CosmicScale 2026-05-25 confirmed these work. |
+| **U-05** OSDSYS exit | Reported fixed (date unrecorded) | — | |
+| **U-06** PAL asset aspect | Unknown (verify on hardware) | — | |
+| **D-12** startup backend auto-init | PASS | 2026-03-28 | `PLDR.LoadHDDModules()` routing restored Profile/cwd HDD POPSTARTER resolution. |
+| **D-13** device switching without runtime locks | Unknown | — | |
+| **D-16** first-entry USB backend discovery | PASS | (after 2026-03-27 fix) | Bounded wait in `BuildUsbIdentityDeferred()`. |
+| **U-11** boot-device label display | Unknown | — | Main menu can show the label; not formally verified. |
+| **S-09** keyboard layout persistence | Unknown | — | |
 
 ## Known Open Work
-- Preserve the reported `D-12` HDD startup auto-init fix while iterating on HDD launch-path regressions.
-- Preserve the dedicated HDD boot `pfs1:` mount contract from `etc/boot.lua` while iterating on startup/Profile resolution.
-- Preserve the reported `D-16` USB first-entry fix and confirm MX4SIO behavior remains unchanged on future retests.
-- Resolve HDD-backed `POPSTARTER.ELF` handoff when POPSTARTER itself is on HDD, including non-HDD game launches.
-- Preserve the restored `D-15` path where HDD titles launch correctly when POPSTARTER stays on the non-HDD boot device.
-- Re-verify `BOOT.ELF` after HDD page init on current source.
-- Record concrete run logs in `QA_REGRESSION_MATRIX.md`.
-- Implement HDD exFAT menu flow.
-- Implement SMB menu flow.
-- Implement ILINK menu flow.
-- Decide whether a broader ART system is still needed beyond current sidecar/HDD-common cover support.
+
+1. **U-10 BOOT.ELF from HDD-booted POPSLoader** — still broken, not solved by V2 or PR #458/460. Investigation pending. Suspect DEV9 hardware state or memory-layout pollution unique to HDD-booted POPSLoader; needs diagnostic instrumentation to confirm before next code attempt.
+2. **DKWDRV-on-HDD and wLaunchELF launch verdicts** — awaiting hardware testing of PR #460 artifact at https://github.com/NathanNeurotic/POPSLoader/actions/runs/26416917597 .
+3. **`PLDR.LAUNCH_ARGS` UI auto-navigation** — infrastructure landed in PR #458; consumer not yet wired into `ui.lua` initial page selection.
+4. **Layer C full lazy IRX loading** — only the precursor (device hint) shipped. Aggressive deferrals (`mmceman` unless MMCE boot, `ds34bt` unless BT enabled, `usbd` unless USB family) queued for a separate PR after current launch-path fixes settle.
+5. **Settings sidecar first-run MC-to-sidecar migration** — currently we just save where we loaded from. Could optionally copy MC settings to per-device sidecar on first save when the user moves POPSLoader to a new device.
+6. **Settings UI redesign (Berion mockup)** — gated on U-10 + DKWDRV-HDD + wLaunchELF hardware results settling. Mockup PNGs still to land at `C:\Users\natha\Documents\assets\` for `docs/mockups/`.
+7. **HDD (exFAT), SMB (v1), ILINK** menu flows remain intentionally unimplemented.
 
 ## Verification Status
-- Code/build/package statements above are repository-verified.
-- Hardware behavior is `Unknown (verify on hardware)` unless explicitly recorded as a reported result.
+
+- Code/build/package statements above are repository-verified at commit `740fa87` (BETA-12-PLAY head after PR #460 merge).
+- Hardware behavior is `Unknown (verify on hardware)` unless explicitly recorded in the table above with a date.
+- See `QA_REGRESSION_MATRIX.md` for the full experiment chronology.

--- a/TRUTHSHEET.md
+++ b/TRUTHSHEET.md
@@ -1,4 +1,4 @@
-Last updated: 2026-03-29
+Last updated: 2026-05-25
 
 # TRUTHSHEET
 
@@ -12,10 +12,10 @@ Non-negotiable behavioral invariants that changes must preserve unless an explic
 - Rationale: deterministic startup and no dependency on external Lua script files.
 - Verification: embedded searcher is installed, filesystem Lua loaders are disabled, and required runtime Lua blobs are embedded.
 
-### Truth 2: Settings persistence is transactional
+### Truth 2: Settings persistence is transactional and per-device
 - Scope: `bin/POPSLDR/ui.lua`, `bin/POPSLDR/system.lua`.
-- Rationale: avoid immediate writes while navigating and keep save/apply failure handling explicit.
-- Verification: edits stage in drafts; `CommitSettingsChanges` runs on confirm/leave; persisted file is `mc0:/POPSTARTER/.pldrs`.
+- Rationale: avoid immediate writes while navigating, keep save/apply failure handling explicit, and let a POPSLoader install carry its own settings (not always to Memory Card).
+- Verification: edits stage in drafts; `CommitSettingsChanges` runs on confirm/leave; `PLDR.SETTINGS_PATH` is resolved at load time -- `APP_DIR_LOCAL/.pldrs` sidecar preferred (HDD installs land at `pfs1:/<install dir>/.pldrs` because `etc/boot.lua` mounts the boot partition RW by default), with `mc0:/POPSTARTER/.pldrs` as fallback. Save writes go to whichever was loaded.
 
 ### Truth 3: USB vs MX4SIO identity comes from mount driver
 - Scope: `bin/POPSLDR/system.lua`, `src/luasystem.cpp`.
@@ -51,11 +51,16 @@ Non-negotiable behavioral invariants that changes must preserve unless an explic
 - `HDD (exFAT)` main-menu path is intentionally not implemented and must continue to report that status until feature work lands.
 - `SMB (v1)` main-menu path is intentionally not implemented and must continue to report that status until feature work lands.
 
-## Current Unresolved Hardware Markers
-- `D-10`: HDD `POPSTARTER.ELF` on HDD sidecar/CWD is still reported to black-screen on hardware.
-- `D-14`: non-HDD game + HDD-backed `POPSTARTER.ELF` is also still reported failing on hardware.
-- `U-10`: `BOOT.ELF` after HDD page init is still a connected concern; the current conditional-reboot/cold-prep line remains `Unknown (verify on hardware)`.
-- `U-06`: PAL/NTSC menu asset proportions still need hardware confirmation.
+## Current Hardware Status Markers
+- `D-10` (HDD POPSTARTER + HDD game): **PASS** as of 2026-05-22 hardware (B2 fix at commit `4ae6679`). Must be preserved by any future launch-path change.
+- `D-14` (HDD POPSTARTER + non-HDD game): **PASS** as of 2026-05-22 hardware. Same partition-aware route as D-10.
+- `D-15` (non-HDD POPSTARTER + HDD game): **PASS** as of 2026-05-22 hardware.
+- `DKWDRV from MC`: **PASS** as of 2026-05-25 hardware (Nuno).
+- `DKWDRV from HDD custom path`: **Hardware pending** on PR #460 (V2-mimicry, commit `740fa87`); previous PR #458 attempt FAILED 2026-05-25.
+- `BOOT.ELF from USB-booted POPSLoader` (L-07): V2 working route restored by PR #460. Hardware pending re-verification.
+- `BOOT.ELF from HDD-booted POPSLoader` (U-10): **FAIL** 2026-05-25 (Nuno). Long-standing, not addressed by current PRs. Pursued only after PR #460 verdict settles.
+- `POPSLoader from wLaunchELF`: **FAIL** on some wLE builds (CosmicScale 2026-05-25). PR #458's fileXio-teardown in `_ps2sdk_memory_init` targets this. Hardware pending.
+- `U-06` (PAL/NTSC menu asset proportions): Unknown, still needs hardware confirmation.
 
 ## Add-New-Truth Template
 ```markdown

--- a/src/include/luaplayer.h
+++ b/src/include/luaplayer.h
@@ -37,8 +37,6 @@ int ResolveAssetPathTyped(char* out, size_t outsz, const char* relativeName, Ass
 #define dbgprintf(args...) ;
 #endif
 
-int getBootDevice(void);
-
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define CLAMP(val, min, max) ((val)>(max)?(max):((val)<(min)?(min):(val)))
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -13,8 +13,6 @@
 
 //extern int size_loader_elf;
 
-void IOP_Reset(void);
-
 /* Normalize a pathname by removing
   . and .. components, duplicated /, etc. */
 char* __ps2_normalize_path(char *path_name)
@@ -166,154 +164,19 @@ int ResolveAssetPathTyped(char* out, size_t outsz, const char* relativeName, Ass
 }
 
 
-void IOP_Reset(void)
-{
-	// resets IOP and update with EELOADCNF
-	
-  	while(!SifIopReset("rom0:UDNL rom0:EELOADCNF",0));
-  	while(!SifIopSync());
-  	SifExitIopHeap();
-  	SifLoadFileExit();
-  	SifExitRpc();
-  	SifExitCmd();
-  	
-  	SifInitRpc(0);
-  	FlushCache(0);
-  	FlushCache(2);
-}
-
-//--------------------------------------------------------------
-// ELF-header structures and identifiers
-#define ELF_MAGIC	0x464c457f
-#define ELF_PT_LOAD	1
-
-//--------------------------------------------------------------
-typedef struct
-{
-	u8	ident[16];
-	u16	type;
-	u16	machine;
-	u32	version;
-	u32	entry;
-	u32	phoff;
-	u32	shoff;
-	u32	flags;
-	u16	ehsize;
-	u16	phentsize;
-	u16	phnum;
-	u16	shentsize;
-	u16	shnum;
-	u16	shstrndx;
-} elf_header_t;
-//--------------------------------------------------------------
-typedef struct
-{
-	u32	  type;
-	u32	  offset;
-	void *vaddr;
-	u32	  paddr;
-	u32	  filesz;
-	u32	  memsz;
-	u32	  flags;
-	u32	  align;
-} elf_pheader_t;
-
-void load_modules(void)
-{
-    // Apply loadmodulebuffer and prefix check patch
-    sbv_patch_enable_lmb();
-    sbv_patch_disable_prefix_check();
-    
-    SifLoadModule("rom0:SIO2MAN", 0, 0);
-	SifLoadModule("rom0:CDVDFSV", 0, 0);
-    SifLoadModule("rom0:CDVDMAN", 0, 0);
-    SifLoadModule("rom0:MCMAN", 0, 0);
-    SifLoadModule("rom0:MCSERV", 0, 0);
-   	SifLoadModule("rom0:PADMAN", 0, 0);  
-	
-}
-
-void CleanUp(int iop_reset)
-{	
-   if (iop_reset) {
-   		IOP_Reset();
-    
-   		SifLoadFileInit();
-		load_modules();
-	}
-	
-  	SifExitIopHeap();
-  	SifLoadFileExit();
-  	SifExitRpc();
-  	SifExitCmd();
-  	
-  	FlushCache(0);
-  	FlushCache(2);
-}
-
-/*
-void load_elf(const char *elf_path, int reboot_iop, char** Cargs, int Cargc)
-{   
-	u8 *boot_elf;
-	elf_header_t *boot_header;
-	elf_pheader_t *boot_pheader;
-	int i;
-	char *args[6];
-	char **final_argv;
-	int final_argc = 1;
-	char elfpath[1024];
-	//int n = 0;
-	
-    CleanUp(reboot_iop);	
-
-	SifInitRpc(0);
-	SifLoadFileInit();
- 	SifLoadFileExit();  
-
-	strcpy(elfpath, elf_path);
-	if (Cargs == NULL || Cargc < 1) {
-		args[0] = elfpath;
-		args[1] = elfpath;
-		final_argv = args;
-	} else {
-		final_argv = Cargs;
-		final_argc = Cargc;
-	}
-
-	// Load & execute embedded loader from here	
-	boot_elf = (u8 *)&loader_elf;
-	
-	// Get Elf header
-	boot_header = (elf_header_t *)boot_elf;
-	
-	// Check elf magic
-	if ((*(u32*)boot_header->ident) != ELF_MAGIC) 
-		return;
-
-	// Get program headers
-	boot_pheader = (elf_pheader_t *)(boot_elf + boot_header->phoff);
-	
-	// Scan through the ELF's program headers and copy them into apropriate RAM
-	// section, then padd with zeros if needed.
-	for (i = 0; i < boot_header->phnum; i++) {
-		
-		if (boot_pheader[i].type != ELF_PT_LOAD)
-			continue;
-
-		memcpy(boot_pheader[i].vaddr, boot_elf + boot_pheader[i].offset, boot_pheader[i].filesz);
-	
-		if (boot_pheader[i].memsz > boot_pheader[i].filesz)
-			memset((void*)((int)boot_pheader[i].vaddr + boot_pheader[i].filesz), 0, boot_pheader[i].memsz - boot_pheader[i].filesz);
-	}		
-	
-	SifExitRpc();
-	
-	// Execute Elf Loader
-	ExecPS2((void *)boot_header->entry, 0, final_argc, final_argv);	
-	
-}
-*/
-///////////////////////////////////////////////
+/* Removed 2026-05-25 (audit cleanup):
+ *
+ * The IOP_Reset / load_modules / CleanUp trio and the commented-out
+ * load_elf function were the original (pre-elf_loader) launch
+ * infrastructure. They were superseded by src/elf_loader/src/elf.c and
+ * the BRAM child loader long ago; the only caller of CleanUp was the
+ * already-commented-out load_elf, so the whole chain was dead weight
+ * with shadow elf_header_t / elf_pheader_t typedefs that conflicted
+ * with the proper definitions in src/elf_loader/src/elf.h.
+ *
+ * If you need to reference the historical implementation, it's
+ * preserved in git history at commit dff091c (BETA-12-PLAY pre-audit).
+ */
 
 void* AllocateLargestFreeBlock(size_t* Size)
 {


### PR DESCRIPTION
## Summary

Hardware-test-independent cleanup while we wait on testers. Three categories of change, all source-verified or text-only.

### Doc refresh (no hardware claims, source-verified state only)

- **STATE.md**: rewritten to reflect current repo at \`740fa87\` (BETA-12-PLAY head). D-10/D-14/D-15/DKWDRV-MC marked PASS per 2026-05-22/25 hardware. DKWDRV-HDD/wLaunchELF/L-07 marked hardware-pending on PR #460. U-10 marked still broken (separate problem). Includes settings sidecar, ResolveBootContext unification, PLDR.LAUNCH_ARGS infrastructure, and full current launch-path routing matrix.
- **ROADMAP.md**: rewritten with current priorities — test PR #460, wLaunchELF, U-10 investigation, LAUNCH_ARGS UI wiring. Berion GUI overhaul gated on current launch-path verdict.
- **TRUTHSHEET.md**: Truth 2 updated — settings are now per-device sidecar with MC fallback, not unconditionally \`mc0:/POPSTARTER/.pldrs\`.
- **HDD_POPSTARTER_HANDOFF.md**: marked **RESOLVED** at the top. Historical content preserved below. D-10/D-14/D-15 closed by the B2 fix at commit \`4ae6679\` on 2026-05-22.
- **QA_REGRESSION_MATRIX.md**: appended 2026-05-25 rows for Nuno's PR #457/#458 hardware results, CosmicScale's wLaunchELF report, and PR #460 source-verified status. Historical chronology unchanged.

### Code cleanup (dead-weight removal, no behavior change)

- \`src/system.cpp\`: removed dead \`IOP_Reset\` / \`load_modules\` / \`CleanUp\` functions and the commented-out \`load_elf\` block. These were the pre-elf_loader launch infrastructure, superseded by \`src/elf_loader/src/elf.c\` long ago. Only \`CleanUp\`'s caller was the already-commented-out \`load_elf\`. Shadow \`elf_header_t\` / \`elf_pheader_t\` typedefs that conflicted with the proper definitions in \`src/elf_loader/src/elf.h\` also removed.
- \`src/include/luaplayer.h\`: removed dangling \`int getBootDevice(void);\` declaration with no definition anywhere.

Historical implementation preserved in git history at \`dff091c\`.

### CI improvement

- \`.github/workflows/compilation.yml\`: extended the Lua syntax validation step to cover all bundled \`bin/POPSLDR/*.lua\` plus \`etc/boot.lua\`. Previously only \`boot.lua\` was checked. The others are embedded via \`bin2c\` as raw bytes, so syntax errors otherwise only surfaced at runtime on real hardware.

## Safety

- **Zero source-code logic touched.** Only docs, dead-code removal, and CI surface.
- **D-10 / D-14 / D-15 / DKWDRV / BOOT.ELF / settings / all launch paths untouched.**
- Designer's work (Settings redesign, toast notifications, 33 PNG assets, Berion GUI overhaul prompt) all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)