### PR TITLE
[DRAFT] UX: hide .VCD on game list, marquee long titles, settings scroll

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -81,6 +81,37 @@ local function StripVcdExtension(name)
   local s = tostring(name or "")
   return (string.gsub(s, "%.[Vv][Cc][Dd]$", ""))
 end
+
+-- Horizontal marquee for the selected, overflowing game-list row. There is
+-- no scissor/clip API for a pixel-smooth scroll, so this steps by whole
+-- characters within the fixed column using the Font.ftWidth measurement
+-- (C fntCalcDimensions binding). Continuous via a "label .. gap .. label"
+-- scroll buffer; cosmetic; resets when the selection changes.
+local MARQUEE_HOLD_FRAMES = 36   -- pause showing the head before scrolling
+local MARQUEE_STEP_FRAMES = 6    -- frames per one-character advance
+local function FitFromLeft(font, text, max_w)
+  local s = tostring(text or "")
+  -- Trim from the right until the run fits the column. ftWidth is exact for
+  -- the proportional font; only runs for the single focused row.
+  while #s > 0 and Font.ftWidth(font, s) > max_w do
+    s = string.sub(s, 1, -2)
+  end
+  return s
+end
+local function MarqueeLabel(font, label, max_w, tick)
+  if type(Font.ftWidth) ~= "function" then return label end
+  if Font.ftWidth(font, label) <= max_w then
+    return label
+  end
+  local sep = "    "
+  local scroll = label..sep..label
+  local cycle = string.len(label) + string.len(sep)
+  local start_char = 1
+  if tick > MARQUEE_HOLD_FRAMES then
+    start_char = (math.floor((tick - MARQUEE_HOLD_FRAMES) / MARQUEE_STEP_FRAMES) % cycle) + 1
+  end
+  return FitFromLeft(font, string.sub(scroll, start_char), max_w)
+end
 local function ResolveSelectedVcdPath(entry, game_path)
   if entry == nil or entry == "" then
     return nil
