### PR TITLE
fix+diag(DKWDRV): cold IOP reboot + CDVD modules for MC DKWDRV — needs HW test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ export HEADER
 RESET_IOP = 1
 #---------------------- enable DEBUGGING MODE ---------------------#
 DEBUG = 0
+#- DKWDRV launch diagnostic (GS_BGCOLOUR per-stage paint in the     #
+#- reboot-IOP exit path of elf.c). ON for the hardware-tester build #
+#- that investigates the DKWDRV->MC "hangs on pic" failure; release #
+#- builds MUST set this to 0.                                       #
+DKWDRV_DEBUG_COLORS = 1
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#
@@ -267,7 +272,7 @@ elfloader: src/elf_loader/libcustom-elf-loader.a
 src/elf_loader/libcustom-elf-loader.a: src/elf_loader
 	@$(MAKE) cleanbin
 	@$(MAKE) -C src/elf_loader/src/loader/ clean all
-	@$(MAKE) -C src/elf_loader clean all
+	@$(MAKE) -C src/elf_loader DKWDRV_DEBUG_COLORS=$(DKWDRV_DEBUG_COLORS) clean all
 
 $(EE_OBJS_DIR):
 	@mkdir -p $@

--- a/src/elf_loader/Makefile
+++ b/src/elf_loader/Makefile
@@ -10,6 +10,14 @@ BIN2C = $(PS2SDK)/bin/bin2c
 EE_OBJS = src/elf.o loader.o
 EE_LIB = libcustom-elf-loader.a
 
+# DKWDRV launch diagnostic (GS_BGCOLOUR per-stage paint in elf.c's
+# reboot-IOP exit path). Propagated from the parent Makefile so a single
+# toggle controls it. Release builds MUST have DKWDRV_DEBUG_COLORS=0.
+DKWDRV_DEBUG_COLORS ?= 0
+ifeq ($(DKWDRV_DEBUG_COLORS),1)
+EE_CFLAGS += -DDKWDRV_DEBUG_COLORS
+endif
+
 .PHONY: FORCE
 
 src/loader/bin/loader.elf:

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -642,6 +642,21 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		return ExecuteHddBackedViaEmbeddedLoader(resolved_path, partition, argc, argv);
 	}
 
+	/* DKWDRV launch diagnostic (DKWDRV_DEBUG_COLORS, Makefile toggle).
+	 * After the U-10 fix, the ONLY remaining caller of this reboot-IOP
+	 * path is MC DKWDRV (ui.lua OpenDKWDRV; POPSTARTER uses reboot=0 and
+	 * BOOT.ELF was moved to reboot=0). Nuno 2026-05-31 reported MC DKWDRV
+	 * "hangs on pic" -> black screen. Paint the GS background at each
+	 * stage so a tester photo shows exactly where it dies. No-op unless
+	 * DKWDRV_DEBUG_COLORS is defined. Colors match the child loader's
+	 * convention (loader.c) for consistency. */
+#ifdef DKWDRV_DEBUG_COLORS
+#define SET_DKW_BG(c) {*((volatile unsigned long int *)0x120000E0) = c;}
+#else
+#define SET_DKW_BG(c)
+#endif
+	SET_DKW_BG(0xFFFFFF); /* WHITE  - entered reboot-IOP exit path */
+
 	SifInitRpc(0);
 	SifLoadFileInit();
 	ret = SifLoadElf(resolved_path, &elfdata);
@@ -650,40 +665,55 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	if (ret != 0 || elfdata.epc == 0) {
 		return -2;
 	}
+	SET_DKW_BG(0xFFFF00); /* CYAN   - SifLoadElf OK, target in EE RAM */
 
-	/* Unmount all live PFS slots before SifIopReset, including the boot
-	 * partition's pfs1: that etc/boot.lua established for HDD-booted
-	 * POPSLoader. The diagnostic build (PR #463, Nuno 2026-05-26) showed
-	 * that for U-10 (BOOT.ELF from HDD-booted POPSLoader) the screen
-	 * stops painting at YELLOW = right after SifLoadElf, before ORANGE
-	 * = post-SifIopReset would paint. SifIopReset itself hangs because
-	 * fileXio is still holding the pfs1: RPC server thread on the IOP
-	 * side (ps2sdk #425). Unmounting all PFS slots here releases those
-	 * server-side resources so the reset completes.
-	 *
-	 * For HDD-backed targets the keep mask is set by Lua-side launch
-	 * prep (see PrepareForExternalELFLaunch / SetExecKeepPfsMask) so we
-	 * preserve any slot that the target needs across exec. For non-HDD
-	 * targets the keep mask defaults to 0 and we unmount every slot.
-	 * The previous `is_hdd_backed_exec_path` gate skipped the unmount
-	 * entirely for non-HDD targets like BOOT.ELF, which was the active
-	 * sabotage diagnosed in PR #463.
+	/* Unmount all live PFS slots before SifIopReset (see PR #463/#464 for
+	 * the BOOT.ELF history). For MC DKWDRV with no HDD session the keep
+	 * mask is 0 and there is typically nothing mounted, but this is kept
+	 * unconditional so a DKWDRV launch after HDD use also tears pfs down.
 	 */
 	unmount_pfs_slots_for_exec(build_exec_keep_mask(resolved_path));
+	SET_DKW_BG(0x00FF00); /* GREEN  - PFS unmount returned */
 
 	FlushCache(0);
