### PR TITLE
docs(readme): complete the Credits roster + explain the missing GitHub contributors box

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,15 +268,21 @@ See [STATE.md](STATE.md) "Known Open Work" and [ROADMAP.md](ROADMAP.md) for the 
 
 ## Credits
 
-*   **israpps (El_isra)**: Original POPSLoader project creator.
+*   **[israpps (El_isra)](https://github.com/israpps)**: Original POPSLoader project creator.
 *   **Daniel Santos**: Creator of the Enceladus runtime foundation.
 *   **krHACKen**: Author of POPStarter.
 *   **Berion**: User interface design and theme assets.
-*   **nuno6573**: Cover-art engine integrations and scripting.
+*   **[nuno6573](https://github.com/nuno6573)**: Cover-art engine integrations, scripting, and hardware testing.
 *   **Hugopocked**: POPStarter fixes.
-*   **saildot4k**: BDMA-ATA (exFAT internal-HDD / ATA backend), fixes, feedback, and oversight.
+*   **[saildot4k](https://github.com/saildot4k) (R3Z3N)**: BDMA-ATA (exFAT internal-HDD / ATA backend), the wLaunchELF_R3Z reference work our USB fixes are built on, the settings-UI review rounds, fixes, feedback, and oversight.
+*   **[oldman63](https://github.com/oldman63) (Sári Gábor)**: The complete Hungarian localization, plus the localization bug reports that hardened it for every language.
+*   **sAGA**: Relentless hardware testing and pin-sharp reports — the USB enumeration saga, the internal-HDD freeze diagnosis rounds, and UI suggestions that shipped.
+*   **CosmicScale**: exFAT internal-HDD hardware verification and the per-device POPSTARTER idea.
+*   **FifthFox**: The per-device USB-delay POPSTARTER report that shaped the launch resolver.
 *   **Ripto / NathanNeurotic**: Maintenance, UI polishing, and release engineering.
-*   **P4NCHOL1NO, VizoR, provato, nuno6573, TnA-Plastic, and the community**: Hardware testing.
+*   **P4NCHOL1NO, VizoR, provato, TnA-Plastic, and the community**: Hardware testing.
+
+*(GitHub's sidebar can't be trusted to show this repo's contributors — it omits the contributors box on forked repositories — so this list is the canonical one. If you contributed and aren't here, that's a bug: open an issue.)*
 
 ---
 


### PR DESCRIPTION
## Why the repo page shows no contributors

**The repo is a fork**, and GitHub omits the contributors box on fork homepages — even though the contributors API returns the data (NathanNeurotic 581, oldman63 2, nuno6573 1). Fork commits also **don't count toward anyone's GitHub profile**, so oldman63's merged translation work earns him nothing profile-side as long as this stays a fork.

## The in-repo fix (this PR)

The README Credits section becomes the canonical roster: adds **oldman63 (Sári Gábor)**, **sAGA**, **CosmicScale**, and **FifthFox**, connects **saildot4k ↔ R3Z3N** and credits the wLE_R3Z reference work, links GitHub profiles where known, and closes with a standing invitation to open an issue if anyone's missing.

## The full fix (maintainer action, not in this PR)

**Detach the repo from the fork network**: check *Settings → General* for a "Leave fork network" option; if it's not offered, a short [GitHub Support request](https://support.github.com/contact) ("please detach NathanNeurotic/POPSLoader from its fork network — it has long been an independent project with its own releases") does it. After detaching: the contributors box appears on the repo page, and everyone's commits start counting toward their profiles. Given the project has its own release line and diverged history, detaching costs only the "forked from" banner and the one-click upstream-PR flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)