### PR TITLE
LAUNCH_ARGS: wire game/debug consumers + post-release doc refresh

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,50 +1,46 @@
-Last updated: 2026-05-25
+Last updated: 2026-05-28 (post-BETA-10-5)
 
 # ROADMAP
 
 ## Status Snapshot
 
-- D-10, D-14, D-15 are hardware-PASS as of 2026-05-22 (B2 fix at commit `4ae6679`). The partition-aware HDD POPSTARTER route is the load-bearing fix to preserve through any new work.
-- DKWDRV from MC is hardware-PASS as of 2026-05-25 (Nuno).
-- DKWDRV from custom HDD path is **awaiting hardware** on PR #460 (commit `740fa87`, BETA-12-PLAY head). PR #460 completes the V2-mimicry that PR #452 (V4) missed: Lua `reboot_iop=0` + a new DKWDRV special-case route in `LoadELFFromFileWithPartition` mirroring the BOOT.ELF V2 contract.
-- BOOT.ELF from USB-booted POPSLoader (L-07) was working in V2 (commit `d23520a`, 2026-05-23). PR #458 regressed it by adding an `is_boot_elf_target` IOP-reset branch in the child loader; PR #460 reverted that. Source-verified back at the V2 working route; hardware re-verification pending.
-- BOOT.ELF from HDD-booted POPSLoader (U-10) is **still broken** and was never solved by V2 either. Pursued only after PR #460 hardware verdict settles.
-- POPSLoader launched from wLaunchELF (CosmicScale 2026-05-25) fails on some wLE builds. PR #458's `_ps2sdk_memory_init` fileXio-teardown (Layer A) targets this. Hardware pending.
-- Backend infrastructure added in PR #458/459/460: per-device settings sidecar (`PLDR.SETTINGS_PATH` resolves at load time with `APP_DIR_LOCAL/.pldrs` preferred and `mc0:/POPSTARTER/.pldrs` fallback), unified `ResolveBootContext` resolver feeding settings/UI/IRX decisions, NHDDL-style launch arg parsing (`-page=`, `-mode=`, `-game=`, `-debug`).
+- **BETA-10-5 shipped 2026-05-27** (tag at `9a0ebe2`). Nuno confirmed clean on hardware 2026-05-28.
+- D-10, D-14, D-15 are hardware-PASS (B2 fix at commit `4ae6679`). The partition-aware HDD POPSTARTER route is the load-bearing fix to preserve through any new work.
+- DKWDRV from MC is hardware-PASS (Nuno, 2026-05-25 and post-release).
+- DKWDRV from custom HDD path is **known-broken accepted** in BETA-10-5. Workaround: use the default MC DKWDRV path. PR #460 V2-mimicry was the last attempt; pragmatic call per Nuno + maintainer 2026-05-27 is to ship and revisit later.
+- BOOT.ELF from USB-booted POPSLoader (L-07) is working via the V2 route (`d23520a`).
+- BOOT.ELF from HDD-booted POPSLoader (U-10) is **known-broken accepted** in BETA-10-5. Long-standing; V2 didn't solve it either. Workaround: Exit → OSDSYS or console reboot. Investigation notes preserved in `docs/U10_INVESTIGATION.md`.
+- POPSLoader launched from wLaunchELF: works in the common flow (CosmicScale post-PR #458). One latent failure mode reported by Nuno 2026-05-27 (wLE → USB POPSLoader → BOOT.ELF) — code analysis says it takes the same route as the working autoboot/OSDSYS cases, so likely always-broken/latent rather than a regression; not enumerated as known-broken pending a clearer repro.
+- Backend infrastructure (PR #458/459/460/462): per-device settings sidecar with first-run migration, unified `ResolveBootContext` resolver feeding settings/UI/IRX decisions, NHDDL-style launch arg parsing (`-page=`, `-mode=`, `-game=`, `-debug`) with carousel auto-nav, game auto-launch, and debug context surfacing all wired.
 - `docs/LAUNCH_HYGIENE.md` documents the launch-path architecture and the V2 mimicry rationale.
 - `HDD (exFAT)`, `SMB (v1)`, `ILINK` remain intentionally unimplemented menu entries.
 
 ## Immediate Priorities
 
-### 1) Resolve DKWDRV-on-HDD on hardware
-- Test PR #460 artifact: https://github.com/NathanNeurotic/POPSLoader/actions/runs/26416917597
-- If DKWDRV-on-HDD PASSES, that closes the V4 saga (PR #452 reverted, PR #458 reverted, PR #460 completes the V2 mimicry).
-- If FAILS, escalate to a diagnostic build: enable `LOADER_ENABLE_DEBUG_COLORS` in the child loader, ship to Nuno, identify the exact stage at which the black-screen happens. The hooks already exist in `src/elf_loader/src/loader/src/loader.c` lines 24-43; just need to define the macro at build time.
-- Regression checks on the same artifact: D-10, D-15, DKWDRV-MC, BOOT.ELF from USB-booted POPSLoader.
+### 1) Settings UI redesign (Berion mockup)
+- Blocked on Berion's mockup PNGs landing at `C:\Users\natha\Documents\assets\` and being committed to `docs/mockups/`. Without the visual oracle, the Lua port is hard to start.
+- Hardware blockers (D-10/D-14/D-15/DKWDRV-MC/BOOT.ELF) are now settled per BETA-10-5. Implementation can start the moment the mockups land.
+- Scope: Context menu, Settings (per-category pages superseding the OPL focused-list), Joypad configuration, On-screen keyboard. Boot/splash and game list are out of scope.
+- Full implementation prompt and per-screen pixel specs live in `docs/GUI_OVERHAUL_PROMPT.md`.
 
-### 2) wLaunchELF launch (CosmicScale)
-- Same artifact as priority 1.
-- PR #458 added `SifExitRpc() + SifInitRpc(0) + fileXioExit()` before `SifIopReset` in `_ps2sdk_memory_init`, per the documented ps2sdk #425 workaround.
-- If still failing, the next angles are: pin a specific ps2dev/ps2dev image tag in CI to rule out toolchain drift, or investigate whether `SifIopReset(NULL, 0x80000000)` (verbose-mode flag) has a different IOP-reset path than `("", 0)`.
+### 2) Layer C full lazy IRX loading
+- Precursor (pre-IRX device classification hint) landed in PR #458.
+- Deferred (high risk for input/controllers): defer `mmceman` unless boot device is MMCE, `ds34bt` unless user has BT pads enabled, `usbd` unless boot device is USB/MX4SIO/DS3-4 USB.
+- Test plan MUST explicitly verify pad input survival across all deferred-load combinations. Expected gain per the audit in `docs/LAUNCH_HYGIENE.md`: 30-50% pre-Lua startup time reduction.
 
-### 3) U-10 BOOT.ELF from HDD-booted POPSLoader
-- Long-standing, predates this session.
-- V2 didn't solve it. PR #458's attempts didn't solve it. Reverted.
-- Investigation candidates: explicit `dev9Shutdown()` before exec (the network/HDD expansion module retains hardware state across `SifIopReset` — BOOT.ELF inheriting that may be the culprit), or routing through the child loader with a specifically-crafted IOP teardown.
-- Worth a focused investigation PR (no code) before another fix attempt.
-
-### 4) `PLDR.LAUNCH_ARGS` UI auto-navigation
-- Infrastructure landed in PR #458. Parsing, normalization, and a `PLDR.LAUNCH_ARGS = {page, page_raw, game, debug}` table all work.
-- Need to wire the consumer: `ui.lua` initial page selection should check `PLDR.LAUNCH_ARGS.page` and jump to the named carousel target on boot.
-- Smallest risk: gate on `PLDR.LAUNCH_ARGS.page ~= nil` only; existing flows unchanged when no flag passed.
-
-### 5) Display and UX verification
+### 3) Display and UX verification
 - Re-run `U-06` to confirm PAL/NTSC menu asset proportions on hardware.
 - Re-run `U-08` / `U-09` on slower/large libraries to judge whether busy overlays communicate activity clearly enough.
 
-### 6) Coverage and documentation
-- `STATE.md`, `TRUTHSHEET.md`, `QA_REGRESSION_MATRIX.md`, `HDD_POPSTARTER_HANDOFF.md` were all updated to current reality on 2026-05-25 alongside this file (PR #461).
+### 4) Coverage and documentation
 - Add concrete run logs for: D-13 device switching without runtime locks, S-09 keyboard layout persistence, U-11 boot-device label display.
+
+## Pragmatically Accepted (not blocking)
+
+- **U-10 BOOT.ELF from HDD-booted POPSLoader** — known-broken accepted. Investigation hypotheses in `docs/U10_INVESTIGATION.md`. If revisited: ship the diagnostic build (`LOADER_ENABLE_DEBUG_COLORS`) before another fix attempt. Branch `claude/diag-u10` exists.
+- **DKWDRV from custom HDD path** — known-broken accepted. PR #460's V2 mimicry didn't fix it on hardware. If revisited: GS BGCOLOUR diagnostics don't work on this path (runs through too fast against POPSLoader's still-active framebuffer); need a different angle (Lua-side notification or explicit framebuffer clear before paint).
+- **HDD r/w driver swap probe** (`ps2hdd-osd.irx` → `ps2hdd.irx`) — branch `claude/hdd-rw-probe` exists with the 2-line change. Would unlock HDD settings sidecar IF D-10 doesn't regress. Requires hardware test.
+- **wLE → USB-POPSLoader → BOOT.ELF latent failure** (Nuno 2026-05-27) — code analysis says it takes the same route as working cases, so almost certainly always-broken/latent rather than a regression. Not enumerated as known-broken pending a clearer repro.
 
 ## Secondary Work
 
@@ -80,4 +76,3 @@ Last updated: 2026-05-25
 - Additional themes/skins.
 - Broader network/backend support after SMB and ILINK have defined baselines.
 - More ambitious artwork cache policy after current launch/runtime issues are stable.
-- First-run MC-to-sidecar settings migration: if user moves POPSLoader to a new device, optionally copy `mc0:/POPSTARTER/.pldrs` to the new sidecar on first save.

--- a/STATE.md
+++ b/STATE.md
@@ -1,4 +1,4 @@
-Last updated: 2026-05-27 (release-prep)
+Last updated: 2026-05-28 (post-BETA-10-5; LAUNCH_ARGS game/debug consumers wired)
 
 # STATE
 
@@ -34,7 +34,9 @@ POPSLoader is a PS2 launcher for POPStarter built on Enceladus runtime pieces, w
 - `parseLaunchArgs()` in `main.cpp` recognizes `-page=*`, `-mode=*` (NHDDL alias for `-page`), `-game=*`, `-debug`.
 - `System.getLaunchArgs()` exposes parsed values to Lua.
 - `PLDR.LAUNCH_ARGS = {page, page_raw, game, debug}` normalized in `system.lua`.
-- Auto-navigation wiring not yet consumed by `ui.lua`; the infrastructure is in place but a downstream PR is needed to wire `-page=hdd` into the initial page selection.
+- `-page=` drives carousel auto-nav (PR #462).
+- `-game=` triggers `PLDR.AutoLaunchFromLaunchArgs()` after `AutoInitStartupBackends`; requires `-page=` to be set so the target backend is brought up and the right scene is used. Supported pages: HDD (game format `PARTITION|relpath`), USB / MX4SIO / MMCE (game format `FILE.VCD`). On launch failure, falls through to the main menu with an error toast.
+- `-debug` queues a boot-context toast (`PLDR.SurfaceLaunchArgsDebug()`) showing the resolved `kind`, `boot_path`, `sidecar_path`, `settings`, and parsed launch args. Useful for diagnosing how POPSLoader classified its environment without rebuilding with DPRINTF.
 
 ### Backend init / runtime
 - Startup backend auto-init exists and uses boot path information, configured executable paths, and selected profile path.
@@ -102,13 +104,13 @@ Investigation artifacts archived: `docs/U10_INVESTIGATION.md` (hypotheses + diag
 
 ## Known Open Work
 
-1. **`PLDR.LAUNCH_ARGS.game` auto-launch wiring** — argv parser + Lua storage landed in PR #458. The `page` value drives carousel auto-nav (PR #462). `game` and `debug` are parsed but no consumer is wired yet.
-2. **Layer C full lazy IRX loading** — only the precursor (device hint) shipped. Aggressive deferrals (`mmceman` unless MMCE boot, `ds34bt` unless BT enabled, `usbd` unless USB family) queued for a separate PR. High reward for boot time; high risk to input/controller availability if done carelessly.
-3. **Settings sidecar first-run MC-to-sidecar migration** — currently we just save where we loaded from. Could optionally copy MC settings to per-device sidecar on first save when the user moves POPSLoader to a new device. Disabled for HDD installs (driver constraint).
-4. **Settings UI redesign (Berion mockup)** — Mockup PNGs still to land at `C:\Users\natha\Documents\assets\` for `docs/mockups/`. Hardware blockers (D-10/D-14/D-15/DKWDRV-MC/BOOT.ELF) are now settled per Nuno's BETA-10-5 hardware pass; this is ready to start once the visual oracle is committed.
-5. **U-10 / DKWDRV-HDD proper fixes** — pragmatically accepted as known-broken in BETA-10-5. If revisited, see `docs/U10_INVESTIGATION.md` for the hypothesis catalog and diagnostic-first workflow.
-6. **HDD r/w driver swap probe** (`ps2hdd-osd.irx` → `ps2hdd.irx`) — branch `claude/hdd-rw-probe` exists with the 2-line change ready for hardware test. Would unlock HDD settings sidecar IF D-10 doesn't regress.
-7. **HDD (exFAT), SMB (v1), ILINK** menu flows remain intentionally unimplemented.
+1. **Layer C full lazy IRX loading** — only the precursor (device hint) shipped. Aggressive deferrals (`mmceman` unless MMCE boot, `ds34bt` unless BT enabled, `usbd` unless USB family) queued for a separate PR. High reward for boot time; high risk to input/controller availability if done carelessly.
+2. **Settings UI redesign (Berion mockup)** — Mockup PNGs still to land at `C:\Users\natha\Documents\assets\` for `docs/mockups/`. Hardware blockers (D-10/D-14/D-15/DKWDRV-MC/BOOT.ELF) are now settled per Nuno's BETA-10-5 hardware pass; this is ready to start once the visual oracle is committed.
+3. **U-10 / DKWDRV-HDD proper fixes** — pragmatically accepted as known-broken in BETA-10-5. If revisited, see `docs/U10_INVESTIGATION.md` for the hypothesis catalog and diagnostic-first workflow.
+4. **HDD r/w driver swap probe** (`ps2hdd-osd.irx` → `ps2hdd.irx`) — branch `claude/hdd-rw-probe` exists with the 2-line change ready for hardware test. Would unlock HDD settings sidecar IF D-10 doesn't regress.
+5. **HDD (exFAT), SMB (v1), ILINK** menu flows remain intentionally unimplemented.
+
+(`PLDR.LAUNCH_ARGS.game` and `-debug` consumers wired in this branch — see Launch arguments section above. The first-run MC-to-sidecar settings migration is implemented in `LoadSettingsNonFatal` via the `migrate_to_sidecar` flag added in PR #462; it pins `PLDR.SETTINGS_PATH` to the sidecar location whenever settings load from the MC fallback but a non-HDD sidecar is computable.)
 
 ## Verification Status
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -5084,8 +5084,100 @@ function Touch(FILE)
   end
 end
 
+-- NHDDL-style auto-launch from -page=<kind> -game=<selector>. Both args
+-- must be set; if either is missing, behavior is unchanged. Page selects
+-- the target device backend and scene; game is the device-specific
+-- selector that PLDR.RunPOPStarterGame already understands:
+--   page=hdd    game=<PARTITION>|<relpath>   e.g. __.POPS|SLUS_007.42.RAMPAGE.VCD
+--   page=usb    game=<FILE.VCD>              relative to mass:/POPS
+--   page=mmce   game=<FILE.VCD>              relative to mmce0:/POPS
+--   page=mx4sio game=<FILE.VCD>              relative to mx4sio:/POPS
+-- On success the function never returns (ExecPS2 hands off to POPSTARTER).
+-- On failure it returns false and the welcome screen + main menu run
+-- normally with an error toast queued for the user.
+function PLDR.AutoLaunchFromLaunchArgs()
+  if type(PLDR.LAUNCH_ARGS) ~= "table" then return false end
+  local page = PLDR.LAUNCH_ARGS.page
+  local game = PLDR.LAUNCH_ARGS.game
+  if type(page) ~= "string" or page == "" then return false end
+  if type(game) ~= "string" or game == "" then return false end
+  if type(UI) ~= "table" or type(UI.SCENES) ~= "table" then return false end
+
+  local scene, gamelocation
+  if page == "HDD" and UI.SCENES.GHDD ~= nil then
+    scene = UI.SCENES.GHDD
+    gamelocation = ""
+    if type(PLDR.LoadHDDModules) == "function" then
+      pcall(PLDR.LoadHDDModules)
+    end
+  elseif page == "USB" and UI.SCENES.GUSBFAT ~= nil then
+    scene = UI.SCENES.GUSBFAT
+    gamelocation = "mass:/POPS"
+    if type(PLDR.EnsureUsbMassReadyOnce) == "function" then
+      pcall(PLDR.EnsureUsbMassReadyOnce)
+    end
+  elseif page == "MX4SIO" and UI.SCENES.GMX4SIO ~= nil then
+    scene = UI.SCENES.GMX4SIO
+    gamelocation = "mx4sio:/POPS"
+    if type(PLDR.InitMX4SIOPopsRoot) == "function" then
+      pcall(PLDR.InitMX4SIOPopsRoot)
+    end
+  elseif page == "MMCE" and UI.SCENES.GSMB ~= nil then
+    scene = UI.SCENES.GSMB
+    if type(PLDR.DetectMMCESlot) == "function" then
+      pcall(PLDR.DetectMMCESlot, true)
+    end
+    local mmce_prefix = (type(PLDR.MMCE) == "table" and PLDR.MMCE.PREFIX) or "mmce0:/"
+    gamelocation = mmce_prefix.."POPS"
+  else
+    if type(UI.Notif_queue) == "table" and type(UI.Notif_queue.add) == "function" then
+      UI.Notif_queue.add("Auto-launch page not supported: "..tostring(page), "warn")
+    end
+    return false
+  end
+
+  UI.CURSCENE = scene
+  if UI.LASTSCENE == nil then
+    UI.LASTSCENE = scene
+  end
+
+  local ok, err = pcall(PLDR.RunPOPStarterGame, gamelocation, game, scene, nil)
+  if not ok and type(UI.Notif_queue) == "table" and type(UI.Notif_queue.add) == "function" then
+    UI.Notif_queue.add("Auto-launch failed: "..tostring(err), "error")
+  end
+  return ok
+end
+
+-- Debug consumer: when -debug is passed, surface the resolved boot context
+-- and launch args as a toast so the user can verify how POPSLoader classified
+-- its environment without rebuilding with DPRINTF enabled. Visible on the
+-- main menu if no -game= is passed, or on the main menu after an auto-launch
+-- failure if both -debug and -game= are passed.
+function PLDR.SurfaceLaunchArgsDebug()
+  if type(PLDR.LAUNCH_ARGS) ~= "table" or PLDR.LAUNCH_ARGS.debug ~= true then
+    return
+  end
+  if type(UI) ~= "table" or type(UI.Notif_queue) ~= "table"
+     or type(UI.Notif_queue.add) ~= "function" then
+    return
+  end
+  local lines = {"[debug] boot context"}
+  local ctx = (type(PLDR.GetBootContext) == "function") and PLDR.GetBootContext() or nil
+  if type(ctx) == "table" then
+    lines[#lines+1] = "kind: "..tostring(ctx.kind or "<nil>")
+    lines[#lines+1] = "boot_path: "..tostring(ctx.boot_path or "<nil>")
+    lines[#lines+1] = "sidecar: "..tostring(ctx.sidecar_path or "<nil>")
+  end
+  lines[#lines+1] = "settings: "..tostring(PLDR.SETTINGS_PATH or "<nil>")
+  lines[#lines+1] = "args.page: "..tostring(PLDR.LAUNCH_ARGS.page or "<nil>")
+  lines[#lines+1] = "args.game: "..tostring(PLDR.LAUNCH_ARGS.game or "<nil>")
+  UI.Notif_queue.add(table.concat(lines, "\n"), "info")
+end
+
 PLDR.LoadSettingsNonFatal()
 PLDR.AutoInitStartupBackends()
+PLDR.SurfaceLaunchArgsDebug()
+PLDR.AutoLaunchFromLaunchArgs()
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.MMAIN


### PR DESCRIPTION
## Summary
- `PLDR.AutoLaunchFromLaunchArgs()` wired in `bin/POPSLDR/system.lua`: when both `-page=<kind>` and `-game=<selector>` are passed, auto-launches via `RunPOPStarterGame` right after `AutoInitStartupBackends`. Supports HDD / USB / MX4SIO / MMCE. Failure mode: error toast queued, falls through to main menu.
- `PLDR.SurfaceLaunchArgsDebug()` wired: `-debug` queues a boot-context toast (kind, boot_path, sidecar_path, settings, args) so users can diagnose POPSLoader's environment classification without rebuilding with DPRINTF.
- `STATE.md` / `ROADMAP.md` post-BETA-10-5 refresh: reflect Nuno's 2026-05-28 hardware confirmation, mark A/B done, correct the stale "migration not implemented" item (PR #462 already implemented it; PR #466 only excluded HDD).

## What it doesn't do
- Layer C lazy IRX deferral is a separate (in-progress) effort — not in this PR.
- Mockup-driven Settings redesign still blocked on Berion's PNGs landing.

## Test plan
- [ ] Build green in CI
- [ ] Hardware: boot POPSLoader with `-page=hdd -game=__.POPS|<some VCD>` from wLaunchELF or HOSDMenu; should auto-launch the HDD title.
- [ ] Hardware: boot with `-page=usb -game=<FILE.VCD>` (USB POPSLoader, file in `mass:/POPS/`); should auto-launch the USB title.
- [ ] Hardware: boot with `-debug`; should show boot-context toast on main menu.
- [ ] Hardware: boot with `-debug -page=hdd -game=<bogus-selector>`; should show debug toast + auto-launch failure toast.
- [ ] Regression: boot with no launch args; default flow unchanged.
- [ ] Regression: boot with `-page=hdd` only (no `-game`); carousel auto-nav to HDD page, no auto-launch (existing PR #462 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)