### PR TITLE
fix(version): rolling must not impersonate the experimental channel

### DIFF
--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,11 +1,11 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.0.2-dev-EXP10
+Title=POPSLoader 1.0.2-dev
 CfgVersion=8
 $ConfigSource=1
-Version=1.0.2-dev-EXP10
+Version=1.0.2-dev
 Package=1
-Release=July 16th, 2026 (experimental)
+Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com
 Genre=Emulator
 Description=POPSloader is a GUI for POPSTARTER launcher which lets you play your PS1 games in .VCD format from HDD or USB.

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.0.2-dev-EXP10"
+POPSLDR_VER = "v1.0.2-dev"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)


### PR DESCRIPTION
## What

[PR #514](https://github.com/NathanNeurotic/POPSLoader/pull/514) (experimental → dev) graduated all the experiments to rolling — but it also carried the **EXP10 version stamps** into dev, so the currently-published rolling build identifies as **1.0.2-dev-EXP10** in Settings > About, on the Credits grey line, and in `title.cfg`.

That breaks the three-channel self-identification scheme (`1.0.1` public / `1.0.2-dev` rolling / `1.0.2-dev-EXP<n>` experimental): a tester reading the version can no longer tell rolling from experimental — the exact confusion the stamps were introduced to prevent (the EXP5 renaming lesson).

## Fix

Restore dev's three stamp sites to `1.0.2-dev` (`etc/boot.lua` `POPSLDR_VER`, `title.cfg` `Title=`/`Version=`; the `Release=` line drops the "(experimental)" suffix). **No content changes** — everything #514 graduated stays. Merging this republishes rolling with the correct identity.

lua54 parse-clean on boot.lua. (`EXPERIMENTAL_NOTES.md` also rode into dev via #514 — left in place deliberately: it is inert on this branch, only the experimental workflow reads it, and removing it would create permanent merge friction with the experimental branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)