### PR TITLE
[PROBE - DO NOT MERGE YET] HDD r/w driver swap (ps2hdd-osd -> ps2hdd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ IOP_MODULES = iomanX.o fileXio.o \
 			  sio2man.o mcman.o mcserv.o padman.o libsd.o \
 			  usbd.o audsrv.o bdm.o bdmfs_fatfs.o \
 			  usbmass_bd.o cdfs.o ds34bt.o ds34usb.o \
-			  ps2dev9.o ps2atad.o ps2hdd-osd.o ps2fs.o mmceman.o \
+			  ps2dev9.o ps2atad.o ps2hdd.o ps2fs.o mmceman.o \
 			  mx4sio_bd.o bdm_query.o
 
 EMBEDDED_RSC = boot.o builtin_font.o \

--- a/src/luaHDD.cpp
+++ b/src/luaHDD.cpp
@@ -84,7 +84,7 @@ static int GetHDDStatus(lua_State *L) {
 IMPORT_BIN2C(poweroff_irx);
 IMPORT_BIN2C(ps2dev9_irx);
 IMPORT_BIN2C(ps2atad_irx);
-IMPORT_BIN2C(ps2hdd_osd_irx);
+IMPORT_BIN2C(ps2hdd_irx);
 IMPORT_BIN2C(ps2fs_irx);
 
 #define CHECK_ERR(MODULE) if (ID < 0 || RET == 1) {lua_pushboolean(L, false); lua_pushstring(L, MODULE); lua_pushinteger(L, ID); lua_pushinteger(L, RET); goto ERR;}
@@ -116,7 +116,7 @@ static int Load_HDD_IRX(lua_State *L) {
     CHECK_ERR("ATAD");
 
     /* PS2HDD.IRX */
-    ID = SifExecModuleBuffer(&ps2hdd_osd_irx, size_ps2hdd_osd_irx, sizeof(hddarg), hddarg, &RET);
+    ID = SifExecModuleBuffer(&ps2hdd_irx, size_ps2hdd_irx, sizeof(hddarg), hddarg, &RET);
     DPRINTF(" [PS2HDD.IRX]: ret=%d, ID=%d\n", RET, ID);
     CHECK_ERR("PS2HDD");
 


### PR DESCRIPTION
## DO NOT MERGE — TEST ARTIFACT ONLY

This is a **probe** to test whether the read-only-vs-read-write IRX driver variant is what makes HDD settings sidecar saves fail.

## Background

Nuno's 2026-05-26 hardware test on PR #464 confirmed:
- ✅ boot.lua `pfs1:` path normalization works (error msg now correctly shows `pfs1:/APPS/PS1_POPSLOADER/.pldrs` instead of slot-less `pfs:/...`)
- ❌ HDD settings save still fails with "may be read-only"

The mount IS RW per FIO_MT_RDWR default in `src/luaHDD.cpp:23`. So the failure is on the IRX driver side. POPSLoader embeds `ps2hdd-osd.irx` — the OSD-context variant of the HDD driver. The regular `ps2hdd.irx` is the full-capability variant other PS2 homebrew (OPL game saves, wLE config writes, etc.) uses for HDD writes.

## What this PR changes

**2 lines, surgical:**

- `Makefile` IOP_MODULES: `ps2hdd-osd.o` → `ps2hdd.o`
- `src/luaHDD.cpp` (4 substitutions): `ps2hdd_osd_irx` → `ps2hdd_irx`

The Makefile vpath pulls `$(PS2SDK)/iop/irx/ps2hdd.irx` for the new build.

## Risk

D-10 (HDD POPSTARTER + HDD game) currently passes and uses this driver for reads. **If the regular `ps2hdd.irx` has different runtime semantics from `-osd`, D-10 could regress.** That's the high-risk failure mode. Only hardware test confirms.

## Hardware test plan (for Nuno or any HDD-equipped tester)

In this exact order:

1. **D-10 regression check (CRITICAL):** HDD-installed POPSLoader + HDD POPSTARTER + HDD game. Must still launch successfully.
2. **HDD settings save (NEW positive control):** Change a setting (Video Standard, Profile, anything), exit, reboot, reopen Settings. Saved value should persist via `pfs1:/<install>/.pldrs`.

If (1) passes AND (2) passes → merge as a follow-up PR on BETA-12-PLAY.
If (1) regresses → abandon the swap, document the constraint.
If (1) passes but (2) still fails → the driver isn't the issue; we'd need to add diagnostic logging to capture the actual `open()` errno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)