### PR TITLE
fix(launch-args): make -page/-mode navigate on hardware + harden parsing + docs

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -1989,7 +1989,19 @@ local function NormalizeLaunchPage(value)
   if type(value) ~= "string" or value == "" then
     return nil
   end
+  -- Defensive normalization. CNF-sourced values can arrive decorated:
+  -- OSDMenu strips only \r\n from an arg line (trailing spaces survive),
+  -- users sometimes quote values, and two flags written on ONE arg line
+  -- arrive as a single argv token ("hdd -debug"). Strip quotes/whitespace
+  -- and keep only the first word so all of those still resolve. No
+  -- legitimate page value contains a space, so this is lossless.
   local key = string.lower(value)
+  key = string.gsub(key, '^[%s"\']+', "")
+  key = string.gsub(key, '[%s"\']+$', "")
+  key = string.match(key, "^([^%s]+)") or ""
+  if key == "" then
+    return nil
+  end
   if key == "hdd" or key == "ata" or key == "pfs" or key == "apa" then
     return "HDD"
   end
@@ -2030,9 +2042,23 @@ if type(System) == "table" and type(System.getLaunchArgs) == "function" then
     end
     local game_raw = tostring(args.game or "")
     if game_raw ~= "" then
-      PLDR.LAUNCH_ARGS.game = game_raw
+      -- Trim surrounding whitespace/quotes only; game selectors contain
+      -- internal spaces ("Bomberman - Party Edition") that must survive.
+      game_raw = string.gsub(game_raw, '^[%s"\']+', "")
+      game_raw = string.gsub(game_raw, '[%s"\']+$', "")
+      if game_raw ~= "" then
+        PLDR.LAUNCH_ARGS.game = game_raw
+      end
     end
     PLDR.LAUNCH_ARGS.debug = (args.debug == true)
+    -- Recover a -debug that was written on the same CNF arg line as the
+    -- page flag ("-page=hdd -debug" arrives as ONE argv token; the C parse
+    -- captures "hdd -debug" into page and the standalone -debug match
+    -- never fires). NormalizeLaunchPage above already keeps only the
+    -- first word of the page value.
+    if not PLDR.LAUNCH_ARGS.debug and string.find(string.lower(page_raw), "%-debug") ~= nil then
+      PLDR.LAUNCH_ARGS.debug = true
+    end
   end
 end
 
@@ -2210,11 +2236,25 @@ if type(PLDR) == "table" and type(PLDR.LAUNCH_ARGS) == "table"
   }
   local opt = page_to_opt[PLDR.LAUNCH_ARGS.page]
   if opt ~= nil and type(UI.MainMenu) == "table" then
+    -- UI.MainMenu carries a __newindex write-guard (ui.lua tail) that
+    -- SILENTLY DROPS any OPT assignment unless Carousel.allowOptWrite is
+    -- raised -- the carousel's own animation handler is the only code that
+    -- raises it. Without raising the same gate here, this whole block is a
+    -- no-op: the OPT write is swallowed, and the Carousel index writes
+    -- below get overwritten by the first MainMenu.Play(), which re-syncs
+    -- the carousel FROM OPT (still 1) on every non-animating frame. That
+    -- double clobber is exactly why -page/-mode had no visible effect on
+    -- hardware (CosmicScale, 2026-06-09).
+    local carousel = type(UI.MainMenu.Carousel) == "table" and UI.MainMenu.Carousel or nil
+    if carousel ~= nil then
+      carousel.allowOptWrite = true
+    end
     UI.MainMenu.OPT = opt
-    if type(UI.MainMenu.Carousel) == "table" then
-      UI.MainMenu.Carousel.currentIndex = opt
-      UI.MainMenu.Carousel.targetIndex = opt
-      UI.MainMenu.Carousel.scrollPos = opt + 0.0
+    if carousel ~= nil then
+      carousel.allowOptWrite = false
+      carousel.currentIndex = opt
+      carousel.targetIndex = opt
+      carousel.scrollPos = opt + 0.0
     end
   end
 end