@@ -2169,6 +2200,13 @@ UI = {
         elseif (UI.GameList.CURR < UI.GameList.STARTUP) then
           UI.GameList.STARTUP = CLAMP(UI.GameList.CURR-1, 1, ammount)
         end
+        -- Advance the marquee clock for the focused row; reset on selection change.
+        if UI.GameList.MarqueeSel ~= UI.GameList.CURR then
+          UI.GameList.MarqueeSel = UI.GameList.CURR
+          UI.GameList.MarqueeTick = 0
+        else
+          UI.GameList.MarqueeTick = (UI.GameList.MarqueeTick or 0) + 1
+        end
         for i = UI.GameList.STARTUP, ammount do
           if i >= (UI.GameList.STARTUP+UI.GameList.MAXDRAW) then break end
           local Y = layout.LIST_Y + ((i-UI.GameList.STARTUP) * layout.LIST_ROW_H)
@@ -2178,7 +2216,12 @@ UI = {
             display_name = string.match(hdd_relpath, "([^/]+)$") or hdd_relpath
           end
 	          local c = (i == UI.GameList.CURR) and UI.COLORS.LIST_SELECTED or UI.COLORS.LIST_UNSELECTED
-	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, StripVcdExtension(display_name), c)
+          local label = StripVcdExtension(display_name)
+          -- Only the focused row scrolls (OPL-style); others clip as before.
+          if i == UI.GameList.CURR then
+            label = MarqueeLabel(BFONT, label, layout.LIST_W, UI.GameList.MarqueeTick or 0)
+          end
+	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, label, c)
         end
         local cover_enabled = UI.CoverPreviewEnabled ~= false
         local cover_img = nil

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -2937,19 +2937,79 @@ UI = {
           end
         end
 
-        local y = top_y
+        -- Focus-following scroll viewport. The page previously placed a fixed
+        -- top-Y and, when the item stack was taller than the title->footer
+        -- area, simply OVERFLOWED off-screen -- lower rows (Show Devices
+        -- checkboxes, the Save/Reset/Discard actions) became unreachable.
+        -- Precompute each item's content offset (variable row heights), then
+        -- scroll only when needed so the focused row stays visible. When the
+        -- content fits, item_off + base_y == the original y exactly, so the
+        -- non-overflowing layout is unchanged.
+        local view_top = layout.TITLE_Y + TITLE_GAP
+        local view_h = footer_top_y - view_top
+        local item_off = {}
+        local item_h = {}
+        do
+          local acc = 0
+          for i = 1, #items do
+            local it = items[i]
+            if it.kind == "section" and i > 1 then acc = acc + SECTION_GAP_BEFORE end
+            item_off[i] = acc
+            if it.kind == "section" then item_h[i] = SECTION_HEADER_H
+            elseif it.kind == "spacer" then item_h[i] = SPACER_H
+            else item_h[i] = ROW_H end
+            acc = acc + item_h[i]
+          end
+        end
+        local scrolling = total_h > view_h
+        local scroll = 0
+        local base_y = top_y
+        if scrolling then
+          base_y = view_top
+          scroll = UI.SettingsScroll or 0
+          local f = UI.SettingsFocus
+          local f_off = item_off[f] or 0
+          local f_h = item_h[f] or ROW_H
+          if f_off < scroll then
+            scroll = f_off
+          elseif (f_off + f_h) > (scroll + view_h) then
+            scroll = f_off + f_h - view_h
+          end
+          local max_scroll = total_h - view_h
+          if scroll < 0 then scroll = 0 end
+          if scroll > max_scroll then scroll = max_scroll end
+          UI.SettingsScroll = scroll
+        else
+          UI.SettingsScroll = 0
+        end
+
         for i = 1, #items do
           local it = items[i]
-          if it.kind == "section" then
-            if i > 1 then y = y + SECTION_GAP_BEFORE end
-            DrawSection(it.label, y)
-            y = y + SECTION_HEADER_H
-          elseif it.kind == "spacer" then
-            y = y + SPACER_H
-          else
-            DrawRow(it, y, UI.SettingsFocus == i)
-            y = y + ROW_H
+          local row_y = base_y + item_off[i] - scroll
+          -- When scrolling, draw only fully-visible rows so nothing paints
+          -- over the title or footer; when it fits, draw everything (original).
+          local show = (not scrolling)
+            or (row_y >= view_top and (row_y + item_h[i]) <= (footer_top_y + 1))
+          if show then
+            if it.kind == "section" then
+              DrawSection(it.label, row_y)
+            elseif it.kind == "spacer" then
+              -- nothing to draw
+            else
+              DrawRow(it, row_y, UI.SettingsFocus == i)
+            end
           end
+        end
+
+        -- Minimal scrollbar so "there's more below/above" is discoverable.
+        if scrolling and total_h > 0 then
+          local track_x = SAFE_RIGHT + 4
+          local thumb_h = math.max(16, math.floor(view_h * view_h / total_h))
+          local max_scroll = total_h - view_h
+          local t = (max_scroll > 0) and (scroll / max_scroll) or 0
+          local thumb_y = view_top + math.floor((view_h - thumb_h) * t)
+          Graphics.drawRect(track_x, view_top, 2, view_h, separator_color)
+          Graphics.drawRect(track_x, thumb_y, 2, thumb_h, accent_color)
         end
 
         Input_GetEvent()

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -71,6 +71,16 @@ local function BasenameWithoutExtension(path)
   end
   return StripExtension(basename) or basename
 end
+-- Strip a trailing POPS ".VCD" extension (any case) for game-list display,
+-- and ONLY that extension. The previous code blanket-chopped the last 4
+-- characters of every entry, which silently truncated titles that did NOT
+-- end in .VCD (e.g. "Bomberman" -> "Bombe"). A generic last-extension strip
+-- can't be used either: it would eat the tail of titles containing a dot
+-- ("Mr. Driller" -> "Mr"). So match .VCD specifically.
+local function StripVcdExtension(name)
+  local s = tostring(name or "")
+  return (string.gsub(s, "%.[Vv][Cc][Dd]$", ""))
+end
 local function ResolveSelectedVcdPath(entry, game_path)
   if entry == nil or entry == "" then
     return nil
@@ -2168,7 +2178,7 @@ UI = {
             display_name = string.match(hdd_relpath, "([^/]+)$") or hdd_relpath
           end
 	          local c = (i == UI.GameList.CURR) and UI.COLORS.LIST_SELECTED or UI.COLORS.LIST_UNSELECTED
-	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, string.sub(display_name,1, -5), c)
+	          Font.ftPrint(BFONT, layout.LIST_X, Y, 0, layout.LIST_W, 16, StripVcdExtension(display_name), c)
         end
         local cover_enabled = UI.CoverPreviewEnabled ~= false
         local cover_img = nil

--- a/src/luagraphics.cpp
+++ b/src/luagraphics.cpp
@@ -173,9 +173,18 @@ static int lua_ftprint(lua_State *L) {
 	return 0;
 }
 
+static int lua_ftwidth(lua_State *L) {
+	int argc = lua_gettop(L);
+	if (argc != 2) return luaL_error(L, "wrong number of arguments");
+	int fontid = luaL_checkinteger(L, 1);
+	const char* text = luaL_checkstring(L, 2);
+	lua_pushinteger(L, fntCalcDimensions(fontid, text));
+	return 1;
+}
+
 static int lua_ftunload(lua_State *L){
-	int argc = lua_gettop(L); 
-	if (argc != 1) return luaL_error(L, "wrong number of arguments"); 
+	int argc = lua_gettop(L);
+	if (argc != 1) return luaL_error(L, "wrong number of arguments");
 	int fontid = luaL_checkinteger(L, 1);
 	fntRelease(fontid);
 	return 0;
@@ -225,6 +234,7 @@ static const luaL_Reg Font_functions[] = {
 	{"ftSetPixelSize",    lua_ftSetPixelSize},
 	{"ftSetCharSize", 	   lua_ftSetCharSize},
 	{"ftPrint",         		 lua_ftprint},
+	{"ftWidth",            		 lua_ftwidth},
 	{"ftUnload",           		lua_ftunload},
 	{"ftEnd",           	       lua_ftend},
 	//gsFont functions


### PR DESCRIPTION
Community-requested UX improvements (psxplace feedback batch).

### 1. Hide `.VCD` extension on the game list ✅ (this commit)
The list rendered titles via `string.sub(name, 1, -5)` — a blanket "chop the last 4 chars" hack assuming every entry ends in `.VCD`. That **silently truncated** any title without that extension (`Bomberman` → `Bombe`), and a generic last-extension strip can't replace it (it would eat `Mr. Driller` → `Mr`). New `StripVcdExtension()` removes **only** a trailing `.VCD` (any case). *(Nadwiślański)*

### 2. Marquee-scroll long titles 🚧 (incoming)
Long game titles clip at the column edge. Adds a `Font.ftWidth` binding (wraps the existing C `fntCalcDimensions`) and a windowed marquee for the selected row. *(Ripto)*

### 3. Settings scroll viewport 🚧 (incoming)
The settings list computes a fixed top-Y and **overflows off-screen** when taller than the area (no scrolling) — long device lists can't be reached. Adds a focus-following scroll viewport. *(Ripto — "zip scroll")*

Lua-only except the additive `Font.ftWidth` binding. Draft until all three land + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)