### PR TITLE
MX4SIO boot retry + diagnostic — PR #476 single-shot scan wasn't enough

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2474,11 +2474,11 @@ UI = {
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             elseif reason == "save_failed" then
-              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only", "error")
+              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only"..((type(BOOT_MX4SIO_PROBE_RESULT) == "string" and BOOT_MX4SIO_PROBE_RESULT ~= "") and "\nmx4sio probe: "..BOOT_MX4SIO_PROBE_RESULT or ""), "error")
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             else
-              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only", "error")
+              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only"..((type(BOOT_MX4SIO_PROBE_RESULT) == "string" and BOOT_MX4SIO_PROBE_RESULT ~= "") and "\nmx4sio probe: "..BOOT_MX4SIO_PROBE_RESULT or ""), "error")
               UI.SyncSettingsSelectionFromRuntime()
               UI.SyncSettingsDraftFromRuntime()
             end

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -65,6 +65,7 @@ if string.find(ARGV0, "^hdd0:") then
 end
 
 BOOT_MX4SIO_PREFIX = nil
+BOOT_MX4SIO_PROBE_RESULT = nil
 if string.find(ARGV0, "^[Mm][Xx]4[Ss][Ii][Oo]") then
   -- MX4SIO boot: the mx4sio:/ argv0 prefix is the BDM device-kind
   -- label, NOT a writable fileXio mount. The launcher (wLaunchELF,
@@ -89,27 +90,48 @@ if string.find(ARGV0, "^[Mm][Xx]4[Ss][Ii][Oo]") then
   if type(System) == "table" and type(System.initMX4SIO) == "function" then
     pcall(System.initMX4SIO)
   end
-  System.sleep(1) -- MX4SIO double-ping settle
-  if type(System) == "table" and type(System.refreshMassBackends) == "function" then
-    pcall(System.refreshMassBackends)
-  end
-  -- Scan mass slots for the one with sdc/mx4 ioctl driver. First match
-  -- wins. mass slots are volatile so do NOT cache the slot number --
-  -- subsequent boots may land on a different one.
-  local MX_ROOT = nil
-  if type(System.getMassMountDriver) == "function" then
+  -- Initial settle for the MX4SIO double-ping. PR #476 had a single
+  -- 1-second sleep + single scan; Nuno's 2026-05-28 PM hardware test
+  -- showed that's not enough on real hardware -- the BDM didn't see
+  -- the SD card on the first probe, the scan returned nothing, the
+  -- cwd translation never happened, and settings still tried to write
+  -- to mx4sio:/<path>/.pldrs. PLDR.InitMX4SIOPopsRoot uses a 3-attempt
+  -- retry with sleep(1) between failures (~3s worst case) -- mirror
+  -- that here so the scan succeeds even when the first probe misses.
+  System.sleep(1)
+  local function scan_for_mx4sio_root()
+    if type(System.refreshMassBackends) == "function" then
+      pcall(System.refreshMassBackends)
+    end
+    if type(System.getMassMountDriver) ~= "function" then
+      return nil, "no_getMassMountDriver"
+    end
     for slot = 0, 9 do
       local root = (slot == 0) and "mass:/" or ("mass"..tostring(slot)..":/")
       local ok, driver = pcall(System.getMassMountDriver, root)
       if ok and type(driver) == "string" and driver ~= "" then
         local lowered = string.lower(driver)
         if string.find(lowered, "mx4", 1, true) ~= nil or string.find(lowered, "sdc", 1, true) ~= nil then
-          MX_ROOT = root
-          break
+          return root, "found:"..root.."="..driver
         end
       end
     end
+    return nil, "no_match"
   end
+  local MX_ROOT = nil
+  local probe_trace = {}
+  for attempt = 1, 3 do
+    local root, info = scan_for_mx4sio_root()
+    probe_trace[#probe_trace + 1] = "a"..tostring(attempt)..":"..tostring(info or "nil")
+    if root ~= nil then
+      MX_ROOT = root
+      break
+    end
+    if attempt < 3 then
+      System.sleep(1)
+    end
+  end
+  BOOT_MX4SIO_PROBE_RESULT = table.concat(probe_trace, ";")
   if MX_ROOT ~= nil then
     BOOT_MX4SIO_PREFIX = MX_ROOT
     -- Translate mx4sio:/<rel> argv0 directory to MX_ROOT/<rel>/.


### PR DESCRIPTION
> **Follow-up to PR #476**, which was merged but didn't fix Nuno's MX4SIO save error on the rolling-release rebuilt from BETA-12-PLAY at commit 95c937b. Same error reproduced:
>
> ```
> Failed to save settings -- Booted from: MX4SIO
> Couldn't save settings
> mx4sio:/APPS/PS1_POPSLOADER/.pldrs may be read-only
> ```

## Why PR #476's fix didn't work on hardware

The PR #476 boot.lua branch did a single 1-second sleep + single-shot mass-slot scan after `System.initMX4SIO`. On Nuno's real hardware that wasn't enough — the BDM didn't see the SD card on the first probe, the scan returned nothing, the cwd translation never happened, and settings still tried to write to `mx4sio:/<path>/.pldrs`.

`PLDR.InitMX4SIOPopsRoot` (the existing MX4SIO page-entry init) already uses a 3-attempt retry pattern with `System.sleep(1)` between failures for the same MX4SIO double-ping reason. The boot.lua scan needed to mirror that.

## This fix

**`etc/boot.lua`** — `mx4sio:` boot branch:
- 3-attempt retry loop with `sleep(1)` between failed attempts (mirrors `PLDR.InitMX4SIOPopsRoot`).
- `refreshMassBackends` runs at the start of every scan attempt (not just once), so a freshly-attached BDM device is picked up on retry.
- Captures a diagnostic trace into the `BOOT_MX4SIO_PROBE_RESULT` Lua global: `\"a1:no_match;a2:found:mass0:/=sdc;...\"` — tells us per-attempt whether the scan found the device, on which slot, and which driver string was reported.

**`bin/POPSLDR/ui.lua`** — the \"Couldn't save settings\" toast now appends `BOOT_MX4SIO_PROBE_RESULT` when it's set. Nuno's next photo will include the probe trace so we can debug remotely if the retry still misses.

## Test plan (HARDWARE)

- [ ] **MX4SIO-rooted POPSLoader**: settings save no longer shows the read-only error; sidecar at `<mass*>:/<install path>/.pldrs` is created.
- [ ] If the save STILL fails: photograph the new error toast — it now includes the probe trace (which attempts succeeded/failed, which slot if any). Send to maintainer.
- [ ] USB / MC / MMCE save: no regression.
- [ ] HDD-rooted POPSLoader: settings still fall back to `mc0:/POPSTARTER/.pldrs` per PR #466.
- [ ] Preservation contracts (D-10/D-14/D-15, DKWDRV-MC, BOOT.ELF) all still PASS.

## What this doesn't do

- No fallback to `mc0:/POPSTARTER/.pldrs` if the retry exhausts. If the retry misses the SD card on all 3 attempts (~3s total), save still fails. The diagnostic trace tells us what happened so we can either tune the retry further or add the mc0 fallback as a third iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)