### PR TITLE
[DRAFT - HARDWARE TEST REQUIRED] Layer C: defer mmceman.irx unless boot device is MMCE

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1093,6 +1093,15 @@ function PLDR.EnsureMmceReadyOnce()
     return true
   end
 
+  -- Layer C lazy load: mmceman.irx is only loaded eagerly when boot
+  -- device is MMCE (see src/main.cpp). For USB / MC / MX4SIO / HDD
+  -- (any of hdd*, pfs*, ata*, apa*) boots, the IRX is deferred and
+  -- must be loaded here before any mc%d:/ MMCE accessor will work.
+  -- System.ensureMmceman() is idempotent: no-op if already loaded.
+  if type(System) == "table" and type(System.ensureMmceman) == "function" then
+    pcall(System.ensureMmceman)
+  end
+
   if type(_G.ensureMmceInit) == "function" then
     pcall(_G.ensureMmceInit)
   end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3136,6 +3136,25 @@ local function EnsureBootHddMountReady()
   return nil
 end
 
+-- Defined BEFORE ClassifyStartupMassTargets so the closure correctly
+-- captures the local. Lua's `local function f()` is sugar for
+-- `local f; f = function()...end` -- the local doesn't exist in scope
+-- until its declaration line, so a caller above can't capture it as an
+-- upvalue and falls through to a global lookup (nil) at call time.
+-- Hardware regression 2026-05-28: rolling-release crashed on Enceladus
+-- boot with `attempt to call a nil value (global 'ClassifyMassRootDriver')`
+-- because this was declared further down the file.
+local function ClassifyMassRootDriver(driver)
+  local value = string.lower(tostring(driver or ""))
+  if value == "" then
+    return "unknown"
+  end
+  if string.find(value, "mx4", 1, true) ~= nil or string.find(value, "sdc", 1, true) ~= nil then
+    return "mx4sio"
+  end
+  return "usb"
+end
+
 local function ClassifyStartupMassTargets(targets)
   if type(targets) ~= "table" or type(targets.mass_roots) ~= "table" then
     return
@@ -3271,17 +3290,6 @@ local function EnsureMassBackendsReady(mode)
   if type(System) == "table" and type(System.initUSB) == "function" then
     pcall(System.initUSB)
   end
-end
-
-local function ClassifyMassRootDriver(driver)
-  local value = string.lower(tostring(driver or ""))
-  if value == "" then
-    return "unknown"
-  end
-  if string.find(value, "mx4", 1, true) ~= nil or string.find(value, "sdc", 1, true) ~= nil then
-    return "mx4sio"
-  end
-  return "usb"
 end
 
 local function WaitMassProbeRetry(attempt, max_attempts)

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1096,7 +1096,10 @@ function PLDR.EnsureMmceReadyOnce()
   -- Layer C lazy load: mmceman.irx is only loaded eagerly when boot
   -- device is MMCE (see src/main.cpp). For USB / MC / MX4SIO / HDD
   -- (any of hdd*, pfs*, ata*, apa*) boots, the IRX is deferred and
-  -- must be loaded here before any mc%d:/ MMCE accessor will work.
+  -- must be loaded here before any mmce%d:/ accessor will work.
+  -- MMCE (third-party memory card adapters like MemoryCard Pro) is a
+  -- distinct device from standard PS2 MC -- MC uses mc%d:/ paths and
+  -- the always-loaded mcman/mcserv IRX stack, not mmceman.
   -- System.ensureMmceman() is idempotent: no-op if already loaded.
   if type(System) == "table" and type(System.ensureMmceman) == "function" then
     pcall(System.ensureMmceman)

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -34,6 +34,9 @@ extern unsigned int size_usbmass_bd_irx;
 extern unsigned char cdfs_irx[];
 extern unsigned int size_cdfs_irx;
 
+extern unsigned char mmceman_irx;
+extern unsigned int size_mmceman_irx;
+
 
 static bool LoadIrxCheckedBuffer(const char *name, unsigned char *irx, unsigned int size, int *out_id, int *out_ret);
 static void BuildMassRootPath(int index, char *out_root, size_t out_sz);
