### PR TITLE
fix (DRAFT): Class B/U-10 BOOT.ELF exit matched to wLaunchELF loader (no post-reset reload)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,20 @@ export HEADER
 RESET_IOP = 1
 #---------------------- enable DEBUGGING MODE ---------------------#
 DEBUG = 0
+#- Class A bootstrap diagnostic (GS_BGCOLOUR per-stage paint in    #
+#- _ps2sdk_memory_init). Turn ON only for diagnostic-build         #
+#- artifacts handed to hardware testers; release builds MUST be 0. #
+#- ACTIVE in this branch for the Class A/B diagnostic DRAFT PR.    #
+#- Revert to 0 before any non-diagnostic release.                  #
+BOOTSTRAP_DEBUG_COLORS = 1
+#- Class B / U-10 exit diagnostic (GS_BGCOLOUR per-stage paint in  #
+#- LoadELFFromFileExecPS2RebootIOPWithPartition direct-launch      #
+#- path: BOOT.ELF / DKWDRV.ELF / generic non-HDD-backed exec).     #
+#- Turn ON only for diagnostic-build artifacts handed to hardware  #
+#- testers; release builds MUST be 0.                              #
+#- ACTIVE in this branch for the Class A/B diagnostic DRAFT PR.    #
+#- Revert to 0 before any non-diagnostic release.                  #
+EXIT_DEBUG_COLORS = 1
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#
@@ -57,6 +71,14 @@ endif
 ifeq ($(DEBUG),1)
 EE_CXXFLAGS += -DDEBUG
 endif
+
+ifeq ($(BOOTSTRAP_DEBUG_COLORS),1)
+EE_CXXFLAGS += -DBOOTSTRAP_DEBUG_COLORS
+endif
+
+#- EXIT_DEBUG_COLORS is consumed by src/elf_loader/Makefile (elf.c #
+#- is built there, not here). We propagate the variable explicitly #
+#- via the sub-make invocation in the elfloader target below.      #
 
 BIN2S = $(PS2SDK)/bin/bin2c
 
@@ -267,7 +289,7 @@ elfloader: src/elf_loader/libcustom-elf-loader.a
 src/elf_loader/libcustom-elf-loader.a: src/elf_loader
 	@$(MAKE) cleanbin
 	@$(MAKE) -C src/elf_loader/src/loader/ clean all
-	@$(MAKE) -C src/elf_loader clean all
+	@$(MAKE) -C src/elf_loader EXIT_DEBUG_COLORS=$(EXIT_DEBUG_COLORS) clean all
 
 $(EE_OBJS_DIR):
 	@mkdir -p $@

--- a/src/elf_loader/Makefile
+++ b/src/elf_loader/Makefile
@@ -10,6 +10,15 @@ BIN2C = $(PS2SDK)/bin/bin2c
 EE_OBJS = src/elf.o loader.o
 EE_LIB = libcustom-elf-loader.a
 
+# Class B / U-10 exit diagnostic (GS_BGCOLOUR per-stage paint in
+# LoadELFFromFileExecPS2RebootIOPWithPartition). Propagated from the
+# parent Makefile so a single toggle there controls both the parent
+# and this sub-make. Release builds MUST have EXIT_DEBUG_COLORS=0.
+EXIT_DEBUG_COLORS ?= 0
+ifeq ($(EXIT_DEBUG_COLORS),1)
+EE_CFLAGS += -DEXIT_DEBUG_COLORS
+endif
+
 .PHONY: FORCE
 
 src/loader/bin/loader.elf:

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -658,11 +658,15 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	 *   PURPLE - re-init RPC + reload MC modules returned
 	 *   RED    - about to ExecPS2 the loaded ELF
 	 *
