### PR TITLE
HOTFIX: Lua forward-reference crash on boot (ClassifyMassRootDriver)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3124,6 +3124,25 @@ local function EnsureBootHddMountReady()
   return nil
 end
 
+-- Defined BEFORE ClassifyStartupMassTargets so the closure correctly
+-- captures the local. Lua's `local function f()` is sugar for
+-- `local f; f = function()...end` -- the local doesn't exist in scope
+-- until its declaration line, so a caller above can't capture it as an
+-- upvalue and falls through to a global lookup (nil) at call time.
+-- Hardware regression 2026-05-28: rolling-release crashed on Enceladus
+-- boot with `attempt to call a nil value (global 'ClassifyMassRootDriver')`
+-- because this was declared further down the file.
+local function ClassifyMassRootDriver(driver)
+  local value = string.lower(tostring(driver or ""))
+  if value == "" then
+    return "unknown"
+  end
+  if string.find(value, "mx4", 1, true) ~= nil or string.find(value, "sdc", 1, true) ~= nil then
+    return "mx4sio"
+  end
+  return "usb"
+end
+
 local function ClassifyStartupMassTargets(targets)
   if type(targets) ~= "table" or type(targets.mass_roots) ~= "table" then
     return
@@ -3259,17 +3278,6 @@ local function EnsureMassBackendsReady(mode)
   if type(System) == "table" and type(System.initUSB) == "function" then
     pcall(System.initUSB)
   end
-end
-
-local function ClassifyMassRootDriver(driver)
-  local value = string.lower(tostring(driver or ""))
-  if value == "" then
-    return "unknown"
-  end
-  if string.find(value, "mx4", 1, true) ~= nil or string.find(value, "sdc", 1, true) ~= nil then
-    return "mx4sio"
-  end
-  return "usb"
 end
 
 local function WaitMassProbeRetry(attempt, max_attempts)


### PR DESCRIPTION
> **CRITICAL HOTFIX — please merge ASAP.** Rolling-release artifact built off BETA-12-PLAY currently crashes on Enceladus boot with `attempt to call a nil value (global 'ClassifyMassRootDriver')`. Hardware-confirmed by tester 2026-05-28.

## What broke

The PR #472 maintainer refinement commit `7b587fe` reorganized the mass-classification helpers and ended up declaring `ClassifyMassRootDriver` further down the file than `ClassifyStartupMassTargets` which calls it.

Lua's `local function f()` is sugar for `local f; f = function()...end`. The local doesn't exist in scope until its declaration line, so a caller declared **above** can't capture it as an upvalue — the lookup falls through to globals (nil) at call time, and crashes the first time `ClassifyStartupMassTargets` runs.

`PLDR.AutoInitStartupBackends` calls `ClassifyStartupMassTargets` during boot, so this hit immediately on hardware.

The Lua syntax check didn't catch it (the source is syntactically valid; it's broken only at runtime).

## Fix

Move the `local function ClassifyMassRootDriver` declaration to just above `ClassifyStartupMassTargets`, and remove the now-duplicate later declaration. No behavior change — body is identical.

## Test plan

- [ ] CI green
- [ ] **HARDWARE**: confirm rolling-release artifact boots past the Enceladus error on the unit that hit the crash
- [ ] Regression: USB / MX4SIO / HDD / MC / MMCE boots all reach the main menu

## Related

- Same fix is also in [PR #471](https://github.com/NathanNeurotic/POPSLoader/pull/471) (Layer C) since rolling-release was built from #471. Whichever lands first fixes testers; the other can be rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)