-	while (!SifIopReset("", 0)) {
+	SET_DKW_BG(0x00FFFF); /* YELLOW - about to SifIopReset (cold reboot) */
+
+	/* H-B fix (grounded in the known-good build's src/system.cpp::IOP_Reset,
+	 * which the maintainer's working POPSLoader used for every reboot
+	 * launch): use a FULL cold IOP reboot with the UDNL/EELOADCNF image,
+	 * NOT the bare soft reset. POPSLoader had SifIopReset("", 0) here; the
+	 * working source had SifIopReset("rom0:UDNL rom0:EELOADCNF", 0). For a
+	 * PS1 disc loader like DKWDRV the bare soft reset leaves the IOP in a
+	 * state DKWDRV cannot drive (candidate cause of the "hangs on pic"
+	 * black screen). The working reset also tears down IOP heap + cmd
+	 * before re-init, mirrored below. */
+	while (!SifIopReset("rom0:UDNL rom0:EELOADCNF", 0)) {
 	}
 	while (!SifIopSync()) {
 	}
+	/* Mirror the working IOP_Reset() teardown: tear down IOP heap + cmd
+	 * before re-initializing RPC, exactly as src/system.cpp did. */
+	SifExitIopHeap();
+	SifLoadFileExit();
+	SifExitRpc();
+	SifExitCmd();
+	SET_DKW_BG(0x00A5FF); /* ORANGE - IOP cold reboot + sync + teardown done */
 
 	SifInitRpc(0);
 	SifLoadFileInit();
+	/* H-B fix: reload the FULL module set the working build's load_modules()
+	 * used, not just SIO2MAN/MCMAN/MCSERV. DKWDRV is a PS1 disc loader and
+	 * needs the CDVD modules; their absence is a strong candidate for a
+	 * disc-init hang on the DKWDRV splash ("on pic"). Order matches the
+	 * working source exactly (CDVDFSV before CDVDMAN). */
 	SifLoadModule("rom0:SIO2MAN", 0, NULL);
+	SifLoadModule("rom0:CDVDFSV", 0, NULL);
+	SifLoadModule("rom0:CDVDMAN", 0, NULL);
 	SifLoadModule("rom0:MCMAN", 0, NULL);
 	SifLoadModule("rom0:MCSERV", 0, NULL);
+	SifLoadModule("rom0:PADMAN", 0, NULL);
 	SifLoadFileExit();
-	SifExitRpc();
+	SET_DKW_BG(0x800080); /* PURPLE - modules reloaded */
 
 	FlushCache(0);
 	FlushCache(2);
@@ -696,6 +726,8 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 		final_argv = dkwdrv_argv;
 	}
 
+	SET_DKW_BG(0x0000FF); /* RED    - about to ExecPS2 the target */
 	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, final_argc, final_argv);
+#undef SET_DKW_BG
 	return -1;
 }


### PR DESCRIPTION
## DKWDRV → Memory Card "hangs on pic" — attempt 2 (grounded + diagnostic)

Attempt 1 (embedded-loader routing, closed #480) did **not** fix it on hardware (Nuno 2026-05-31: still black screen; BOOT.ELF still OK → no regression). This is a different, grounded hypothesis **plus** diagnostics so the next cycle is decisive either way.

### Why this is grounded, not a guess
There's **no DKWDRV code in the known-good reference build** (it predates DKWDRV), so we can't diff DKWDRV directly. But that build's *general reboot-launch sequence* (`src/system.cpp` `IOP_Reset` + `load_modules`) is the proven mechanism the maintainer's working POPSLoader used. Two concrete deltas from POPSLoader's current code:

1. **Cold IOP reboot** — `SifIopReset("rom0:UDNL rom0:EELOADCNF", 0)` (full reboot from ROM) instead of the bare `SifIopReset("", 0)` soft reset. A PS1 disc loader needs a real cold IOP; the soft reset is the leading "hangs on pic" suspect. Also mirrors the working teardown (`SifExitIopHeap`/`SifExitRpc`/`SifExitCmd`).
2. **Full module reload** — adds **CDVDFSV + CDVDMAN** (+ PADMAN), matching the working `load_modules()` order. **DKWDRV reads a PS1 disc**, so the missing CDVD modules are a strong disc-init-hang candidate. POPSLoader was only reloading SIO2MAN/MCMAN/MCSERV.

### Diagnostic (on in this build)
`DKWDRV_DEBUG_COLORS=1` paints the GS background per stage. If it still fails, the frozen color tells us exactly where:

| Color | Stage |
|---|---|
| WHITE | entered reboot path |
| CYAN | SifLoadElf OK (target in RAM) |
| GREEN | pfs unmount done |
| YELLOW | about to cold-reboot IOP |
| ORANGE | IOP reboot + sync + teardown done |
| PURPLE | modules reloaded |
| RED | about to ExecPS2 |

### Scope / safety
- **Only** `LoadELFFromFileExecPS2RebootIOPWithPartition` — after the U-10 fix, MC DKWDRV is the **sole** caller (POPSTARTER & BOOT.ELF are reboot=0). Zero regression surface for the working paths.
- DRAFT; release builds must set `DKWDRV_DEBUG_COLORS=0`. Needs hardware confirmation.

### Test (Nuno, when rested)
Launch DKWDRV from Memory Card.
- Boots → 🎉 fixed (then I strip diagnostics + open a clean PR).
- Still black screen → **note the color** — that pinpoints the exact failing call.
Also re-confirm HDD → Exit → BOOT.ELF still OK (same build).

Generated with Claude Code.