-	 * If the tester's screen stops on YELLOW (no further paint for >5s)
-	 * we have direct confirmation that SifIopReset is the hang point and
-	 * the next F-fix angle (fileXioExit() / dev9Shutdown() before reset,
-	 * mirroring the Layer A teardown in main.cpp::_ps2sdk_memory_init)
-	 * is the right next experiment.
+	 * UPDATE (B1, 2026-05-29): the fileXioExit() teardown this note
+	 * predicted is now APPLIED below (after the PFS unmount, before the
+	 * reset). Corroborated independently by a Codex audit of cc74a3e and
+	 * by this project's own prior analysis. So this build is now a
+	 * CANDIDATE-FIX + diagnostic in one:
+	 *   - If U-10 now boots through (screen sails past YELLOW to ORANGE/
+	 *     BLUE/PURPLE/RED and BOOT.ELF launches), B1 is confirmed.
+	 *   - If it still stops at YELLOW, fileXioExit was insufficient and
+	 *     the next angle is dev9Shutdown() for HDD-launched POPSLoader.
 	 */
 #ifdef EXIT_DEBUG_COLORS
 #define SET_EXIT_BG(c) {*((volatile unsigned long int *)0x120000E0) = c;}
@@ -701,6 +705,26 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	 */
 	unmount_pfs_slots_for_exec(build_exec_keep_mask(resolved_path));
 	SET_EXIT_BG(0x00FF00); /* GREEN - PFS unmount returned */
