### PR TITLE
fix(i18n): the credits body now translates (trailing-newline mismatch)

### DIFF
--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -5653,7 +5653,12 @@ UI = {
 		
           Font.ftPrintMultiLineAligned(LFONT, UI.SCR.X_MID, layout.TITLE_Y, 20, UI.SCR.X, 40, PLDR.L("POPSLoader\nfor POPStarter"), currcol)
           Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 60, 20, UI.SCR.X, 40, PLDR.L("Code by El_isra"), currcol)
-          Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 80, 20, UI.SCR.X, UI.SCR.Y, [[
+          -- The long-string literal keeps a trailing newline that the TSV key
+          -- lacks, so L() never matched and the body stayed English under every
+          -- language even though the full translation exists (sAGA's photo:
+          -- two Hungarian lines above an English block). Strip it for the
+          -- lookup; the renderer never needed the trailing blank line.
+          Font.ftPrintMultiLineAligned(BFONT, UI.SCR.X_MID, layout.TITLE_Y + 80, 20, UI.SCR.X, UI.SCR.Y, PLDR.L((([[
 Design by Berion
 Scripts by nuno6573 and Ripto
 Based on Enceladus by Daniel Santos
@@ -5669,7 +5674,7 @@ If you bought it, you have been scammed
 
 Compatibility problems? Visit:
 youtube.com/@hugopocked6695
-]], currcol)
+]]):gsub("\n$", ""))), currcol)
         -- Build-identity + boot-timing lines (bottom-anchored above the footer).
         -- Line 1: the BUILD_INFO.txt stamp when that loose file sits next to the
         -- ELF, else the embedded POPSLDR_VER. A normal one-file install ships NO


### PR DESCRIPTION
From sAGA's EXP12 photo: the credits title and "Code by" lines render in Hungarian (activated by the earlier sink fix) while the body block stays English — the `[[...]]` literal carries a trailing newline the TSV key lacks, so the lookup never matched despite oldman63 having translated the entire body. Strips the trailing newline for the lookup; the stripped literal is verified byte-identical to the TSV key, so the full-body translation (his own credits wording, including "sAGA/oldman63") now renders in every language that has the row.

lua54 parse-clean; host harness 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)