@@ -5216,7 +5256,21 @@ function PLDR.AutoLaunchFromLaunchArgs()
     return false
   end
 
+  -- UI.CURSCENE carries a __newindex write-guard (ui.lua tail) that drops
+  -- the assignment unless UI.Transition.allowSceneWrite is raised -- and it
+  -- stays false until after WelcomeDraw. Raise it for this one write so the
+  -- scene context is real (BlockLaunchFailure/back-nav read it after a
+  -- failed auto-launch). The launch itself never depended on this: the
+  -- scene is passed to RunPOPStarterGame as an argument.
+  local scene_gate = type(UI.Transition) == "table" and UI.Transition or nil
+  local prev_scene_write = scene_gate ~= nil and scene_gate.allowSceneWrite or nil
+  if scene_gate ~= nil then
+    scene_gate.allowSceneWrite = true
+  end
   UI.CURSCENE = scene
+  if scene_gate ~= nil then
+    scene_gate.allowSceneWrite = prev_scene_write
+  end
   if UI.LASTSCENE == nil then
     UI.LASTSCENE = scene
   end
@@ -5256,8 +5310,12 @@ end
 
 PLDR.LoadSettingsNonFatal()
 PLDR.AutoInitStartupBackends()
-PLDR.SurfaceLaunchArgsDebug()
+-- Auto-launch BEFORE surfacing the debug toast: Notif_queue keeps only the
+-- 2 newest toasts, so queueing the debug toast last guarantees it survives
+-- an auto-launch failure toast instead of being evicted by it. (On
+-- auto-launch success control never returns, so the order is moot.)
 PLDR.AutoLaunchFromLaunchArgs()
+PLDR.SurfaceLaunchArgsDebug()
 
 ---MAIN PROGRAM BEHAVIOUR BEGINS
 local initial_scene = UI.SCENES.MMAIN

