### PR TITLE
fix(DKWDRV): MC DKWDRV reboot_iop=0 — matches BETA-8 working path (needs HW test)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1238,27 +1238,26 @@ UI = {
           if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
             pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
           end
-          -- Pick the launch route based on where DKWDRV.ELF lives.
-          --   * mc / non-HDD: reboot_iop=1 -- direct path with full IOP
-          --     reset, reload SIO2MAN/MCMAN/MCSERV, ExecPS2 with
-          --     synthesized argv0. MC DKWDRV is confirmed working.
-          --   * HDD (hdd?:/ or pfs?:/): reboot_iop=0 -- non-reboot path.
-          --     This pairs with the DKWDRV special-case route in
-          --     src/elf_loader/src/elf.c LoadELFFromFileWithPartition,
-          --     which mirrors the BOOT.ELF V2 contract (d23520a) and
-          --     routes through ExecuteViaEmbeddedLoader so the child
-          --     loader's wipeUserMem + filexio-direct-load + SifExitRpc
-          --     + ExecPS2 sequence fires. PR #452 (V4) tried only the
-          --     Lua-side reboot_iop=0 without the C-side routing change,
-          --     which fell through to direct LoadExecPS2 and black-
-          --     screened. The complete V2-mimicry needs BOTH halves.
-          local lower_elf = string.lower(tostring(elf_path or ""))
-          local is_hdd_path = string.find(lower_elf, "^hdd%d:") ~= nil
-            or string.find(lower_elf, "^pfs%d*:/") ~= nil
-            or string.find(lower_elf, "^ata%d*:") ~= nil
-            or string.find(lower_elf, "^apa%d*:") ~= nil
-          local dkwdrv_reboot_iop = is_hdd_path and 0 or 1
-          local rc = System.loadELF(elf_path, dkwdrv_reboot_iop, elf_path)
+          -- DKWDRV launch: reboot_iop=0 for ALL DKWDRV (MC and HDD).
+          --
+          -- 2026-05-31 regression fix, grounded in BETA-8 (commit f396020),
+          -- which the maintainer confirmed had WORKING DKWDRV-from-MC. In
+          -- BETA-8 the launch was System.loadELF(path, 1, path), but BETA-8's
+          -- lua_loadELF binding IGNORED the reboot flag whenever an argv0 was
+          -- present and always called LoadELFFromFileExecPS2 -- a direct
+          -- SifInitRpc -> SifLoadElf -> ExecPS2 with NO SifIopReset. So DKWDRV
+          -- historically launched with no IOP reset at all.
+          --
+          -- The current binding instead HONORS reboot_iop: a 3-arg call with
+          -- reboot=1 routes to LoadELFFromFileExecPS2RebootIOP, whose
+          -- SifIopReset("",0) soft reset is what hangs DKWDRV-MC on hardware
+          -- ("hangs on pic", Nuno 2026-05-31). reboot=0 + argv0 routes to
+          -- LoadELFFromFileExecPS2 (luasystem.cpp), which is byte-identical to
+          -- BETA-8's proven no-reset path. So passing reboot_iop=0 restores
+          -- exactly the BETA-8 behavior.
+          --
+          -- HDD DKWDRV already used reboot_iop=0, so it is unchanged.
+          local rc = System.loadELF(elf_path, 0, elf_path)
           if type(PLDR) == "table" and type(PLDR.RestoreWorkingDirectory) == "function" then
             pcall(PLDR.RestoreWorkingDirectory, previous_cwd)
           end


### PR DESCRIPTION
## DKWDRV → Memory Card "hangs on pic" — grounded fix (attempt 3, the right one)

Found the regression the same way we cracked U-10: **diffed against a build that worked.** The maintainer recalled DKWDRV-MC working back in **BETA-7/8**, and BETA-8 (`f396020`) has the *identical* `mc0:/PS1_DKWDRV/DKWDRV.ELF` launch we have now.

### The regression (fact, not hypothesis)
**BETA-8 (working):** `System.loadELF(path, 1, path)` → but BETA-8's `lua_loadELF` binding **ignored the reboot flag when an argv0 was present** and always called `LoadELFFromFileExecPS2` → direct `SifInitRpc → SifLoadElf → ExecPS2`, **no `SifIopReset`**. DKWDRV launched with no IOP reset at all.

**Now:** the binding was changed to **honor** `reboot_iop`. The same 3-arg call with `reboot=1` routes to `LoadELFFromFileExecPS2RebootIOP` → `SifIopReset("",0)` → the soft reset that **hangs**. That routing change is the regression — DKWDRV's working path was never a reset path.

### The fix (one line)
Pass `reboot_iop=0` for MC DKWDRV. `reboot=0 + argv0` routes to `LoadELFFromFileExecPS2`, which is **byte-identical to BETA-8's proven no-reset path** (verified in current source). Restores exactly what BETA-8 did.

### Why the previous two attempts failed (both closed)
- **#480** (embedded-loader routing): wrong *no-reset* path — used `ExecuteViaEmbeddedLoader` (child loader), but BETA-8 used the *direct* `LoadELFFromFileExecPS2`.
- **#481** (cold reboot + CDVD modules): wrong *direction* — doubled down on resetting. BETA-8 proves DKWDRV wants **no reset at all**, not a better one.

### Scope / safety
- **MC / non-HDD DKWDRV:** `reboot=1 → 0` (the fix).
- **HDD DKWDRV:** already `reboot=0 + argv0` → same `LoadELFFromFileExecPS2` path — **unchanged**.
- **POPSTARTER / BOOT.ELF:** untouched.
- No diagnostic flags; normal release build. Draft pending hardware.

### Test (Nuno)
Launch DKWDRV from Memory Card.
- Boots → 🎉 confirmed; merge.
- Still hangs → report (this matches BETA-8 exactly, so a failure would mean something else changed in the C path since then — next step would be a direct BETA-8 elf.c diff).
Re-confirm HDD → Exit → BOOT.ELF still OK (same build).

Generated with Claude Code.