### PR TITLE
[DRAFT] DKWDRV on custom HDD path: route through partition-aware loader (+ loader stage-color diag)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ export HEADER
 RESET_IOP = 1
 #---------------------- enable DEBUGGING MODE ---------------------#
 DEBUG = 0
-#- Embedded child-loader stage-color diagnostic. The HDD-resident      #
-#- DKWDRV launch now routes through the child loader, so enable this   #
-#- for the tester build investigating the custom-HDD-path black screen #
-#- -- a frozen color then names the exact failing stage. Release       #
-#- builds MUST set this to 0.                                          #
-LOADER_ENABLE_DEBUG_COLORS = 1
+#- Embedded child-loader stage-color diagnostic (GS BGCOLOUR per stage).#
+#- 0 = release/off. Set to 1 only for a tester build that needs the     #
+#- child loader to paint its stage so a frozen color names the failing  #
+#- step (e.g. the custom-HDD-path DKWDRV investigation). MUST be 0 for   #
+#- any build that ships.                                                 #
+LOADER_ENABLE_DEBUG_COLORS = 0
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ export HEADER
 RESET_IOP = 1
 #---------------------- enable DEBUGGING MODE ---------------------#
 DEBUG = 0
+#- Embedded child-loader stage-color diagnostic. The HDD-resident      #
+#- DKWDRV launch now routes through the child loader, so enable this   #
+#- for the tester build investigating the custom-HDD-path black screen #
+#- -- a frozen color then names the exact failing stage. Release       #
+#- builds MUST set this to 0.                                          #
+LOADER_ENABLE_DEBUG_COLORS = 1
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#
@@ -266,7 +272,7 @@ elfloader: src/elf_loader/libcustom-elf-loader.a
 
 src/elf_loader/libcustom-elf-loader.a: src/elf_loader
 	@$(MAKE) cleanbin
