### PR TITLE
[DRAFT] boot: full IOP cold reboot (UDNL) — launcher-agnostic (OSD-XMB fix)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,11 +654,26 @@ extern "C" void _ps2sdk_memory_init() {
      * MC autoboot) are unaffected: each new call has a "not
      * initialized" guard. The only behavioral delta is that the IOP
      * reset now completes instead of hanging when fileXio was alive.
+     *
+     * FULL COLD REBOOT (rom0:UDNL rom0:EELOADCNF) rather than the bare
+     * SifIopReset("", 0). A bare reset reboots the IOP but a heavier
+     * no-reset parent can leave residual IOP state that the plain reset
+     * does not fully clear, which later trips the partition-aware
+     * POPSTARTER launch ("exec did not transfer control"). The canonical
+     * offender here is OSD-XMB (HiroTex, on DanielSant0s' Athena Env):
+     * its "reset IOP before launch" option is OFF by default, so it hands
+     * us Athena's loaded IOP stack (dev9/atad/pfs/network/...). POPSLoader
+     * itself boots, but a subsequently-launched HDD POPSTARTER fails to
+     * hand off (Nuno 2026-06). UDNL reloads the IOP kernel from ROM,
+     * guaranteeing a clean slate regardless of what the parent left, which
+     * makes POPSLoader launcher-agnostic. This is exactly the reset the
+     * project's own known-good reference build used (src/system.cpp
+     * IOP_Reset: SifIopReset("rom0:UDNL rom0:EELOADCNF", 0)).
      */
     SifExitRpc();
     SifInitRpc(0);
     fileXioExit();
-    while (!SifIopReset("", 0)){};
+    while (!SifIopReset("rom0:UDNL rom0:EELOADCNF", 0)){};
     while (!SifIopSync()){};
     SifInitRpc(0);
 #endif


### PR DESCRIPTION
## What & why

POPSTARTER launch fails with **"exec did not transfer control"** when POPSLoader is launched from **OSD-XMB** (Nuno, 2026-06). **Not D-10** (which is fixed and preserved) — this is the **U-10 / dirty-IOP family** (ps2sdk [#425](https://github.com/ps2dev/ps2sdk/issues/425)).

### Root cause (confirmed)
[OSD-XMB](https://github.com/HiroTex/OSD-XMB) (HiroTex, on DanielSant0s' Athena Env) has its **"reset IOP before launch" option OFF by default**, so it hands POPSLoader Athena's loaded IOP stack (dev9/atad/pfs/network/…). POPSLoader's boot teardown (`_ps2sdk_memory_init`) already exits fileXio + resets the IOP for no-reset parents (the wLaunchELF/Class-A fix), but used a **bare** `SifIopReset("", 0)`. A bare reset doesn't fully clear a heavier parent's residual IOP state — POPSLoader boots fine (the UI/diagnostic rendered on Nuno's screen), but the subsequent partition-aware HDD POPSTARTER launch can't hand off.

### Change
Upgrade the boot teardown to a **full cold reboot**:
```c
SifIopReset("rom0:UDNL rom0:EELOADCNF", 0)
```
which reloads the IOP kernel from ROM, guaranteeing a clean slate regardless of the parent. This is **the exact reset string the project's own known-good reference build uses** (`src/system.cpp` `IOP_Reset`). The pre-reset teardown (`SifExitRpc`/`SifInitRpc`/`fileXioExit`) is unchanged.

### Status — needs hardware verification
- ✅ Should fix the OSD-XMB → POPSTARTER launch.
- ⚠️ It's a **boot-sequence change affecting every launch path**, so please regression-test **regular boots too**: MC autoboot, USB, HDD, MMCE, SMB, MX4SIO, wLaunchELF, PSBBN/HOSDMenu/OSDMenu — confirm POPSLoader still boots and launches normally.
- Immediate alternative for users: enable OSD-XMB's own "Reset IOP" toggle for the POPSLoader entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)