### PR TITLE
ci(rolling): publish only on push -- PRs were silently republishing the rolling channel

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -270,7 +270,12 @@ jobs:
           compression-level: 0
 
       - name: Publish rolling release
-        if: success()
+        # push-only: pull_request runs still build + harness-gate the merge
+        # preview, but must never move the floating rolling-release tag -- PR
+        # #510 (opened 2026-07-16) silently republished the rolling channel
+        # from its synthetic merge commit because this step had no event gate
+        # (the MEGA job below always had one).
+        if: success() && github.event_name == 'push'
         shell: sh
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Any same-repo PR was silently **republishing the rolling channel**: `rolling-release.yml` triggers on `pull_request` (so PRs get the harness + build gate, which is good), but the `Publish rolling release` step was gated only on `success()` — so a PR run moved the floating `rolling-release` tag and republished the release from the PR's **synthetic merge commit**.

## Evidence

[PR #510](https://github.com/NathanNeurotic/POPSLoader/pull/510) did this today: `git ls-remote origin refs/tags/rolling-release` now returns `ad9da13`, which is `Merge aaafd11 into c30cd8f` — a commit that exists only as the PR merge ref. (Content-wise that publish was benign — it is the post-merge preview of dev + the reviewed USB fix — but the channel moved without any push to `dev`, and the tester-facing channel-identification scheme depends on rolling == dev.)

## Fix

Gate the publish step on `github.event_name == 'push'`, exactly like the MEGA-archive job always was. PR runs still build, run the boot-brick harness gate, and upload the workflow artifact — they just can't publish. This PR's own run is the proof: its publish step should show as **skipped**.

Found by the adversarial review workflow while verifying the EXP9 push; the experimental workflow does not have this hole (no `pull_request` trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)