-	@$(MAKE) -C src/elf_loader/src/loader/ clean all
+	@$(MAKE) -C src/elf_loader/src/loader/ LOADER_ENABLE_DEBUG_COLORS=$(LOADER_ENABLE_DEBUG_COLORS) clean all
 	@$(MAKE) -C src/elf_loader clean all
 
 $(EE_OBJS_DIR):

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1684,6 +1684,15 @@ function PLDR.PrepareForExternalELFLaunch(path, extra_keep_slots, keep_slots_aft
   return PrepareForExternalELFLaunch(path, extra_keep_slots, keep_slots_after_load)
 end
 
+-- Expose the HDD partition-context builder so the launcher UI can route
+-- HDD-resident targets (e.g. DKWDRV on a custom HDD path) through the same
+-- partition-aware path POPSTARTER games use. Returns (context, reason):
+-- context is an "hdd?:PART:" string for System.loadELFWithPartition, or nil
+-- (with a reason) when the path can't be mapped to a partition.
+function PLDR.BuildHddPartitionContext(path, recovery_candidates)
+  return BuildHddPartitionContext(path, recovery_candidates)
+end
+
 function PLDR.PrepareForColdExternalELFLaunch()
   return PrepareForColdExternalELFLaunch()
 end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1693,6 +1693,18 @@ function PLDR.BuildHddPartitionContext(path, recovery_candidates)
   return BuildHddPartitionContext(path, recovery_candidates)
 end
 
+-- Expose the partition-scoped exec-path normalizer (the SAME one POPSTARTER
+-- HDD custom paths use). Converts a composite/browsed HDD path like
+-- "hdd0:__common:pfs1:/APPS/PS1_DKWDRV/DKWDRV.ELF" -> a slot-less
+-- "pfs:/APPS/PS1_DKWDRV/DKWDRV.ELF". Paired with a "hdd?:PART:" context +
+-- PrepareForColdExternalELFLaunch, this lets the C side mount the partition
+-- FRESH on pfs0: by partition NAME -- so the launch never depends on which
+-- pfs slot the browser happened to use (works for __common, +OPL, etc.).
+-- Returns nil if the path carries no normalizable mounted/relpath form.
+function PLDR.BuildPartitionScopedExecPath(path)
+  return BuildPartitionScopedExecPath(path)
+end
+
 function PLDR.PrepareForColdExternalELFLaunch()
   return PrepareForColdExternalELFLaunch()
 end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1282,31 +1282,54 @@ UI = {
             end
             rc = System.loadELF(elf_path, 0, elf_path)
           elseif is_hdd_path then
-            -- Case (2): HDD-resident DKWDRV (custom HDD path). Route through
-            -- the SAME partition-aware machinery POPSTARTER games use:
-            -- loadELFWithPartition -> LoadELFFromFileExecPS2RebootIOPWith-
-            -- Partition -> ExecuteHddBackedViaEmbeddedLoader, which mounts the
-            -- partition and hands off via the BRAM child loader. The prior
-            -- code routed this through a plain direct ExecPS2 that cannot
-            -- mount an HDD partition, so a composite path like
-            -- hdd0:PART:pfs1:/.. black-screened (Nuno 2026-06-02).
-            -- nil-fallback: if the partition context can't be built, fall
-            -- back to the prior behavior (no worse than today).
-            if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
-              pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
-            end
+            -- Case (2): HDD-resident DKWDRV (custom HDD path, e.g.
+            -- hdd0:__common:pfs1:/APPS/PS1_DKWDRV/DKWDRV.ELF, or +OPL, etc).
+            -- Normalize the launch EXACTLY like POPSTARTER's HDD custom-path
+            -- flow (the proven-working reference -- D-10 passes hardware):
+            --   1. partition context  -> "hdd0:PART:"   (BuildHddPartitionContext)
+            --   2. slot-less exec path -> "pfs:/REL"     (BuildPartitionScopedExecPath)
+            --   3. COLD prep (PrepareForColdExternalELFLaunch) -> unmount ALL
+            --      pfs slots so the partition the browser left mounted/held
+            --      (on whatever pfsN:) is freed.
+            --   4. loadELFWithPartition(pfs:/REL, 1, hdd0:PART:, argv0) ->
+            --      ExecuteHddBackedViaEmbeddedLoader mounts PART FRESH on pfs0:
+            --      BY NAME and hands off via the BRAM child loader.
+            -- This is slot-agnostic on purpose: we never assume which pfsN:
+            -- the browser used, because cold prep frees everything and the C
+            -- side re-mounts by partition name. The earlier attempt passed the
+            -- raw composite path + kept the held mount, so the C-side fresh
+            -- pfs0: mount collided (pfs won't double-mount a partition) and
+            -- returned -1 before the child loader (Nuno HW 2026-06-04).
+            -- nil-fallback: if no partition context / normalized path can be
+            -- built, fall back to prior plain behavior (no worse than today).
             local partition_context = nil
             if type(PLDR) == "table" and type(PLDR.BuildHddPartitionContext) == "function" then
               local ok, ctx = pcall(PLDR.BuildHddPartitionContext, elf_path)
               if ok then partition_context = ctx end
             end
+            local exec_path_norm = nil
+            if type(PLDR) == "table" and type(PLDR.BuildPartitionScopedExecPath) == "function" then
+              local ok, p = pcall(PLDR.BuildPartitionScopedExecPath, elf_path)
+              if ok and type(p) == "string" and p ~= "" then exec_path_norm = p end
+            end
             if partition_context ~= nil and partition_context ~= ""
+              and exec_path_norm ~= nil
               and type(System.loadELFWithPartition) == "function" then
-              -- loadELFWithPartition requires reboot_iop ~= 0; it still
-              -- routes to ExecuteHddBackedViaEmbeddedLoader (child loader
-              -- owns IOP state), NOT the in-process SifIopReset block.
-              rc = System.loadELFWithPartition(elf_path, 1, partition_context, elf_path)
+              -- COLD prep: unmount all slots so PART is free to re-mount fresh.
+              if type(PLDR) == "table" and type(PLDR.PrepareForColdExternalELFLaunch) == "function" then
+                pcall(PLDR.PrepareForColdExternalELFLaunch)
+              elseif type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
+                pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
+              end
+              -- reboot_iop=1 selects the partition API; the hdd-backed early
+              -- return reaches ExecuteHddBackedViaEmbeddedLoader (child loader
+              -- owns IOP state), NOT the in-process SifIopReset block. argv0 =
+              -- original path (matches the MC DKWDRV convention, #485).
+              rc = System.loadELFWithPartition(exec_path_norm, 1, partition_context, elf_path)
             else
+              if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
+                pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
+              end
               rc = System.loadELF(elf_path, 0, elf_path)
             end
           else

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1258,34 +1258,65 @@ UI = {
           --      HDD partition needs to survive the prep.
           --
           --  (2) HDD-resident DKWDRV (hdd?:/ pfs?:/ ata?:/ apa?:/), ANY boot
-          --      source. UNCHANGED from the prior confirmed behavior:
-          --      reboot_iop=0 -> the LoadELFFromFileWithPartition DKWDRV
-          --      special case -> ExecuteViaEmbeddedLoader. The cold prep is
-          --      deliberately NOT applied (it would unmount the very
-          --      partition DKWDRV launches from). PrepareForExternalELFLaunch
-          --      keeps DKWDRV's own slot via CollectHddKeepSlots.
+          --      source. Routed through the partition-aware games path
+          --      (loadELFWithPartition -> ExecuteHddBackedViaEmbeddedLoader),
+          --      which mounts the partition + uses the BRAM child loader. The
+          --      prior plain loadELF route went to a direct ExecPS2 that
+          --      cannot mount an HDD partition (black screen on custom HDD
+          --      paths). Cold prep is NOT applied (it would unmount the very
+          --      partition DKWDRV launches from). nil-fallback to the prior
+          --      behavior if no partition context can be built.
           --
           --  (3) MC / non-HDD DKWDRV, POPSLoader NOT booted from HDD.
           --      UNCHANGED: reboot_iop=1, full IOP reset (safe -- no pfs1:
           --      is held when not HDD-booted). This is the confirmed-working
           --      MC DKWDRV path (QA 2026-05-26).
-          local dkwdrv_reboot_iop
+          local rc
           if hdd_loaded and not is_hdd_path then
-            -- Case (1): the regression being fixed.
+            -- Case (1): MC DKWDRV from HDD-booted POPSLoader (MERGED FIX,
+            -- PR #485). Cold prep clears the held boot pfs1:, reboot_iop=0.
             if type(PLDR) == "table" and type(PLDR.PrepareForColdExternalELFLaunch) == "function" then
               pcall(PLDR.PrepareForColdExternalELFLaunch)
             elseif type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
               pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
             end
-            dkwdrv_reboot_iop = 0
-          else
-            -- Cases (2) and (3): byte-for-byte the original behavior.
+            rc = System.loadELF(elf_path, 0, elf_path)
+          elseif is_hdd_path then
+            -- Case (2): HDD-resident DKWDRV (custom HDD path). Route through
+            -- the SAME partition-aware machinery POPSTARTER games use:
+            -- loadELFWithPartition -> LoadELFFromFileExecPS2RebootIOPWith-
+            -- Partition -> ExecuteHddBackedViaEmbeddedLoader, which mounts the
+            -- partition and hands off via the BRAM child loader. The prior
+            -- code routed this through a plain direct ExecPS2 that cannot
+            -- mount an HDD partition, so a composite path like
+            -- hdd0:PART:pfs1:/.. black-screened (Nuno 2026-06-02).
+            -- nil-fallback: if the partition context can't be built, fall
+            -- back to the prior behavior (no worse than today).
             if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
               pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
             end
-            dkwdrv_reboot_iop = is_hdd_path and 0 or 1
+            local partition_context = nil
+            if type(PLDR) == "table" and type(PLDR.BuildHddPartitionContext) == "function" then
+              local ok, ctx = pcall(PLDR.BuildHddPartitionContext, elf_path)
+              if ok then partition_context = ctx end
+            end
+            if partition_context ~= nil and partition_context ~= ""
+              and type(System.loadELFWithPartition) == "function" then
+              -- loadELFWithPartition requires reboot_iop ~= 0; it still
+              -- routes to ExecuteHddBackedViaEmbeddedLoader (child loader
+              -- owns IOP state), NOT the in-process SifIopReset block.
+              rc = System.loadELFWithPartition(elf_path, 1, partition_context, elf_path)
+            else
+              rc = System.loadELF(elf_path, 0, elf_path)
+            end
+          else
+            -- Case (3): MC / non-HDD DKWDRV, POPSLoader NOT booted from HDD.
+            -- UNCHANGED, confirmed-working (QA 2026-05-26): reboot_iop=1.
+            if type(PLDR) == "table" and type(PLDR.PrepareForExternalELFLaunch) == "function" then
+              pcall(PLDR.PrepareForExternalELFLaunch, elf_path)
+            end
+            rc = System.loadELF(elf_path, 1, elf_path)
           end
-          local rc = System.loadELF(elf_path, dkwdrv_reboot_iop, elf_path)
           if type(PLDR) == "table" and type(PLDR.RestoreWorkingDirectory) == "function" then
             pcall(PLDR.RestoreWorkingDirectory, previous_cwd)
           end

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -183,6 +183,29 @@ static int extract_exec_pfs_slot(const char *path) {
 	return -1;
 }
 
+/* For a composite HDD exec path "hddN:PART:pfsM:/rel", return the pfs slot M
+ * that POPSLoader's file browser already mounted PART on (0-3), or -1 if the
+ * path carries no embedded pfs prefix. Mirrors the colon navigation in
+ * extract_exec_relpath, then reuses extract_exec_pfs_slot on the "pfsM:"
+ * substring. Used to reuse a live mount when a fresh mount collides (pfs
+ * refuses to mount the same partition on two slots). */
+static int extract_composite_pfs_slot(const char *path) {
+	const char *partition_end;
+	const char *fs_prefix;
+	if (path == NULL || strncmp(path, "hdd", 3) != 0) {
+		return -1;
+	}
+	partition_end = strchr(path + 5, ':');
+	if (partition_end == NULL) {
+		return -1;
+	}
+	fs_prefix = partition_end + 1;
+	if (strncmp(fs_prefix, "pfs", 3) != 0) {
+		return -1;
+	}
+	return extract_exec_pfs_slot(fs_prefix);
+}
+
 static int mount_hdd_exec_partition(const char *partition, int slot) {
 	char mount_name[6] = "pfs0:";
 
@@ -258,20 +281,41 @@ static int build_hdd_embedded_loader_target_from_partition(const char *resolved_
 
 	relpath = extract_exec_relpath(resolved_path);
 	if (relpath == NULL) {
-		return -1;
+		return -10; /* diag: relpath parse failed */
 	}
 
-	if (mount_hdd_exec_partition(partition, 0) != 0) {
-		return -1;
+	if (mount_hdd_exec_partition(partition, 0) == 0) {
+		/* Fresh mount on pfs0: succeeded -- the HDD-game case (D-10): the
+		 * target partition was not already mounted. Behavior here is
+		 * byte-identical to the prior happy path. */
+		snprintf(load_path, load_path_size, "pfs0:/%s", relpath);
+		if (!can_open_exec_path(load_path)) {
+			return -11; /* diag: mounted pfs0: but file not openable */
+		}
+		*keep_mask_out = 0x01;
+		return 0;
 	}
 
-	snprintf(load_path, load_path_size, "pfs0:/%s", relpath);
-	if (!can_open_exec_path(load_path)) {
-		return -1;
+	/* Fresh mount failed. The partition is almost certainly ALREADY mounted
+	 * on another pfs slot -- the DKWDRV-on-HDD case: POPSLoader's file
+	 * browser mounted PART on pfsM: to read DKWDRV.ELF and held it, and pfs
+	 * refuses to mount the same partition twice. The composite source path
+	 * carries that live pfsM: prefix (e.g. hdd0:__common:pfs1:/...), so reuse
+	 * the existing mount instead of failing. The child loader extracts the
+	 * pfs prefix from load_path dynamically (loader.c) and umounts exactly
+	 * that slot after SifLoadElf, so any slot 0-3 is a valid contract. */
+	{
+		int existing_slot = extract_composite_pfs_slot(resolved_path);
+		if (existing_slot < 0 || existing_slot > 3) {
+			return -13; /* diag: mount failed and no reusable pfs slot in path */
+		}
+		snprintf(load_path, load_path_size, "pfs%d:/%s", existing_slot, relpath);
+		if (!can_open_exec_path(load_path)) {
+			return -12; /* diag: reused live pfs slot but file not openable */
+		}
+		*keep_mask_out = (1U << existing_slot);
+		return 0;
 	}
-
-	*keep_mask_out = 0x01;
-	return 0;
 }
 
 static int build_hdd_embedded_loader_target_from_hdd_path(const char *source_path, char *load_path, size_t load_path_size, unsigned int *keep_mask_out) {
@@ -349,8 +393,9 @@ static int ExecuteHddBackedViaEmbeddedLoader(const char *resolved_path, const ch
 		}
 	}
 
-	if (build_hdd_embedded_loader_target(resolved_path, partition_context, load_path, sizeof(load_path), &required_keep_mask) != 0) {
-		return -1;
+	ret = build_hdd_embedded_loader_target(resolved_path, partition_context, load_path, sizeof(load_path), &required_keep_mask);
+	if (ret != 0) {
+		return ret; /* propagate distinct diag code (-10..-13) instead of -1 */
 	}
 
 	previous_keep_mask = GetExecKeepPfsMask();
@@ -635,7 +680,7 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	}
 
 	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {
-		return -1;
+		return -20; /* diag: resolve_exec_path failed (non-HDD dispatch) */
 	}
 
 	if (is_hdd_backed_exec_path(resolved_path) || is_hdd_backed_exec_path(partition)) {
@@ -697,5 +742,5 @@ int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const cha
 	}
 
 	ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, final_argc, final_argv);
-	return -1;
+	return -21; /* diag: ExecPS2 returned on non-HDD direct path (should not happen) */
 }

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -183,29 +183,6 @@ static int extract_exec_pfs_slot(const char *path) {
 	return -1;
 }
 
-/* For a composite HDD exec path "hddN:PART:pfsM:/rel", return the pfs slot M
- * that POPSLoader's file browser already mounted PART on (0-3), or -1 if the
- * path carries no embedded pfs prefix. Mirrors the colon navigation in
- * extract_exec_relpath, then reuses extract_exec_pfs_slot on the "pfsM:"
- * substring. Used to reuse a live mount when a fresh mount collides (pfs
- * refuses to mount the same partition on two slots). */
-static int extract_composite_pfs_slot(const char *path) {
-	const char *partition_end;
-	const char *fs_prefix;
-	if (path == NULL || strncmp(path, "hdd", 3) != 0) {
-		return -1;
-	}
-	partition_end = strchr(path + 5, ':');
-	if (partition_end == NULL) {
-		return -1;
-	}
-	fs_prefix = partition_end + 1;
-	if (strncmp(fs_prefix, "pfs", 3) != 0) {
-		return -1;
-	}
-	return extract_exec_pfs_slot(fs_prefix);
-}
-
 static int mount_hdd_exec_partition(const char *partition, int slot) {
 	char mount_name[6] = "pfs0:";
 
@@ -284,38 +261,23 @@ static int build_hdd_embedded_loader_target_from_partition(const char *resolved_
 		return -10; /* diag: relpath parse failed */
 	}
 
-	if (mount_hdd_exec_partition(partition, 0) == 0) {
-		/* Fresh mount on pfs0: succeeded -- the HDD-game case (D-10): the
-		 * target partition was not already mounted. Behavior here is
-		 * byte-identical to the prior happy path. */
-		snprintf(load_path, load_path_size, "pfs0:/%s", relpath);
-		if (!can_open_exec_path(load_path)) {
-			return -11; /* diag: mounted pfs0: but file not openable */
-		}
-		*keep_mask_out = 0x01;
-		return 0;
+	/* Mount the partition FRESH on pfs0:, BY NAME. The Lua launch prep does
+	 * a cold external launch (PrepareForColdExternalELFLaunch) before this,
+	 * matching POPSTARTER's HDD custom-path flow: it unmounts ALL pfs slots,
+	 * so the partition is free even if the file browser had left it mounted
+	 * on some other pfsN:. Re-mounting by name is what makes the launch
+	 * slot-agnostic (works for __common, +OPL, etc). */
+	if (mount_hdd_exec_partition(partition, 0) != 0) {
+		return -13; /* diag: fresh pfs0: mount failed (partition busy or absent) */
 	}
 
-	/* Fresh mount failed. The partition is almost certainly ALREADY mounted
-	 * on another pfs slot -- the DKWDRV-on-HDD case: POPSLoader's file
-	 * browser mounted PART on pfsM: to read DKWDRV.ELF and held it, and pfs
-	 * refuses to mount the same partition twice. The composite source path
-	 * carries that live pfsM: prefix (e.g. hdd0:__common:pfs1:/...), so reuse
-	 * the existing mount instead of failing. The child loader extracts the
-	 * pfs prefix from load_path dynamically (loader.c) and umounts exactly
-	 * that slot after SifLoadElf, so any slot 0-3 is a valid contract. */
-	{
-		int existing_slot = extract_composite_pfs_slot(resolved_path);
-		if (existing_slot < 0 || existing_slot > 3) {
-			return -13; /* diag: mount failed and no reusable pfs slot in path */
-		}
-		snprintf(load_path, load_path_size, "pfs%d:/%s", existing_slot, relpath);
-		if (!can_open_exec_path(load_path)) {
-			return -12; /* diag: reused live pfs slot but file not openable */
-		}
-		*keep_mask_out = (1U << existing_slot);
-		return 0;
+	snprintf(load_path, load_path_size, "pfs0:/%s", relpath);
+	if (!can_open_exec_path(load_path)) {
+		return -11; /* diag: mounted pfs0: but file not openable */
 	}
+
+	*keep_mask_out = 0x01;
+	return 0;
 }
 
 static int build_hdd_embedded_loader_target_from_hdd_path(const char *source_path, char *load_path, size_t load_path_size, unsigned int *keep_mask_out) {

--- a/src/elf_loader/src/loader/src/loader.c
+++ b/src/elf_loader/src/loader/src/loader.c
@@ -22,9 +22,14 @@
 #include <fileXio_rpc.h>
 
 #ifdef LOADER_ENABLE_DEBUG_COLORS
-#include <debug.h>
+// The GS BGCOLOUR write (raw register, no library) is the diagnostic that survives a
+// black screen: it paints the whole frame a stage color even when nothing else renders.
+// scr_printf text output is deliberately NOT wired up here -- it needs -ldebug plus
+// init_scr() (a GS framebuffer the loader never sets up at this stage), so it both fails
+// to link and would only target a text console we may not have on a black screen. Keep
+// DPRINTF a no-op so enabling the stage colors stays link-clean.
 #define SET_GS_BGCOLOUR(colour) {*((volatile unsigned long int *)0x120000E0) = colour;}
-#define DPRINTF(x...) scr_printf(x)
+#define DPRINTF(x...) do {} while (0)
 #else
 #define SET_GS_BGCOLOUR(colour)
 #define DPRINTF(x...) do {} while (0)


### PR DESCRIPTION
## What & why

DKWDRV launched from a **custom HDD path** (e.g. `hdd0:__common:pfs1:/APPS/PS1_DKWDRV/DKWDRV.ELF`, or `+OPL`, any partition) failed. This is the **M1 routing mismatch**, separate from the merged MC DKWDRV fix (#485).

### How it was diagnosed (Nuno HW, 2026-06-04)
First iteration moved it off the old "direct-exec black screen" — POPSLoader's UI gracefully showed **"DKWDRV failed to launch, return code: -1"** with **no GS color**, i.e. the failure was in the **parent**, before the embedded child loader. MC DKWDRV still launched fine (no regression). Distinct return codes + that observation localized it precisely.

### Root cause
`OpenDKWDRV` passed the **raw composite** path and **kept the browser's held mount**. The C side then tried to mount the partition **fresh on `pfs0:`**, but the file browser already had it mounted on `pfs1:` — and **PFS won't mount the same partition on two slots** → `-1` before hand-off.

### Why POPSTARTER custom HDD paths *don't* hit this (the fix)
POPSTARTER uses the same C machinery but **normalizes in Lua first**, and that's the proven-working model now applied to DKWDRV:
1. `BuildPartitionScopedExecPath` → **slot-less** `pfs:/REL` (drops the browser's `pfsN:`)
2. `BuildHddPartitionContext` → `hdd0:PART:`
3. `PrepareForColdExternalELFLaunch` → **unmount all** pfs slots (frees the held mount)
4. `loadELFWithPartition("pfs:/REL", 1, "hdd0:PART:")` → C side mounts `PART` **fresh on `pfs0:` by name** → child loader

This is **slot/partition-agnostic by construction** — `__common`, `+OPL`, any slot all behave identically, because cold prep frees everything and the mount is by partition *name*.

### Changes
- **bin/POPSLDR/system.lua** — expose `PLDR.BuildPartitionScopedExecPath` (the slot-less normalizer POPSTARTER uses).
- **bin/POPSLDR/ui.lua** `OpenDKWDRV` case (2) — normalize → cold prep → `loadELFWithPartition`; nil-fallback to prior plain `loadELF` if normalization fails.
- **src/elf_loader/src/elf.c** — **distinct diagnostic return codes** for the HDD-backed build path (`-10` relpath, `-11` file-not-openable on pfs0:, `-13` fresh mount failed, `-20/-21` dispatch). The modal prints them, so any remaining failure names its exact step. (An interim reuse-the-held-mount heuristic was removed — cold-prep + fresh-mount-by-name is the correct POPSTARTER contract.)
- **src/elf_loader/src/loader/src/loader.c** + **Makefile** — `LOADER_ENABLE_DEBUG_COLORS=1` for this tester build, made link-clean (GS stage colors only, no `scr_printf`/`-ldebug`).

### Scope / safety
- Only `OpenDKWDRV`'s `is_hdd_path` branch changes. **Cases (1) MC+HDD-boot and (3) MC+non-HDD-boot are byte-identical to merged #485.** POPSTARTER games (D-10) untouched.
- Preserves USB/MMCE/SMB/MX4SIO + non-HDD POPSTARTER flows, mx4sio `mass:/`, HDD-install→mc0 fallback, mmceman lazy-load, D-10/D-14/D-15.

### Status
**Draft — needs hardware confirmation.** Release builds MUST set `LOADER_ENABLE_DEBUG_COLORS=0` before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)