@@ -72,6 +75,7 @@ static bool bdm_fatfs_irx_loaded = false;
 static bool usbmass_irx_loaded = false;
 static bool cdfs_irx_loaded = false;
 static bool mx4sio_irx_loaded = false;
+static bool mmceman_irx_loaded = false;
 
 static bool EnsureBDM()
 {
@@ -125,6 +129,33 @@ static bool EnsureCDFS()
 	}
 	cdfs_irx_loaded = true;
 	return true;
+}
+
+// Layer C lazy-load entry point for mmceman. main.cpp's boot sequence
+// eagerly loads mmceman_irx ONLY when boot_device_hint == "MMCE"; for any
+// other boot device (USB / MC / MX4SIO / HDD in any variant: hdd*, pfs*,
+// ata*, apa* — see detectBootDeviceHintFromArgv0 in main.cpp), this is
+// called on demand by PLDR.EnsureMmceReadyOnce in system.lua before any
+// MMCE probe (PLDR.DetectMMCESlot). Idempotent: subsequent calls after a
+// successful load are no-ops.
+bool EnsureMmceman()
+{
+	if (mmceman_irx_loaded) {
+		return true;
+	}
+	if (!LoadIrxCheckedBuffer("mmceman.irx", &mmceman_irx, size_mmceman_irx, NULL, NULL)) {
+		return false;
+	}
+	mmceman_irx_loaded = true;
+	return true;
+}
+
+// Called from main.cpp when mmceman was loaded eagerly by the boot
+// sequence (MMCE-booted case). Syncs the EnsureMmceman tracker so the
+// Lua-side ensureMmceman() call later is a no-op instead of double-loading.
+void MarkMmcemanLoaded()
+{
+	mmceman_irx_loaded = true;
 }
 
 static bool EnsureBdmQueryRpc()
@@ -1365,6 +1396,12 @@ static int lua_ensure_cdfs(lua_State *L)
 	return 1;
 }
 
