### PR TITLE
fix(DKWDRV): MC DKWDRV via embedded loader (no IOP reset) — needs HW test

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1257,8 +1257,27 @@ UI = {
             or string.find(lower_elf, "^pfs%d*:/") ~= nil
             or string.find(lower_elf, "^ata%d*:") ~= nil
             or string.find(lower_elf, "^apa%d*:") ~= nil
-          local dkwdrv_reboot_iop = is_hdd_path and 0 or 1
-          local rc = System.loadELF(elf_path, dkwdrv_reboot_iop, elf_path)
+          local rc
+          if is_hdd_path then
+            -- HDD DKWDRV: unchanged. reboot_iop=0 with argv0 -> existing
+            -- HDD-backed routing (its separate routing question is tracked
+            -- elsewhere; not touched here).
+            rc = System.loadELF(elf_path, 0, elf_path)
+          else
+            -- MC / non-HDD DKWDRV (Nuno 2026-05-31: "dkwdrv exit to memory
+            -- card hangs on pic"). Previously this used reboot_iop=1, which
+            -- routes to the in-process SifIopReset("",0) soft reset -- the
+            -- SAME mechanism that hung HDD->BOOT.ELF (fixed in PR #479).
+            -- Route MC DKWDRV through the proven embedded child loader
+            -- instead: the 2-arg loadELF (NO argv0) reaches
+            -- LoadELFFromFile -> is_dkwdrv_elf_path -> ExecuteViaEmbeddedLoader
+            -- (elf.c), which performs no in-process IOP reset. The C side
+            -- synthesizes argv0 (dkwdrv_argv[0] = resolved_path), so dropping
+            -- the Lua argv0 is required to hit that route, not the 3-arg
+            -- LoadELFFromFileExecPS2 direct-exec path. Mirrors the confirmed
+            -- BOOT.ELF fix (same embedded-loader, no-reset path).
+            rc = System.loadELF(elf_path, 0)
+          end
           if type(PLDR) == "table" and type(PLDR.RestoreWorkingDirectory) == "function" then
             pcall(PLDR.RestoreWorkingDirectory, previous_cwd)
           end


### PR DESCRIPTION
## DKWDRV → Memory Card hang ("hangs on pic")

Tester Nuno 2026-05-31: *"Sanity check on dkwdrv exit to memory card FAILED it hangs on pic."*

**Not a regression from #479** — that fix was scoped to `LaunchBootElf` (BOOT.ELF only); DKWDRV code was untouched. This is the **same-class root cause**: MC DKWDRV used `reboot_iop=1` → `LoadELFFromFileExecPS2RebootIOP` → `SifIopReset("", 0)`, the in-process soft reset that hung HDD→BOOT.ELF.

### Fix (source-grounded, mirrors the confirmed #479 fix)
Route MC DKWDRV through the **proven embedded child loader** — the same no-reset path that fixed BOOT.ELF and runs D-10.

- Change: `System.loadELF(elf_path, 0)` (2-arg, **no argv0**) → `LoadELFFromFile` → `is_dkwdrv_elf_path` → `ExecuteViaEmbeddedLoader` (`elf.c:494`). No in-process IOP reset; argv0 synthesized C-side.
- **Why drop the argv0:** the prior 3-arg call with `reboot=0` routes to `LoadELFFromFileExecPS2` (direct exec), *bypassing* the embedded loader (the "M1" routing trap). The 2-arg form is required to hit the embedded-loader DKWDRV case.

### Scope / safety
- **MC / non-HDD DKWDRV only.** HDD DKWDRV is byte-identical to before (`reboot=0` + argv0).
- Clean off `BETA-12-PLAY` (post-#479), no diagnostic flags — normal release-shaped build.

### Status
**DRAFT — needs hardware confirmation before merge.** Same gate the BOOT.ELF fix passed.

### Test (Nuno)
Launch DKWDRV from Memory Card (note your POPSLoader boot source: HDD vs USB/MC):
- Launches → ✅ fix confirmed, this merges.
- Still hangs → report; the embedded-loader path has its own (child-loader) diagnostics we can enable.

Generated with Claude Code.