### PR TITLE
Fix MX4SIO boot-path settings save (sidecar on writable mass*:/ slot)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -102,6 +102,18 @@ local function ResolveAppDirLocal()
   if IsPfsMountedPath(current_dir) and IsRawHddPartitionPath(app_dir) then
     return current_dir
   end
+  -- MX4SIO boot: argv0 prefix mx4sio:/ is the BDM device-kind label,
+  -- not a writable fileXio mount. etc/boot.lua translates cwd to the
+  -- actual mass*:/ slot (identified by sdc/mx4 ioctl driver name --
+  -- the same PR #472 rule). When that translation succeeded, prefer
+  -- the cwd over the raw mx4sio:/-rooted APP_DIR so the settings
+  -- sidecar at APP_DIR/.pldrs and other write paths target the
+  -- writable mass*:/ root. Hardware regression 2026-05-28 PM:
+  -- "mx4sio:/APPS/PS1_POPSLOADER/.pldrs may be read-only" (Nuno).
+  local app_dir_lower = string.lower(app_dir or "")
+  if string.match(app_dir_lower, "^mx4sio%d*:") and string.match(current_dir, "^mass%d*:/") then
+    return current_dir
+  end
   return EnsureTrailingSlashNormRaw(app_dir)
 end
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -63,6 +63,73 @@ if string.find(ARGV0, "^hdd0:") then
     end
   end
 end
+
+BOOT_MX4SIO_PREFIX = nil
+if string.find(ARGV0, "^[Mm][Xx]4[Ss][Ii][Oo]") then
+  -- MX4SIO boot: the mx4sio:/ argv0 prefix is the BDM device-kind
+  -- label, NOT a writable fileXio mount. The launcher (wLaunchELF,
+  -- HOSDmenu, NHDDL, etc.) was able to load POPSLOADER.ELF through
+  -- some kernel-side indirection, but fileXio file writes against
+  -- mx4sio:/<path> fail with "may be read-only" (Nuno 2026-05-28 PM
+  -- hardware: `mx4sio:/APPS/PS1_POPSLOADER/.pldrs may be read-only`).
+  --
+  -- The writable filesystem path is the mass*:/ slot where bdmfs_fatfs
+  -- mounts the SD card once mx4sio_bd has loaded. The slot is volatile
+  -- (depends on hotplug + IRX load order), so we identify it
+  -- dynamically by the same ioctl driver-name rule PR #472 uses for
+  -- boot-device classification: sdc/mx4 ioctl => MX4SIO.
+  --
+  -- PR #472 also enforces at the C layer that mx4sio_bd requires
+  -- usbmass_bd to be loaded first (maintainer rule: "mx4sio will need
+  -- the usb drivers to activate before it with it"), so this branch
+  -- calls System.ensureUsbMass before System.initMX4SIO.
+  if type(System) == "table" and type(System.ensureUsbMass) == "function" then
+    pcall(System.ensureUsbMass)
+  end
+  if type(System) == "table" and type(System.initMX4SIO) == "function" then
+    pcall(System.initMX4SIO)
+  end
+  System.sleep(1) -- MX4SIO double-ping settle
+  if type(System) == "table" and type(System.refreshMassBackends) == "function" then
+    pcall(System.refreshMassBackends)
+  end
+  -- Scan mass slots for the one with sdc/mx4 ioctl driver. First match
+  -- wins. mass slots are volatile so do NOT cache the slot number --
+  -- subsequent boots may land on a different one.
+  local MX_ROOT = nil
+  if type(System.getMassMountDriver) == "function" then
+    for slot = 0, 9 do
+      local root = (slot == 0) and "mass:/" or ("mass"..tostring(slot)..":/")
+      local ok, driver = pcall(System.getMassMountDriver, root)
+      if ok and type(driver) == "string" and driver ~= "" then
+        local lowered = string.lower(driver)
+        if string.find(lowered, "mx4", 1, true) ~= nil or string.find(lowered, "sdc", 1, true) ~= nil then
+          MX_ROOT = root
+          break
+        end
+      end
+    end
+  end
+  if MX_ROOT ~= nil then
+    BOOT_MX4SIO_PREFIX = MX_ROOT
+    -- Translate mx4sio:/<rel> argv0 directory to MX_ROOT/<rel>/.
+    -- ResolveAppDirLocal in system.lua will see APP_DIR is mx4sio:/-
+    -- prefixed and cwd is mass*:/ and prefer the cwd, so settings
+    -- sidecar resolves to the writable mass*:/ root.
+    local relpath = string.match(ARGV0, "^[Mm][Xx]4[Ss][Ii][Oo]%d*:/?(.*)$") or ""
+    -- Strip the filename so cwd is the directory containing the ELF
+    -- (matches what the HDD branch does for its BOOTPATH).
+    local dir_rel = string.match(relpath, "^(.-)/[^/]*$")
+    if dir_rel == nil then
+      dir_rel = ""
+    end
+    local translated_cwd = MX_ROOT..string.gsub(dir_rel, "^/+", "")
+    if string.sub(translated_cwd, -1) ~= "/" then
+      translated_cwd = translated_cwd.."/"
+    end
+    System.currentDirectory(translated_cwd)
+  end
+end
 GPAD = 0
 Font.ftInit()
 local BOOT_FONT_KEY = "fonts/Roboto-Regular.ttf"


### PR DESCRIPTION
> **Hardware regression** reported by Nuno 2026-05-28 PM on the rolling-release built post-PR-#470/#472/#473. Reproduced on screenshot:
>
> ```
> Failed to save settings -- Booted from: MX4SIO
> Couldn't save settings
> mx4sio:/APPS/PS1_POPSLOADER/.pldrs may be read-only
> ```

## Root cause

When `argv0` is `mx4sio:/APPS/PS1_POPSLOADER/POPSLOADER.ELF`, the `mx4sio:/` prefix is the BDM device-kind label, **not** a writable fileXio mount. The launcher (wLaunchELF, HOSDmenu, NHDDL, etc.) was able to load the ELF through some kernel-side indirection, but fileXio file writes against `mx4sio:/<path>` fail with the read-only error.

The writable filesystem path is the `mass*:/` slot where `bdmfs_fatfs` mounts the SD card once `mx4sio_bd` has loaded.

## Why dynamic slot resolution

Mass slot assignment is **volatile** (depends on hotplug + IRX load order). Per maintainer 2026-05-28: \"when mx4sio: is detected, normalize it to the massN with sdc/mx4 devctl. This way we can be launched from either one, and still function as if they were massN. Also remember massN is volatile and can change, so it needs to dynamically able.\"

So the slot must be identified at boot time using the same ioctl driver-name rule PR #472 uses for boot-device classification: `sdc`/`mx4` ioctl driver name → MX4SIO.

## Fix (mirrors the existing `hdd0:/` boot branch in `etc/boot.lua`)

1. **`etc/boot.lua`**: when `ARGV0` starts with `mx4sio` (any case, any digit suffix), load `usbmass_bd` (the C-layer dependency from PR #472's `lua_mx4sio_init`), then `mx4sio_bd`, sleep 1s for the MX4SIO double-ping settle, refresh the BDM cache, then iterate `mass:/` through `mass9:/` looking for the slot whose ioctl driver name contains \"sdc\" or \"mx4\". **First match wins.** Rewrite `cwd` from `mx4sio:/<rel>/` to `<MX_ROOT>/<rel>/` so relative-path file I/O targets the writable mount. Set `BOOT_MX4SIO_PREFIX = MX_ROOT` for downstream readers.

2. **`bin/POPSLDR/system.lua` `ResolveAppDirLocal`**: when `APP_DIR` (from `main.cpp` `argv`) is `mx4sio:/`-prefixed AND `System.currentDirectory()` is `mass*:/`, prefer the cwd. This lets the `boot.lua` translation propagate to `APP_DIR_LOCAL` without `main.cpp` also needing to translate.

## Impact

- **MX4SIO-rooted POPSLoader settings save** now writes to `<mass*>:/<install path>/.pldrs` — the same per-device sidecar contract that USB / MC / MMCE installs use.
- **Non-MX4SIO boots**: no path-prefix match, branch is skipped entirely. No additional IRX loads, no behavior change.
- **HDD-rooted POPSLoader**: unchanged. HDD branch runs first, this branch only fires for `mx4sio:/` `argv0`.

## Test plan (HARDWARE)

- [ ] MX4SIO-rooted POPSLoader: settings save no longer shows the read-only error; sidecar at `<mass*>:/<install path>/.pldrs` is created.
- [ ] USB / MC / MMCE save: no regression.
- [ ] HDD-rooted POPSLoader: settings still fall back to `mc0:/POPSTARTER/.pldrs` per PR #466 design.
- [ ] Boot device label on main menu still shows \"MX4SIO\" (BOOT_MX4SIO_PREFIX is set; `ResolveBootContext` still classifies as MX4SIO by argv0 prefix).
- [ ] Preservation contracts (D-10/D-14/D-15, DKWDRV-MC, BOOT.ELF) all still PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)