+
+	/* B1 fix (Codex audit of cc74a3e + independent finding, 2026-05-29):
+	 * tear down EE-side fileXio before SifIopReset. POPSLoader calls
+	 * fileXioInit() during boot (src/main.cpp), so __fileXioInited is set
+	 * and the IOP-side fileXio RPC server is live at this point. A live
+	 * fileXio server blocks SifIopReset (ps2sdk #425) -- the same root
+	 * cause Layer A handles at startup in _ps2sdk_memory_init. The PR #464
+	 * F4 PFS unmount alone did NOT release it on hardware; fileXioExit()
+	 * performs the full deinit (clears __fileXioInited and tears down the
+	 * RPC binding) so the reset can complete. It is guarded internally by
+	 * __fileXioInited, so it is a safe no-op if fileXio was never inited.
+	 *
+	 * Scope: HDD-backed POPSTARTER (D-10) never reaches here -- it returns
+	 * earlier via ExecuteHddBackedViaEmbeddedLoader -- so this only affects
+	 * non-HDD-backed reboot launches: BOOT.ELF (the U-10 target), MC
+	 * DKWDRV, and generic direct reboot launches. MC DKWDRV must be
+	 * retested for regression (it gets a fresh IOP + MC modules after this,
+	 * and does not need fileXio across the handoff, so the teardown should
+	 * be transparent to it). */
+	fileXioExit();
 
 	FlushCache(0);
 	SET_EXIT_BG(0x00FFFF); /* YELLOW - about to SifIopReset */

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -642,6 +642,32 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
+	/* B2 (Nuno hardware report 2026-05-29): HDD-launched POPSLoader -> Exit
+	 * -> BOOT.ELF reaches here because ui.lua forces reboot_iop=1 when an
+	 * HDD page was used this session. The manual SifIopReset -> reload-MC-
+	 * modules -> ExecPS2 sequence below then hangs POST-reset: the
+	 * diagnostic build stopped at BLUE for HOSDMENU (hang in the post-reset
+	 * SifInitRpc / SifLoadModule MC reload) and reached RED for wLE (hang at
+	 * ExecPS2). SifIopReset itself COMPLETES -- the reset is not the
+	 * problem; doing the reload+exec from POPSLoader's live EE process is.
+	 *
+	 * Non-HDD-launched BOOT.ELF works because ui.lua leaves reboot_iop=0, so
+	 * it goes through LoadELFFromFileWithPartition -> the embedded child
+	 * loader (identical mc0/mc1 case there). The child loader runs as a
+	 * fresh EE process whose own startup performs the IOP reset (the proven
+	 * Layer-A contract) and unmounts pfs internally (loader.c), so it is
+	 * robust to the HDD session state. Route HDD-launched BOOT.ELF through
+	 * that SAME proven path instead of the fragile in-process reboot
+	 * sequence. No manual PFS unmount / fileXioExit is needed here -- the
+	 * child loader's startup reset tears the IOP (including pfs1:) down.
+	 */
+	if (strcmp(resolved_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
+	    strcmp(resolved_path, "mc1:/BOOT/BOOT.ELF") == 0) {
+		char *boot_argv[1];
+		boot_argv[0] = (char *)resolved_path;
+		return ExecuteViaEmbeddedLoader("", resolved_path, 1, boot_argv);
+	}
+
 	/* Class B / U-10 exit-path diagnostic. When EXIT_DEBUG_COLORS is
 	 * defined (Makefile toggle, off by default), paint the GS background
 	 * register at each stage of the direct-launch sequence so a hardware

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -642,6 +642,35 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
+	/* Class B / U-10 exit-path diagnostic. When EXIT_DEBUG_COLORS is
+	 * defined (Makefile toggle, off by default), paint the GS background
+	 * register at each stage of the direct-launch sequence so a hardware
+	 * tester's photograph of the hang point tells us exactly which call
+	 * pinned the IOP. This is a pure no-op in release builds.
+	 *
+	 *   WHITE  - entered direct-launch (post-HDD-backed gate)
+	 *   CYAN   - SifLoadElf returned with a valid ELF
+	 *   GREEN  - unmount_pfs_slots_for_exec returned
+	 *   YELLOW - FlushCache(0) returned, about to SifIopReset
+	 *   ORANGE - SifIopReset returned (suspect from PR #463 -- screen
+	 *            stops here on U-10 with current code)
+	 *   BLUE   - SifIopSync returned
+	 *   PURPLE - re-init RPC + reload MC modules returned
+	 *   RED    - about to ExecPS2 the loaded ELF
+	 *
+	 * If the tester's screen stops on YELLOW (no further paint for >5s)
+	 * we have direct confirmation that SifIopReset is the hang point and
+	 * the next F-fix angle (fileXioExit() / dev9Shutdown() before reset,
+	 * mirroring the Layer A teardown in main.cpp::_ps2sdk_memory_init)
+	 * is the right next experiment.
+	 */
+#ifdef EXIT_DEBUG_COLORS
+#define SET_EXIT_BG(c) {*((volatile unsigned long int *)0x120000E0) = c;}
+#else
+#define SET_EXIT_BG(c)
+#endif
+	SET_EXIT_BG(0xFFFFFF); /* WHITE - entered direct-launch */
+
 	SifInitRpc(0);
 	SifLoadFileInit();
 	ret = SifLoadElf(resolved_path, &elfdata);
@@ -650,6 +679,7 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	if (ret != 0 || elfdata.epc == 0) {
 		return -2;
 	}
+	SET_EXIT_BG(0xFFFF00); /* CYAN - SifLoadElf returned, ELF valid */
 
 	/* Unmount all live PFS slots before SifIopReset, including the boot
 	 * partition's pfs1: that etc/boot.lua established for HDD-booted
@@ -670,12 +700,16 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	 * sabotage diagnosed in PR #463.
 	 */
 	unmount_pfs_slots_for_exec(build_exec_keep_mask(resolved_path));
+	SET_EXIT_BG(0x00FF00); /* GREEN - PFS unmount returned */
 
 	FlushCache(0);
+	SET_EXIT_BG(0x00FFFF); /* YELLOW - about to SifIopReset */
 	while (!SifIopReset("", 0)) {
 	}
+	SET_EXIT_BG(0x00A5FF); /* ORANGE - SifIopReset returned */
 	while (!SifIopSync()) {
 	}
+	SET_EXIT_BG(0xFF0000); /* BLUE - SifIopSync returned */
 
 	SifInitRpc(0);
 	SifLoadFileInit();
@@ -687,6 +721,7 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 
 	FlushCache(0);
 	FlushCache(2);
+	SET_EXIT_BG(0x800080); /* PURPLE - MC modules reloaded, about to ExecPS2 */
 
 	if (is_dkwdrv_elf_path(resolved_path)) {
 		snprintf(dkwdrv_argv0, sizeof(dkwdrv_argv0), "%s", resolved_path);
@@ -696,6 +731,8 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		final_argv = dkwdrv_argv;
 	}
 
+	SET_EXIT_BG(0x0000FF); /* RED - about to ExecPS2 (last EE instruction we control) */
 	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, final_argc, final_argv);