--- a/docs/LAUNCH_ARGUMENTS.md
+++ b/docs/LAUNCH_ARGUMENTS.md
@@ -1,0 +1,153 @@
+# POPSLoader launch arguments
+
+POPSLoader accepts NHDDL-style launch arguments so a front-end (OSDMenu /
+HOSDMenu, wLaunchELF, a forwarder, etc.) can boot it straight to a device
+page or auto-launch a specific game. Arguments are parsed in
+`src/main.cpp` `parseLaunchArgs()`, exposed to Lua via
+`System.getLaunchArgs()`, and acted on in `bin/POPSLDR/system.lua`.
+
+## The arguments
+
+| Argument | Effect |
+| --- | --- |
+| `-page=<device>` | Open the main-menu carousel already centered on that device page. |
+| `-mode=<device>` | NHDDL-compatible **alias** for `-page=` (identical behavior, same values). |
+| `-game=<selector>` | Auto-launch a game. **Must be combined with `-page=`.** |
+| `-debug` | Show an on-screen toast with the parsed args + resolved boot context. |
+
+Each argument is a separate token, exactly like a command line:
+
+```
+mc0:/PS1_POPSLOADER/POPSLOADER.ELF -page=hdd
+mc0:/PS1_POPSLOADER/POPSLOADER.ELF -mode=ata
+mc0:/PS1_POPSLOADER/POPSLOADER.ELF -page=usb -game=Tekken 3
+mc0:/PS1_POPSLOADER/POPSLOADER.ELF -page=hdd -debug
+```
+
+The first token is always POPSLoader's own ELF path; the launcher supplies
+it as `argv[0]`. Pass each flag as its **own** argument entry — do not join
+them into one quoted string (see *Front-end notes* below).
+
+## Accepted `-page` / `-mode` values
+
+Values are case-insensitive. Aliases in parentheses resolve to the same
+page:
+
+| Page | Accepted values |
+| --- | --- |
+| **HDD** (PFS) | `hdd`, `ata`, `pfs`, `apa` |
+| **USB** | `usb`, `mass` |
+| **MC** | `mc`, `memcard` |
+| **MMCE** | `mmce` |
+| **MX4SIO** | `mx4sio`, `mx4`, `sdc` |
+| **SMB** | `smb` |
+| **BDMA** (HDD exFAT) | `bdma` *(accepted but not navigable — see below)* |
+
+`-mode=ata` is provided specifically for NHDDL parity (`-mode=ata` is how
+NHDDL selects the HDD/ATA path).
+
+## What each argument actually does
+
+### `-page=` / `-mode=` (carousel navigation)
+Opens the main menu with the carousel **pre-positioned** on the requested
+page. It does **not** auto-enter that page's game list — you still press
+**X** to enter, exactly as if you'd scrolled there yourself.
+
+Navigable pages: **MMCE, MX4SIO, HDD (PFS), USB, SMB.** The HDD value
+targets the implemented **PFS** page. `bdma` (HDD exFAT) and the i.Link
+page are intentionally **not** auto-navigated (they aren't wired for it),
+so `-page=bdma` is accepted but has no visible effect. An unrecognized
+value is ignored and the carousel starts on its default page (MMCE).
+
+### `-game=` (auto-launch)
+Boots straight into launching a game. Requires **both** `-page=` and
+`-game=`. Auto-launch is wired for these pages:
+
+| Page | `-game=` selector format |
+| --- | --- |
+| HDD | game title as listed in POPSLoader (e.g. `Bomberman - Party Edition`) |
+| USB | `<FILE>` relative to `mass:/POPS` |
+| MX4SIO | `<FILE>` relative to `mx4sio:/POPS` |
+| MMCE | `<FILE>` relative to `mmce0:/POPS` |
+
+If auto-launch fails (game not found, etc.) POPSLoader does **not** hang —
+it falls back to the normal welcome screen + main menu and shows an error
+toast describing what happened. `-page=smb -game=...` will navigate to SMB
+but will **not** auto-launch (SMB auto-launch isn't wired); it shows an
+"Auto-launch page not supported" toast.
+
+### `-debug`
+Queues an on-screen info toast on the first main-menu frame listing:
+
+```
+[debug] boot context
+kind: <HDD|USB|MC|MMCE|MX4SIO|SMB|HOST>
+boot_path: <argv[0]>
+sidecar: <settings sidecar path>
+settings: <resolved settings path>
+args.page: <normalized page or <nil>>
+args.game: <selector or <nil>>
+```
+
+Use this to confirm the args actually reached POPSLoader. If the toast
+shows `args.page: HDD` you know parsing works and any remaining problem is
+downstream; if the toast never appears, the args didn't reach
+`parseLaunchArgs()` at all (front-end delivery or an outdated build).
+
+## Front-end notes (important)
+
+- **One flag per argument entry.** Front-ends that pass each argument as a
+  distinct `argv` token (OSDMenu's `arg_OSDSYS_ITEM_<n>` lines, NHDDL,
+  OPL) work directly. Writing two flags on one line — e.g.
+  `-page=hdd -debug` as a single value — historically arrived as one token
+  `"-page=hdd -debug"`. POPSLoader now defends against this (it keeps only
+  the first word of a page value and still detects a trailing `-debug`),
+  but the clean, portable form is two separate argument entries.
+- **Whitespace / quotes are tolerated.** Leading/trailing spaces and one
+  pair of surrounding quotes are stripped from each token (some CNF parsers
+  leave a trailing space on the line). Internal spaces in `-game=` values
+  are preserved, so titles like `Bomberman - Party Edition` are fine.
+- **OSDMenu Browser-icon (PATINFO) launches** don't read
+  `arg_OSDSYS_ITEM_*`; for those, arguments come from the OSDMenu
+  `SYSTEM.CNF` `arg` extensions in the partition attribute area.
+- **Build requirement.** These arguments only exist in builds from
+  `BETA-12-PLAY` (feature added 2026-05-25). All Lua runs from assets
+  embedded in the ELF at build time, so updating on-card `.lua` files has
+  **no effect** — you must run a current `POPSLOADER.ELF`. Verify with
+  `-debug`.
+
+## Example OSDMenu `OSDMENU.CNF` entry
+
+```
+name_OSDSYS_ITEM_1 = POPSLoader (HDD)
+path1_OSDSYS_ITEM_1 = mc0:/PS1_POPSLOADER/POPSLOADER.ELF
+arg_OSDSYS_ITEM_1 = -page=hdd
+```
+
+Add games or debug as additional, separate `arg_OSDSYS_ITEM_1` lines:
+
+```
+arg_OSDSYS_ITEM_1 = -page=hdd
+arg_OSDSYS_ITEM_1 = -game=Bomberman - Party Edition
+arg_OSDSYS_ITEM_1 = -debug
+```
+
+## Source map (for maintainers)
+
+| Concern | Location |
+| --- | --- |
+| Token parse + trim | `src/main.cpp` `parseLaunchArgs()`, `trimLaunchArgToken()` |
+| Lua binding | `src/luasystem.cpp` `lua_getLaunchArgs()` → `System.getLaunchArgs()` |
+| Normalize + populate | `bin/POPSLDR/system.lua` `NormalizeLaunchPage()` + `PLDR.LAUNCH_ARGS` |
+| Carousel navigation | `bin/POPSLDR/system.lua` page-jump block (raises `Carousel.allowOptWrite`) |
+| Auto-launch | `bin/POPSLDR/system.lua` `PLDR.AutoLaunchFromLaunchArgs()` |
+| Debug toast | `bin/POPSLDR/system.lua` `PLDR.SurfaceLaunchArgsDebug()` |
+
+### Why navigation needs `allowOptWrite`
+`UI.MainMenu` installs a `__newindex` write-guard that silently drops any
+`OPT` assignment unless `Carousel.allowOptWrite` is raised, and
+`MainMenu.Play()` re-syncs the carousel **from** `OPT` every non-animating
+frame. The page-jump block therefore raises that gate around its `OPT`
+write (and sets the carousel indices to match). Without it the navigation
+is a silent no-op — that was the 2026-06 "launch args do nothing on
+hardware" bug.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,8 +167,41 @@ static const char * detectBootDeviceHintFromArgv0(const char * argv0)
     return "";
 }
 
+/* Strip leading/trailing whitespace and one pair of surrounding quotes
+ * from a launch-arg token, in place. CNF-sourced argv entries arrive
+ * decorated in the wild: OSDMenu's parser strips only \r\n from an arg
+ * line (trailing spaces survive into the token), and users quote values.
+ * Internal spaces are deliberately preserved -- -game= selectors contain
+ * them ("Bomberman - Party Edition"). */
+static void trimLaunchArgToken(char * s)
+{
+    size_t len = strlen(s);
+    size_t start = 0;
+    while (len > 0 && (s[len - 1] == ' ' || s[len - 1] == '\t' ||
+                       s[len - 1] == '\r' || s[len - 1] == '\n')) {
+        s[--len] = '\0';
+    }
+    while (s[start] == ' ' || s[start] == '\t') {
+        start++;
+    }
+    if (len >= start + 2 && (s[start] == '"' || s[start] == '\'') &&
+        s[len - 1] == s[start]) {
+        s[len - 1] = '\0';
+        start++;
+        len--;
+    }
+    if (start > 0) {
+        memmove(s, s + start, len - start + 1);
+    }
+}
+
 static void parseLaunchArgs(int argc, char ** argv)
 {
+    /* Scratch large enough for any token we care about (-game= values cap
+     * at sizeof(launch_arg_game)). Longer tokens are truncated by snprintf,
+     * matching the capture buffers' own limits. */
+    char token[300];
+
     if (argc <= 1 || argv == NULL) {
         return;
     }
@@ -177,14 +210,24 @@ static void parseLaunchArgs(int argc, char ** argv)
         if (a == NULL || a[0] == '\0') {
             continue;
         }
-        if (strncmp(a, "-page=", 6) == 0) {
-            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", a + 6);
-        } else if (strncmp(a, "-mode=", 6) == 0) {
+        /* Work on a trimmed copy: argv strings live in the parent
+         * launcher's memory and must not be modified in place. */
+        snprintf(token, sizeof(token), "%s", a);
+        trimLaunchArgToken(token);
+        if (token[0] == '\0') {
+            continue;
+        }
+        if (strncmp(token, "-page=", 6) == 0) {
+            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", token + 6);
+            trimLaunchArgToken(launch_arg_page);
+        } else if (strncmp(token, "-mode=", 6) == 0) {
             /* NHDDL-compat alias: -mode=ata maps to our -page=ata/hdd flow */
-            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", a + 6);
-        } else if (strncmp(a, "-game=", 6) == 0) {
-            snprintf(launch_arg_game, sizeof(launch_arg_game), "%s", a + 6);
-        } else if (strcmp(a, "-debug") == 0) {
+            snprintf(launch_arg_page, sizeof(launch_arg_page), "%s", token + 6);
+            trimLaunchArgToken(launch_arg_page);
+        } else if (strncmp(token, "-game=", 6) == 0) {
+            snprintf(launch_arg_game, sizeof(launch_arg_game), "%s", token + 6);
+            trimLaunchArgToken(launch_arg_game);
+        } else if (strcmp(token, "-debug") == 0) {
             launch_arg_debug = 1;
         }
     }


### PR DESCRIPTION
## What & why

CosmicScale (OSDMenu dev) reported that `-page=hdd` and `-mode=ata` launch arguments had **zero effect** on hardware (2026-06-09). A scoped multi-agent source trace (C side, Lua load order, OSDMenu argv conventions) cleared the C delivery and Lua plumbing and pinned the cause on the Lua side.

### Root cause (confirmed)
`UI.MainMenu` installs a `__newindex` write-guard (`ui.lua` tail) that **silently drops any `OPT` assignment** unless `Carousel.allowOptWrite` is raised — and `MainMenu.Play()` re-syncs the carousel **from** `OPT` every non-animating frame. The launch-arg page-jump block wrote `UI.MainMenu.OPT` without raising that gate, so the write was swallowed and the surviving carousel-index writes were overwritten by the first `Play()` during `WelcomeDraw`. Both `-page=hdd` and `-mode=ata` normalized correctly to `"HDD"`, but the navigation was a guaranteed no-op.

### Fixes — `bin/POPSLDR/system.lua`
- **Page-jump** now raises `Carousel.allowOptWrite` around the `OPT` write (and sets carousel indices to match) so navigation actually lands. ← the fix.
- **`NormalizeLaunchPage`** trims surrounding whitespace/quotes and keeps only the first word, so CNF-decorated values (`"hdd "`, `'"hdd"'`, `"hdd -debug"` delivered as one token) still resolve. Lossless — no page value contains a space.
- **`-game`** selector trimmed (internal spaces like `Bomberman - Party Edition` preserved); a `-debug` joined onto the page arg line is recovered.
- **`AutoLaunchFromLaunchArgs`** raises `UI.Transition.allowSceneWrite` around its `UI.CURSCENE` write (same guard family).
- **`-debug` toast** queued *after* auto-launch so a failure toast can't evict it (`Notif_queue` keeps the 2 newest).

### Hardening — `src/main.cpp`
- New `trimLaunchArgToken()` trims whitespace + one pair of surrounding quotes per token (on a **copy** — parent argv must not be mutated). OSDMenu leaves trailing spaces on CNF arg lines; this makes delivery robust.

### Docs
- New **`docs/LAUNCH_ARGUMENTS.md`** — full user-facing reference: args, accepted values + aliases, behavior, OSDMenu `OSDMENU.CNF` example, front-end notes (including the embedded-Lua *build requirement*), and a maintainer source map.

### Scope / safety
- Only the launch-arg code paths change. With no launch args, behavior is identical (these paths are inert today). Regression surface to normal boot/menu is nil.
- Needs hardware confirmation. **`-debug` is the decisive signal** — if the toast shows `args.page: HDD`, parsing/delivery work; if it never appears, the args didn't reach `parseLaunchArgs` (front-end or outdated build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)