+static int lua_ensure_mmceman(lua_State *L)
+{
+	lua_pushboolean(L, EnsureMmceman());
+	return 1;
+}
+
 static int lua_mx4sio_init(lua_State *L)
 {
 	int argc = lua_gettop(L);
@@ -1434,6 +1471,7 @@ static const luaL_Reg System_functions[] = {
 	{"ensureBDMFatFs",         lua_ensure_bdm_fatfs},
 	{"ensureUsbMass",          lua_ensure_usb_mass},
 	{"ensureCDFS",             lua_ensure_cdfs},
+	{"ensureMmceman",          lua_ensure_mmceman},
 	{"initMX4SIO",             lua_mx4sio_init},
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,15 @@ __attribute__((used)) static const char CI_MARKER_BOOT_ELF_FAIL[] = "BOOT.ELF la
 extern "C" int SifExecModuleBuffer(void *ptr, int size, int arg_len, const char *args, int *mod_res);
 #endif
 
+/* Layer C lazy-load hooks defined in luasystem.cpp. EnsureMmceman loads
+ * mmceman.irx on demand (idempotent); MarkMmcemanLoaded() lets the
+ * eager MMCE-boot path here record the load so the lazy path is a no-op
+ * later. See detectBootDeviceHintFromArgv0 for the device-kind hint that
+ * gates the eager vs deferred decision; all HDD root variants (hdd, hdd0,
+ * pfs, pfs0, pfs1, ata, apa) classify as "HDD" and defer mmceman. */
+extern bool EnsureMmceman(void);
+extern void MarkMmcemanLoaded(void);
+
 extern char bootString[];
 extern unsigned int size_bootString;
 
@@ -435,28 +444,47 @@ int main(int argc, char * argv[])
 
 	LOAD_IRX_NARG(sio2man_irx);
     if (filexio_ok) {
-        int mmceman_id = -1;
-        int mmceman_ret = -1;
-        bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
-        DPRINTF("mmceman load result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
+        /* Layer C: mmceman is only needed for MMCE memcards. Load it
+         * eagerly only when the boot device is MMCE; otherwise defer to
+         * PLDR.EnsureMmceReadyOnce in system.lua (which calls
+         * System.ensureMmceman before any MMCE probe). All HDD root
+         * variants (hdd, hdd0, pfs, pfs0, pfs1, ata, apa) classify as
+         * "HDD" via detectBootDeviceHintFromArgv0 and defer. */
+        bool mmceman_required_at_boot = (strcmp(boot_device_hint, "MMCE") == 0);
+        if (mmceman_required_at_boot) {
+            int mmceman_id = -1;
+            int mmceman_ret = -1;
+            bool mmceman_ok = LoadIrxChecked("mmceman_irx", &mmceman_irx, size_mmceman_irx, &mmceman_id, &mmceman_ret);
+            DPRINTF("mmceman eager load (boot=MMCE) result: id=%d ret=%d\n", mmceman_id, mmceman_ret);
 #ifdef DEBUG
-        if (mmceman_ok) {
-            smod_mod_info_t info;
-            int lookup_ret = smod_get_mod_by_name("mmceman", &info);
-            if (lookup_ret < 0) {
-                DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
-                DumpLoadedModules();
+            if (mmceman_ok) {
+                smod_mod_info_t info;
+                int lookup_ret = smod_get_mod_by_name("mmceman", &info);
+                if (lookup_ret < 0) {
+                    DPRINTF("mmceman module lookup failed: ret=%d\n", lookup_ret);
+                    DumpLoadedModules();
+                }
             }
-        }
 #endif
-        BootStamp("mmceman load/init");
-        if (mmceman_ok) {
+            if (mmceman_ok) {
+                MarkMmcemanLoaded();
+                mmce_slot0_ready = -1;
+                mmce_slot1_ready = -1;
+                DPRINTF("MMCE probe deferred until MMCE page entry.\n");
+            } else {
+                mmce_slot0_ready = 0;
+                mmce_slot1_ready = 0;
+            }
+            BootStamp("mmceman load/init");
+        } else {
+            /* Non-MMCE boot: skip the eager load. System.ensureMmceman()
+             * will load on demand if a configured POPSTARTER path lives
+             * on MMCE (AutoInitStartupBackends -> DetectMMCESlot) or if
+             * the user enters the MMCE page from the carousel. */
+            DPRINTF("mmceman deferred (boot_device_hint=\"%s\"); will load on demand.\n", boot_device_hint);
             mmce_slot0_ready = -1;
             mmce_slot1_ready = -1;
-            DPRINTF("MMCE probe deferred until MMCE page entry.\n");
-        } else {
-            mmce_slot0_ready = 0;
-            mmce_slot1_ready = 0;
+            BootStamp("mmceman deferred");
         }
     } else {
         DPRINTF("Skipping mmceman init; fileXio not ready.\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -444,12 +444,19 @@ int main(int argc, char * argv[])
 
 	LOAD_IRX_NARG(sio2man_irx);
     if (filexio_ok) {
-        /* Layer C: mmceman is only needed for MMCE memcards. Load it
-         * eagerly only when the boot device is MMCE; otherwise defer to
-         * PLDR.EnsureMmceReadyOnce in system.lua (which calls
-         * System.ensureMmceman before any MMCE probe). All HDD root
-         * variants (hdd, hdd0, pfs, pfs0, pfs1, ata, apa) classify as
-         * "HDD" via detectBootDeviceHintFromArgv0 and defer. */
+        /* Layer C: mmceman is only needed for MMCE memcards (third-party
+         * memory card adapters like MemoryCard Pro that expose mmce0:/,
+         * mmce1:/ paths). This is a DISTINCT device from standard PS2
+         * memory cards, which use mc0:/, mc1:/ paths and the mcman/mcserv
+         * IRX stack loaded unconditionally just below.
+         *
+         * Load mmceman eagerly only when the boot device is MMCE;
+         * otherwise defer to PLDR.EnsureMmceReadyOnce in system.lua
+         * (which calls System.ensureMmceman before any MMCE probe).
+         * All HDD root variants (hdd, hdd0, pfs, pfs0, pfs1, ata, apa)
+         * classify as "HDD" via detectBootDeviceHintFromArgv0 and defer;
+         * MC-booted units (boot_device_hint == "MC") also defer, since
+         * MC support is provided entirely by mcman/mcserv. */
         bool mmceman_required_at_boot = (strcmp(boot_device_hint, "MMCE") == 0);
         if (mmceman_required_at_boot) {
             int mmceman_id = -1;


### PR DESCRIPTION
> **DRAFT - DO NOT MERGE UNTIL HARDWARE VERIFICATION**
>
> This PR defers the eager `mmceman.irx` boot-time load for any non-MMCE boot device. It's the Layer C precursor described in `docs/LAUNCH_HYGIENE.md` (queued, low-risk subset of the full lazy-IRX work). Higher-risk items (`ds34bt`, `usbd` deferral) are out of scope here.

## Summary
- `src/main.cpp`: replaces the unconditional mmceman load with a conditional check on `boot_device_hint == "MMCE"`. MMCE-booted devices keep the eager load; everything else defers.
- `src/luasystem.cpp`: adds `EnsureMmceman()` (idempotent on-demand load) and `MarkMmcemanLoaded()` (sync helper for the eager path). Exposed as `System.ensureMmceman`.
- `bin/POPSLDR/system.lua`: `PLDR.EnsureMmceReadyOnce()` calls `System.ensureMmceman()` before delegating to the existing init path.

## HDD device root coverage (per maintainer feedback)
`detectBootDeviceHintFromArgv0()` in `main.cpp` (lines 146-150) already maps **every HDD root variant** to the single `"HDD"` kind label:

```c
if (strncmp(argv0, "hdd", 3) == 0 ||   // hdd, hdd0, hdd1, ...
    strncmp(argv0, "pfs", 3) == 0 ||   // pfs, pfs0, pfs1, ...
    strncmp(argv0, "ata", 3) == 0 ||   // ata, ata0, ...
    strncmp(argv0, "apa", 3) == 0) {   // apa, apa0, ...
    return \"HDD\";
}
```

The conditional in `main()` is `strcmp(boot_device_hint, \"MMCE\") == 0`, so any HDD-rooted boot in any variant (including the `pfs1:` form set up by `etc/boot.lua`'s `HDD.MountPartition`) correctly defers `mmceman`.

## Test plan (HARDWARE)
- [ ] **MMCE-booted**: `mmceman` eager-loaded as before; MMCE games launch normally.
- [ ] **USB-booted**: `mmceman` deferred; entering MMCE page loads it lazily; MMCE games launch normally.
- [ ] **HDD-booted (pfs1: variant from boot.lua mount)**: `mmceman` deferred; any configured POPSTARTER on MMCE in `AutoInitStartupBackends` triggers the lazy load via `DetectMMCESlot -> EnsureMmceReadyOnce -> ensureMmceman`.
- [ ] **HDD-booted via raw hdd0:/ / ata0:/ / apa0:/ forms**: same as pfs1:.
- [ ] **MC-booted**: `mmceman` deferred; MMCE access on first probe.
- [ ] **Regression: pad input** (USB DS3/4 via `ds34usb`) works on all boot devices. `ds34usb`/`ds34bt`/`usbd` loading is **unchanged** in this PR.
- [ ] **Regression: audio** works on all boot devices.
- [ ] **Regression: D-10/D-14/D-15 launch paths** still work on HDD-booted (boot mount + mmceman deferral combination is the highest-risk scenario).

## What's NOT in this PR
- `ds34bt` deferral — would need a settings toggle or auto-detect to avoid breaking BT-pad-only users.
- `usbd` deferral — `ds34usb` depends on it; high risk to the common pad input path.
- Both items remain in the open backlog (`ROADMAP.md` Layer C section).

## Expected savings
Per the audit table in `docs/LAUNCH_HYGIENE.md`, one IRX load skipped at boot. Modest in absolute terms (~50-100ms) but a clean precursor to the larger lazy-IRX deferrals that need their own hardware test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)