+#undef SET_EXIT_BG
 	return -1;
 }

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -642,70 +642,85 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
-	/* B2 (Nuno hardware report 2026-05-29): POPSLoader was BOOTED FROM HDD,
-	 * then triangle -> Exit -> BOOT.ELF (the normal mc0:/mc1: BOOT.ELF, NOT
-	 * an HDD-backed target). ui.lua forces reboot_iop=1 here because the HDD
-	 * boot left pfs1: mounted, so we land in this reboot variant. Its manual
-	 * SifIopReset -> reload-MC-modules -> ExecPS2 sequence below hangs
-	 * POST-reset: the diagnostic stopped at BLUE for HOSDMENU (hang in the
-	 * post-reset SifInitRpc / SifLoadModule MC reload) and reached RED for
-	 * wLE (hang at ExecPS2). SifIopReset itself COMPLETES -- the reset is
-	 * not the problem; the in-EE-process reload+exec is.
-	 *
-	 * Non-HDD-booted POPSLoader -> BOOT.ELF works because ui.lua leaves
-	 * reboot_iop=0 and it goes through the embedded child loader, which does
-	 * NOT do that fragile in-process reset+reload. Route this case through
-	 * the same proven child loader.
-	 *
-	 * IMPORTANT (the gap in the first B2 attempt): the child loader does NOT
-	 * reset the IOP, and for an mc:/ target it takes its generic branch
-	 * which does NOT unmount pfs (loader.c only unmounts pfs for HDD-
-	 * partition-context *targets*). Since POPSLoader was booted from HDD,
-	 * pfs1: is STILL MOUNTED -- so we must tear the live PFS mounts + fileXio
-	 * down HERE, in-process, before handing off, or BOOT.ELF starts on top
-	 * of a live pfs1:/HDD state. keep_mask=0: a cold BOOT.ELF launch needs
-	 * no pfs slot preserved.
-	 */
-	if (strcmp(resolved_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
-	    strcmp(resolved_path, "mc1:/BOOT/BOOT.ELF") == 0) {
-		char *boot_argv[1];
-		boot_argv[0] = (char *)resolved_path;
-		unmount_pfs_slots_for_exec(0);
-		fileXioExit();
-		return ExecuteViaEmbeddedLoader("", resolved_path, 1, boot_argv);
-	}
-
-	/* Class B / U-10 exit-path diagnostic. When EXIT_DEBUG_COLORS is
-	 * defined (Makefile toggle, off by default), paint the GS background
-	 * register at each stage of the direct-launch sequence so a hardware
-	 * tester's photograph of the hang point tells us exactly which call
-	 * pinned the IOP. This is a pure no-op in release builds.
-	 *
-	 *   WHITE  - entered direct-launch (post-HDD-backed gate)
-	 *   CYAN   - SifLoadElf returned with a valid ELF
-	 *   GREEN  - unmount_pfs_slots_for_exec returned
-	 *   YELLOW - FlushCache(0) returned, about to SifIopReset
-	 *   ORANGE - SifIopReset returned (suspect from PR #463 -- screen
-	 *            stops here on U-10 with current code)
-	 *   BLUE   - SifIopSync returned
-	 *   PURPLE - re-init RPC + reload MC modules returned
-	 *   RED    - about to ExecPS2 the loaded ELF
-	 *
-	 * UPDATE (B1, 2026-05-29): the fileXioExit() teardown this note
-	 * predicted is now APPLIED below (after the PFS unmount, before the
-	 * reset). Corroborated independently by a Codex audit of cc74a3e and
-	 * by this project's own prior analysis. So this build is now a
-	 * CANDIDATE-FIX + diagnostic in one:
-	 *   - If U-10 now boots through (screen sails past YELLOW to ORANGE/
-	 *     BLUE/PURPLE/RED and BOOT.ELF launches), B1 is confirmed.
-	 *   - If it still stops at YELLOW, fileXioExit was insufficient and
-	 *     the next angle is dev9Shutdown() for HDD-launched POPSLoader.
-	 */
+	/* EXIT_DEBUG_COLORS: paint the GS background register at each stage so a
+	 * hardware tester's photo of the hang point tells us which call pinned
+	 * the IOP. No-op in release builds. Defined here so both the wLE-matched
+	 * BOOT.ELF handler below and the general direct-launch path can use it. */
 #ifdef EXIT_DEBUG_COLORS
 #define SET_EXIT_BG(c) {*((volatile unsigned long int *)0x120000E0) = c;}
 #else
 #define SET_EXIT_BG(c)
 #endif
+
+	/* wLE-matched BOOT.ELF exit (Nuno hardware 2026-05-29). Scenario:
+	 * POPSLoader was BOOTED FROM HDD, then triangle -> Exit -> BOOT.ELF
+	 * (the normal mc0:/mc1: target). ui.lua forces reboot_iop=1 for the HDD
+	 * session, landing here. The general direct-launch path below reloads MC
+	 * modules AFTER SifIopReset -- and that is exactly where hardware hung:
+	 * HOSDMENU stopped at BLUE (in the post-reset SifInitRpc / SifLoadModule
+	 * block) and wLE reached RED (ExecPS2). SifIopReset itself COMPLETES.
+	 *
+	 * POPSLoader's elf_loader is forked from wLaunchELF, whose loader.c does
+	 * NOT reload any modules after the reset: it loads the target ELF into EE
+	 * RAM, resets the IOP, SifExitRpc, ExecPS2, and lets the target load its
+	 * own IRXs. Mirror that proven sequence here, scoped to BOOT.ELF so MC
+	 * DKWDRV / generic keep their current (working) reload path below.
+	 *
+	 * The ELF is loaded into EE RAM BEFORE the reset (survives it, needs no
+	 * IOP modules at exec time). pfs1: (live from the HDD boot) + fileXio are
+	 * torn down first; SifIopReset then clears the rest of the IOP. NO
+	 * post-reset reload -- that block is POPSLoader's non-wLE divergence and
+	 * the confirmed hang site.
+	 */
+	if (strcmp(resolved_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
+	    strcmp(resolved_path, "mc1:/BOOT/BOOT.ELF") == 0) {
+		char *boot_argv[1];
+		boot_argv[0] = (char *)resolved_path;
+
+		SET_EXIT_BG(0xFFFFFF); /* WHITE - BOOT.ELF handler entered */
+		SifInitRpc(0);
+		SifLoadFileInit();
+		ret = SifLoadElf(resolved_path, &elfdata);
+		SifLoadFileExit();
+		if (ret != 0 || elfdata.epc == 0) {
+			return -2;
+		}
+		SET_EXIT_BG(0xFFFF00); /* CYAN - SifLoadElf OK, ELF in EE RAM */
+
+		unmount_pfs_slots_for_exec(0); /* clear pfs1: from the HDD boot */
+		fileXioExit();
+		SET_EXIT_BG(0x00FF00); /* GREEN - pfs + fileXio torn down */
+
+		FlushCache(0);
+		SET_EXIT_BG(0x00FFFF); /* YELLOW - about to SifIopReset */
+		while (!SifIopReset("", 0)) {
+		}
+		SET_EXIT_BG(0x00A5FF); /* ORANGE - SifIopReset returned */
+		while (!SifIopSync()) {
+		}
+		SET_EXIT_BG(0xFF0000); /* BLUE - SifIopSync returned */
+
+		/* wLE contract: NO post-reset module reload -- straight to ExecPS2. */
+		SifExitRpc();
+		FlushCache(0);
+		FlushCache(2);
+		SET_EXIT_BG(0x0000FF); /* RED - about to ExecPS2 (wLE-matched) */
+		ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, 1, boot_argv);
+		return -1;
+	}
+
+	/* Class B / U-10 exit-path diagnostic for the GENERAL direct-launch path
+	 * (MC DKWDRV, generic non-HDD-backed reboot launches). BOOT.ELF no longer
+	 * reaches here -- it is handled by the wLE-matched branch above. Colors:
+	 *   WHITE  - entered general direct-launch
+	 *   CYAN   - SifLoadElf returned with a valid ELF
+	 *   GREEN  - unmount_pfs_slots_for_exec returned
+	 *   YELLOW - FlushCache(0) returned, about to SifIopReset
+	 *   ORANGE - SifIopReset returned
+	 *   BLUE   - SifIopSync returned
+	 *   PURPLE - re-init RPC + reload MC modules returned
+	 *   RED    - about to ExecPS2 the loaded ELF
+	 */
 	SET_EXIT_BG(0xFFFFFF); /* WHITE - entered direct-launch */
 
 	SifInitRpc(0);

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -642,29 +642,36 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
-	/* B2 (Nuno hardware report 2026-05-29): HDD-launched POPSLoader -> Exit
-	 * -> BOOT.ELF reaches here because ui.lua forces reboot_iop=1 when an
-	 * HDD page was used this session. The manual SifIopReset -> reload-MC-
-	 * modules -> ExecPS2 sequence below then hangs POST-reset: the
-	 * diagnostic build stopped at BLUE for HOSDMENU (hang in the post-reset
-	 * SifInitRpc / SifLoadModule MC reload) and reached RED for wLE (hang at
-	 * ExecPS2). SifIopReset itself COMPLETES -- the reset is not the
-	 * problem; doing the reload+exec from POPSLoader's live EE process is.
+	/* B2 (Nuno hardware report 2026-05-29): POPSLoader was BOOTED FROM HDD,
+	 * then triangle -> Exit -> BOOT.ELF (the normal mc0:/mc1: BOOT.ELF, NOT
+	 * an HDD-backed target). ui.lua forces reboot_iop=1 here because the HDD
+	 * boot left pfs1: mounted, so we land in this reboot variant. Its manual
+	 * SifIopReset -> reload-MC-modules -> ExecPS2 sequence below hangs
+	 * POST-reset: the diagnostic stopped at BLUE for HOSDMENU (hang in the
+	 * post-reset SifInitRpc / SifLoadModule MC reload) and reached RED for
+	 * wLE (hang at ExecPS2). SifIopReset itself COMPLETES -- the reset is
+	 * not the problem; the in-EE-process reload+exec is.
 	 *
-	 * Non-HDD-launched BOOT.ELF works because ui.lua leaves reboot_iop=0, so
-	 * it goes through LoadELFFromFileWithPartition -> the embedded child
-	 * loader (identical mc0/mc1 case there). The child loader runs as a
-	 * fresh EE process whose own startup performs the IOP reset (the proven
-	 * Layer-A contract) and unmounts pfs internally (loader.c), so it is
-	 * robust to the HDD session state. Route HDD-launched BOOT.ELF through
-	 * that SAME proven path instead of the fragile in-process reboot
-	 * sequence. No manual PFS unmount / fileXioExit is needed here -- the
-	 * child loader's startup reset tears the IOP (including pfs1:) down.
+	 * Non-HDD-booted POPSLoader -> BOOT.ELF works because ui.lua leaves
+	 * reboot_iop=0 and it goes through the embedded child loader, which does
+	 * NOT do that fragile in-process reset+reload. Route this case through
+	 * the same proven child loader.
+	 *
+	 * IMPORTANT (the gap in the first B2 attempt): the child loader does NOT
+	 * reset the IOP, and for an mc:/ target it takes its generic branch
+	 * which does NOT unmount pfs (loader.c only unmounts pfs for HDD-
+	 * partition-context *targets*). Since POPSLoader was booted from HDD,
+	 * pfs1: is STILL MOUNTED -- so we must tear the live PFS mounts + fileXio
+	 * down HERE, in-process, before handing off, or BOOT.ELF starts on top
+	 * of a live pfs1:/HDD state. keep_mask=0: a cold BOOT.ELF launch needs
+	 * no pfs slot preserved.
 	 */
 	if (strcmp(resolved_path, "mc0:/BOOT/BOOT.ELF") == 0 ||
 	    strcmp(resolved_path, "mc1:/BOOT/BOOT.ELF") == 0) {
 		char *boot_argv[1];
 		boot_argv[0] = (char *)resolved_path;
+		unmount_pfs_slots_for_exec(0);
+		fileXioExit();
 		return ExecuteViaEmbeddedLoader("", resolved_path, 1, boot_argv);
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -611,12 +611,48 @@ extern "C" void _ps2sdk_memory_init() {
      * MC autoboot) are unaffected: each new call has a "not
      * initialized" guard. The only behavioral delta is that the IOP
      * reset now completes instead of hanging when fileXio was alive.
+     *
+     * Class A diagnostic (BOOTSTRAP_DEBUG_COLORS): Nuno 2026-05-28 PM
+     * reported "HOSDmenu black screens when launching POPSLoader, we
+     * don't even get to the splash" and "Some builds of wLE blackscreen
+     * as well when booting POPSLoader." Layer A above was meant to
+     * resolve this class (parent-launcher IOP poisoning POPSLoader's
+     * startup) but apparently doesn't for HOSDmenu and certain wLE
+     * builds. Stage-paint the GS background register at each step so
+     * a hardware tester's photograph tells us exactly which call hangs.
+     * The macro is a no-op unless BOOTSTRAP_DEBUG_COLORS is defined in
+     * the build (release builds stay clean).
+     *
+     *   WHITE  - _ps2sdk_memory_init entry (parent IOP state inherited)
+     *   CYAN   - SifExitRpc returned
+     *   GREEN  - SifInitRpc(0) returned (first call)
+     *   YELLOW - fileXioExit returned
+     *   ORANGE - SifIopReset returned (the historically suspect call)
+     *   BLUE   - SifIopSync returned
+     *   PURPLE - SifInitRpc(0) returned (final, about to enter main)
+     *
+     * If the screen stays the previous color for >5 seconds with no
+     * progress, that's the call that hung. Send a photo back so we
+     * know which hypothesis to pursue.
      */
+#ifdef BOOTSTRAP_DEBUG_COLORS
+#define SET_BOOTSTRAP_BG(c) {*((volatile unsigned long int *)0x120000E0) = c;}
+#else
+#define SET_BOOTSTRAP_BG(c)
+#endif
+    SET_BOOTSTRAP_BG(0xFFFFFF); /* WHITE  - entry */
     SifExitRpc();
+    SET_BOOTSTRAP_BG(0xFFFF00); /* CYAN   - after SifExitRpc */
     SifInitRpc(0);
+    SET_BOOTSTRAP_BG(0x00FF00); /* GREEN  - after first SifInitRpc(0) */
     fileXioExit();
+    SET_BOOTSTRAP_BG(0x00FFFF); /* YELLOW - after fileXioExit */
     while (!SifIopReset("", 0)){};
+    SET_BOOTSTRAP_BG(0x00A5FF); /* ORANGE - after SifIopReset */
     while (!SifIopSync()){};
+    SET_BOOTSTRAP_BG(0xFF0000); /* BLUE   - after SifIopSync */
     SifInitRpc(0);
+    SET_BOOTSTRAP_BG(0x800080); /* PURPLE - after final SifInitRpc */
+#undef SET_BOOTSTRAP_BG
 #endif
 }


### PR DESCRIPTION
## DRAFT / HARDWARE-TEST BUILD — do not merge as-is (diagnostic flags ON)

This branch now does TWO things in one tester build:
1. **Applies candidate fix B1** for Class B / U-10 (real code).
2. **Keeps the GS_BGCOLOUR diagnostics** for Class A and (as a fallback) Class B.

So a single rolling-release flash either **fixes U-10** or **tells us exactly where it still hangs**. No wasted test cycle.

---

## 🟢 Candidate fix B1 — Class B / U-10 (`src/elf_loader/src/elf.c`)

`LoadELFFromFileExecPS2RebootIOPWithPartition` unmounted PFS slots before `SifIopReset` (PR #464 "F4") but **never called `fileXioExit()`**. POPSLoader inits fileXio at boot (`src/main.cpp:434`), so the IOP-side fileXio RPC server is live at exit and **blocks `SifIopReset`** (ps2sdk #425) — the same root cause Layer A already handles at startup. F4's unmount alone did not release it on hardware. B1 adds `fileXioExit()` after the unmount, before the reset.

- **Source-verified** against `BETA-12-PLAY @ cc74a3e`.
- **Independently surfaced** by a Codex audit *and* this project's own prior analysis (two convergent findings).
- **Scope:** D-10 (HDD POPSTARTER + game) is unaffected — it returns earlier via `ExecuteHddBackedViaEmbeddedLoader`. Only non-HDD-backed reboot launches are touched: **BOOT.ELF (U-10), MC DKWDRV, generic**. `fileXioExit()` is internally guarded → safe no-op if fileXio wasn't inited.

**B1 verdict from the test:** if U-10 now boots into BOOT.ELF, B1 is confirmed → we extract it to a clean, flags-off PR for the real merge. If U-10 still freezes at YELLOW, fileXioExit was insufficient → next angle is `dev9Shutdown()` gated on HDD LOADSTATE.

---

## 🎨 Diagnostics (GS_BGCOLOUR, behind Makefile flags, ON in this build)

**Class A** — `_ps2sdk_memory_init` (`src/main.cpp`), `BOOTSTRAP_DEBUG_COLORS=1`. Unaffected by B1 (B1 is exit-path only), so this remains a pure diagnostic:

| Color | Stage |
|---|---|
| WHITE | entry | 
| CYAN | after SifExitRpc |
| GREEN | after first SifInitRpc(0) |
| YELLOW | after fileXioExit |
| ORANGE | after SifIopReset |
| BLUE | after SifIopSync |
| PURPLE | after final SifInitRpc(0) |

**Class B / U-10** — exit path (`elf.c`), `EXIT_DEBUG_COLORS=1`. B1's `fileXioExit()` now runs between GREEN and YELLOW:

| Color | Stage |
|---|---|
| WHITE | entered direct-launch |
| CYAN | SifLoadElf returned, ELF valid |
| GREEN | PFS unmount returned |
| YELLOW | **(B1 fileXioExit ran)** about to SifIopReset |
| ORANGE | SifIopReset returned |
| BLUE | SifIopSync returned |
| PURPLE | MC modules reloaded |
| RED | about to ExecPS2 |

---

## Tester protocol

1. Flash the latest **Rolling Release**.
2. **Class B / U-10:** launch POPSLoader **from HDD**, then Exit → **BOOT.ELF**.
   - ✅ If BOOT.ELF launches → **B1 fixed it**, report success.
   - ❌ If it freezes → photo the frozen color.
3. **Class A:** launch POPSLoader from **HOSDmenu** (and/or the bad **wLE**).
   - Photo the frozen color. **Crucial:** does it even show the FIRST color (WHITE)? If the screen is black with no color at all, the failure is *before* our code runs.
4. **Regression check:** confirm **MC DKWDRV** still launches (B1 touches its path; expected transparent).

---

## Held deliberately (NOT in this build — avoids competing/regressive changes)

- **A1** (Class A attach-parent-IOP): high-risk, rewrites boot for every source. Gated on the Class A photo.
- **B2** (route HDD BOOT.ELF through embedded loader): a *competing* fix for the same hang as B1 — shipping both blind would hide which one worked. Fallback only.
- **M1** (DKWDRV-HDD embedded-loader routing): real code/comment mismatch, but could regress a possibly-working path. Separate ticket, needs its own hardware test.

## Pre-merge checklist (when B1 is confirmed)

- [ ] Extract B1 to a clean PR off BETA-12-PLAY with `BOOTSTRAP_DEBUG_COLORS=0` and `EXIT_DEBUG_COLORS=0`
- [ ] Confirm MC DKWDRV regression test passed
- [ ] Then close this draft

Generated with Claude Code.