### PR TITLE
fix(i18n+smb): pre-translate 39 composed toasts; per-file progress while staging SMB modules

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -4842,7 +4842,7 @@ function PLDR.SaveSettingsAtomic()
   -- don't depend on mc0:/POPSTARTER existing.
   if target_is_mc and not mc_dir_ok then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("Cannot access "..tostring(PLDR.POPSTARTER_DIR))
+      UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR))
     end
     return false
   end
@@ -4856,7 +4856,7 @@ function PLDR.SaveSettingsAtomic()
       PLDR.SETTINGS_PATH = PLDR.SETTINGS_PATH_FALLBACK
       ok = true
       if UI ~= nil and UI.Notif_queue ~= nil then
-        UI.Notif_queue.add("Saved to "..tostring(PLDR.SETTINGS_PATH_FALLBACK).."\n(the usual settings location wasn't writable)", "warn")
+        UI.Notif_queue.add(PLDR.L("Saved to").." "..tostring(PLDR.SETTINGS_PATH_FALLBACK).."\n"..PLDR.L("(the usual settings location wasn't writable)"), "warn")
       end
     end
   end
@@ -5299,7 +5299,7 @@ function PLDR.CommitSettingsChanges(opts)
       EmitStage("apply_bdma", "Restoring BDMA mode")
       local restaged = PLDR.ApplyBdmaModeOnce(next_state.bdma_mode, PLDR.NextBdmaApplyToken())
       if not restaged and UI ~= nil and UI.Notif_queue ~= nil then
-        UI.Notif_queue.add("Couldn't restore BDMA mode "..tostring(next_state.bdma_mode).."\nre-select it under Settings > Storage to restage", "warn")
+        UI.Notif_queue.add(PLDR.L("Couldn't restore BDMA mode").." "..tostring(next_state.bdma_mode).."\n"..PLDR.L("re-select it under Settings > Storage to restage"), "warn")
       end
     end
   end
@@ -6206,7 +6206,7 @@ function PLDR.ApplyBdmaMode(mode_key)
   local selected = mode_key or "FAT32"
   if not PLDR.EnsurePopstarterDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("Cannot access "..tostring(PLDR.POPSTARTER_DIR))
+      UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR))
     end
     return false
   end
@@ -6231,14 +6231,14 @@ function PLDR.ApplyBdmaMode(mode_key)
   local suffix = BDMA_SUFFIX[selected]
   if suffix == nil then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("Unknown BDMA mode: "..tostring(selected))
+      UI.Notif_queue.add(PLDR.L("Unknown BDMA mode:").." "..tostring(selected))
     end
     return false
   end
 
   if not PLDR.EnsureBackendForAppDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("BDMA source backend not ready:\n"..APP_DIR_NORM)
+      UI.Notif_queue.add(PLDR.L("BDMA source backend not ready:").."\n"..APP_DIR_NORM)
     end
     return false
   end
@@ -6261,7 +6261,7 @@ function PLDR.ApplyBdmaMode(mode_key)
       end
       if bytes == nil then
         if UI ~= nil and UI.Notif_queue ~= nil then
-          UI.Notif_queue.add("Missing BDMA source (tried):\n"..table.concat(paths, "\n"))
+          UI.Notif_queue.add(PLDR.L("Missing BDMA source (tried):").."\n"..table.concat(paths, "\n"))
         end
         return false
       end
@@ -6355,7 +6355,7 @@ function PLDR.MaybeApplyAdaptiveBdma(ui_scene, device_page)
   if not ok and UI ~= nil and UI.Notif_queue ~= nil then
     -- The caller CANCELS the launch on false, returning to the menu loop --
     -- which is the only place this warn can actually be seen.
-    UI.Notif_queue.add("Adaptive BDMA couldn't stage "..tostring(target).." -- launch cancelled\n("..tostring(why or "apply failed")..") check the memory card, or turn Adaptive BDMA off", "warn")
+    UI.Notif_queue.add(PLDR.L("Adaptive BDMA couldn't stage").." "..tostring(target).." "..PLDR.L("-- launch cancelled").."\n("..tostring(why or "apply failed")..") "..PLDR.L("check the memory card, or turn Adaptive BDMA off"), "warn")
   end
   return ok
 end
@@ -6406,7 +6406,7 @@ end
 -- to re-run whenever an SMB field changes to regenerate the .DAT.
 function PLDR.ApplySmbModules()
   if not PLDR.EnsurePopstarterDir() then
-    if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add("Cannot access "..tostring(PLDR.POPSTARTER_DIR)) end
+    if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR)) end
     return false
   end
   local cfg = PLDR.SmbCopy(PLDR.SMB)
@@ -6421,7 +6421,7 @@ function PLDR.ApplySmbModules()
     if source == nil then
       local bytes = GetEmbeddedAssetBytes(name)
       if bytes == nil then
-        if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add("Missing SMB module (tried):\n"..table.concat(paths, "\n")) end
+        if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add(PLDR.L("Missing SMB module (tried):").."\n"..table.concat(paths, "\n")) end
         return false
       end
       if not WriteBytesAtomicBounded(bytes, dest) then return false end
@@ -6450,7 +6450,7 @@ end
 -- the BDMA usbd/usbhdfsd modules intact. NEVER calls RemovePopstarterMcFolder.
 function PLDR.RemoveSmbModules()
   if not PLDR.EnsurePopstarterDir() then
-    if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add("Cannot access "..tostring(PLDR.POPSTARTER_DIR)) end
+    if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR)) end
     return false
   end
   local ok = true
@@ -6499,14 +6499,14 @@ function PLDR.EnsurePopstarterUiAssets()
   if PLDR.POPSTARTER_MC_FOLDER == false then return true end
   if not PLDR.EnsurePopstarterDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("Cannot access "..tostring(PLDR.POPSTARTER_DIR))
+      UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR))
     end
     return false
   end
 
   if not PLDR.EnsureBackendForAppDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then
-      UI.Notif_queue.add("BDMA source backend not ready:\n"..APP_DIR_NORM)
+      UI.Notif_queue.add(PLDR.L("BDMA source backend not ready:").."\n"..APP_DIR_NORM)
     end
     return false
   end
@@ -6532,7 +6532,7 @@ function PLDR.EnsurePopstarterUiAssets()
         end
         if bytes == nil then
           if UI ~= nil and UI.Notif_queue ~= nil then
-            UI.Notif_queue.add("Missing BDMA UI source (tried):\n"..table.concat(paths, "\n"))
+            UI.Notif_queue.add(PLDR.L("Missing BDMA UI source (tried):").."\n"..table.concat(paths, "\n"))
           end
           return false
         end
@@ -6916,7 +6916,7 @@ local function AppendHddGameList(partition, list_path, on_progress, partition_in
   if DIR == nil then
     -- The partition mounted but its root would not list: surface it instead of
     -- silently showing "No games found" (dir-read faults were invisible before).
-    pcall(UI.Notif_queue.add, string.format("HDD dir read failed: %s (%s)", tostring(list_path), tostring(partition)))
+    pcall(UI.Notif_queue.add, PLDR.L("HDD dir read failed:")..string.format(" %s (%s)", tostring(list_path), tostring(partition)))
     if type(on_progress) == "function" then
       pcall(on_progress, (tonumber(partition_index) or 1) / math.max(tonumber(partition_total) or 1, 1))
     end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -5312,7 +5312,9 @@ function PLDR.CommitSettingsChanges(opts)
     -- sidecar matches the effective (rolled-back) state, mirroring the BDMA rollback.
     local smb_ok
     if next_state.smb_modules == true then
-      smb_ok = PLDR.ApplySmbModules()
+      smb_ok = PLDR.ApplySmbModules(function(i, n, name)
+        EmitStage("apply_smb", PLDR.L("Applying SMB modules").." ("..tostring(i).."/"..tostring(n)..") "..tostring(name))
+      end)
     else
       smb_ok = PLDR.RemoveSmbModules()
     end
@@ -6404,14 +6406,23 @@ end
 -- override -> embedded fallback, exactly like ApplyBdmaMode) and generates the
 -- 2 .DAT from the current PLDR.SMB. Idempotent (atomic overwrites), so it is safe
 -- to re-run whenever an SMB field changes to regenerate the .DAT.
-function PLDR.ApplySmbModules()
+function PLDR.ApplySmbModules(progress)
   if not PLDR.EnsurePopstarterDir() then
     if UI ~= nil and UI.Notif_queue ~= nil then UI.Notif_queue.add(PLDR.L("Cannot access").." "..tostring(PLDR.POPSTARTER_DIR)) end
     return false
   end
+  -- Per-file progress (maintainer report: the save overlay sat on one static
+  -- "Applying SMB modules" through 8 slow memory-card writes -- long enough
+  -- that a normal user reads it as a crash). progress(i, total, name) fires
+  -- before each write; the caller repaints. Best-effort, never load-bearing.
+  local total = #PLDR.SMB_IRX_FILES + 2  -- the 6 IRX + IPCONFIG.DAT + SMBCONFIG.DAT
+  local function step(i, name)
+    if type(progress) == "function" then pcall(progress, i, total, name) end
+  end
   local cfg = PLDR.SmbCopy(PLDR.SMB)
   for i = 1, #PLDR.SMB_IRX_FILES do
     local name = PLDR.SMB_IRX_FILES[i]
+    step(i, name)
     local dest = POPSTARTER_PACK_ROOT.."/"..name
     local paths = PLDR.BdmaSourceCandidates(name)
     local fd, source = PLDR.TryOpenFirst(paths)
@@ -6431,6 +6442,7 @@ function PLDR.ApplySmbModules()
     end
   end
   -- IPCONFIG.DAT: write the static line, or delete any stale file when on DHCP.
+  step(#PLDR.SMB_IRX_FILES + 1, "IPCONFIG.DAT")
   local ip_dest = POPSTARTER_PACK_ROOT.."/IPCONFIG.DAT"
   local ip_body = PLDR.RenderSmbIpconfig(cfg)
   if ip_body == nil then
@@ -6439,6 +6451,7 @@ function PLDR.ApplySmbModules()
     if not WriteBytesAtomicBounded(ip_body, ip_dest) then return false end
   end
   -- SMBCONFIG.DAT: always generated from the current settings.
+  step(total, "SMBCONFIG.DAT")
   if not WriteBytesAtomicBounded(PLDR.RenderSmbConfig(cfg), POPSTARTER_PACK_ROOT.."/SMBCONFIG.DAT") then
     return false
   end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1648,7 +1648,7 @@ UI = {
           end
           if elf_path == nil or not SafeDoesFileExist(elf_path) then
             UI.Modal.Close()
-            UI.Notif_queue.add("No DKWDRV found at this path\n"..configured_path, "error")
+            UI.Notif_queue.add(PLDR.L("No DKWDRV found at this path").."\n"..configured_path, "error")
             return
           end
           UI.LAUNCHING = true
@@ -1766,7 +1766,7 @@ UI = {
             pcall(PLDR.RestoreWorkingDirectory, previous_cwd)
           end
           UI.LAUNCHING = false
-          UI.Notify("DKWDRV failed to launch\nreturn code: "..tostring(rc), 150, "error")
+          UI.Notify(PLDR.L("DKWDRV failed to launch").."\n"..PLDR.L("return code:").." "..tostring(rc), 150, "error")
           return
         end
         UI.Modal.cancel_action = UI.Modal.Close
@@ -1856,7 +1856,7 @@ UI = {
         -- reboot=1 attempts were chasing the wrong mechanism.
         local rc = System.loadELF(elf_path, reboot_iop)
         UI.LAUNCHING = false
-        UI.Notify("BOOT.ELF failed to launch\nreturn code: "..tostring(rc), 150, "error")
+        UI.Notify(PLDR.L("BOOT.ELF failed to launch").."\n"..PLDR.L("return code:").." "..tostring(rc), 150, "error")
         return
       end;
       HandleInput = function ()
@@ -2379,8 +2379,8 @@ UI = {
         Font.ftPrint(SFONT, input_x + 10, input_y + 10, 0, input_w - 20, 16, UI.PathEditor._BuildVisibleValue(46), Color.new(150, 205, 255, 128))
         -- The label names the state R2 SWITCHES TO, not the current one
         -- (R3Z3N: "tell people what you would change to, not what you are on").
-        local mode_label = UI.PathEditor.upper and "Case/Symbols: lower  (R2)" or "Case/Symbols: UPPER  (R2)"
-        local info_label = mode_label.."   Cursor: L1 / R1"
+        local mode_label = UI.PathEditor.upper and PLDR.L("Case/Symbols: lower  (R2)") or PLDR.L("Case/Symbols: UPPER  (R2)")
+        local info_label = mode_label.."   "..PLDR.L("Cursor: L1 / R1")
         Font.ftPrint(SFONT, input_x + 2, input_y + input_h + 10, 0, input_w - 4, 16, info_label, UI.CCOL.GREY)
 
         local key_h = 24
@@ -2712,7 +2712,7 @@ UI = {
         if UI.CURSCENE == UI.SCENES.GSMB then
           local slots = PLDR.GetMMCESlots()
           if #slots > 1 and not UI.ShouldHideAuxText(UI.CURSCENE) then
-            Font.ftPrint(SFONT, layout.LIST_X, layout.LIST_Y - 20, 0, UI.SCR.X, 16, "Slot: "..PLDR.MMCE.PREFIX, UI.CCOL.GREY)
+            Font.ftPrint(SFONT, layout.LIST_X, layout.LIST_Y - 20, 0, UI.SCR.X, 16, PLDR.L("Slot:").." "..PLDR.MMCE.PREFIX, UI.CCOL.GREY)
           end
         end
         if (UI.GameList.CURR > (UI.GameList.STARTUP+(UI.GameList.MAXDRAW-1))) then
@@ -3194,9 +3194,9 @@ UI = {
             if configured_popstarter_path == "" then
               message = "No POPSTARTER.ELF found\nchecked the game device, the launcher folder and mc0:/mc1:"
             else
-              message = "No POPSTARTER found at this path\n"..configured_popstarter_path
+              message = PLDR.L("No POPSTARTER found at this path").."\n"..configured_popstarter_path
               if configured_popstarter_path ~= tostring(popstarter_path) then
-                message = message.."\nResolved: "..tostring(popstarter_path)
+                message = message.."\n"..PLDR.L("Resolved:").." "..tostring(popstarter_path)
               end
             end
             UI.Notif_queue.add(message, "error")
@@ -3223,7 +3223,7 @@ UI = {
           -- smb0: browse mount is unreliable, and this is only a (non-blocking) toast.
           if UI.CURSCENE ~= UI.SCENES.GHDD and UI.CURSCENE ~= UI.SCENES.GSMBNET then
             if not doesFileExist(vcd_full) then
-              UI.Notif_queue.add("Game file missing\n"..vcd_full, "error")
+              UI.Notif_queue.add(PLDR.L("Game file missing").."\n"..vcd_full, "error")
             end
           end
           local launch_path = PLDR.GAMEPATH
@@ -3404,7 +3404,7 @@ UI = {
             if ok then
               UI.Notif_queue.add(was_hidden and "Game shown" or "Game hidden", "ok")
             else
-              UI.Notif_queue.add("Couldn't write .hide to the HDD ("..tostring(reason or "")..").\nYou can still add a \"<game>.hide\" next to the .VCD from a PC.", "warn")
+              UI.Notif_queue.add(PLDR.L("Couldn't write .hide to the HDD").." ("..tostring(reason or "")..")\n"..PLDR.L("You can still add a \"<game>.hide\" next to the .VCD from a PC."), "warn")
             end
           else
             local entry = PLDR.GAMES[UI.GameList.CURR]
@@ -3432,7 +3432,7 @@ UI = {
                 PLDR.SaveGameListCache(cache_path, PLDR.GAMES, PLDR.HIDDEN)
               end
             else
-              UI.Notif_queue.add("Couldn't update hidden state ("..tostring(reason)..")", "error")
+              UI.Notif_queue.add(PLDR.L("Couldn't update hidden state").." ("..tostring(reason)..")", "error")
             end
           end
         end
@@ -3442,7 +3442,7 @@ UI = {
           if r3_save_ok then
             UI.Notif_queue.add(_r3msg, "ok")
           else
-            UI.Notif_queue.add(_r3msg.."\n(could NOT save -- reverts on reboot)", "warn")
+            UI.Notif_queue.add(PLDR.L(_r3msg).."\n"..PLDR.L("(could NOT save -- reverts on reboot)"), "warn")
           end
         end
         local cross_label = UI.Footer.labels.cross_launch
@@ -3757,7 +3757,7 @@ UI = {
             elseif reason == "smb_apply_failed" then
               UI.Notif_queue.add("SMB modules didn't install/remove\nmodule setting reverted; other settings were saved", "error")
             else
-              UI.Notif_queue.add("Couldn't save settings\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only"..((type(BOOT_MX4SIO_PROBE_RESULT) == "string" and BOOT_MX4SIO_PROBE_RESULT ~= "") and "\nmx4sio probe: "..BOOT_MX4SIO_PROBE_RESULT or ""), "error")
+              UI.Notif_queue.add(PLDR.L("Couldn't save settings").."\n"..tostring(PLDR.SETTINGS_PATH or "mc0:/POPSTARTER/.pldrs").." may be read-only"..((type(BOOT_MX4SIO_PROBE_RESULT) == "string" and BOOT_MX4SIO_PROBE_RESULT ~= "") and "\nmx4sio probe: "..BOOT_MX4SIO_PROBE_RESULT or ""), "error")
             end
             if allow_fallback_exit == true then
               UI.ProfileDirty = false
@@ -3944,7 +3944,7 @@ UI = {
              and string.match(path, "^[Pp][Ff][Ss]%d*:") == nil then
             local ok, exists = pcall(doesFileExist, path)
             if not (ok and exists == true) then
-              UI.Notif_queue.add("Path saved, file not found:\n"..path, "warn")
+              UI.Notif_queue.add(PLDR.L("Path saved, file not found:").."\n"..path, "warn")
             end
           end
           return path
@@ -5254,7 +5254,7 @@ UI = {
                   iop_line = h.can_alloc_128k and " [iop128k=ok]" or (" [iop128k=NO("..tostring(h.largest or "?")..")]")
                 end
               end
-              report("Locating exFAT HDD POPS folder..."..iop_line, 0.42)
+              report(PLDR.L("Locating exFAT HDD POPS folder...")..iop_line, 0.42)
               -- Staged progress: system.lua's _AtaStage paints through this hook
               -- (and persists the crash marker) right before each blocking call.
               PLDR.AtaProbeProgress = function(pct, msg)
@@ -5307,12 +5307,12 @@ UI = {
 	                  -- The rc suffix tells a real mount fault apart from clean absence
                   -- (the empty-list-from-a-launcher-boot class reports only this toast).
                   local rc_hint = (PLDR.HDD.LAST_MOUNT_RC ~= nil) and (" (last mount rc: "..tostring(PLDR.HDD.LAST_MOUNT_RC)..")") or ""
-                  UI.Notif_queue.add("No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9"..rc_hint, "warn")
+                  UI.Notif_queue.add(PLDR.L("No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9")..rc_hint, "warn")
 	                elseif #PLDR.GAMES < 1 then
                   UI.Notif_queue.add("No games found on hdd0:\n(__.POPS partitions are empty)", "warn")
                 end
               else
-                UI.Notif_queue.add("HDD not usable\nstatus: "..PLDR.HDD.STATUS, "error")
+                UI.Notif_queue.add(PLDR.L("HDD not usable").."\n"..PLDR.L("status:").." "..PLDR.HDD.STATUS, "error")
               end
               report("Opening HDD list...", 1.0)
               UI.SceneChange(UI.SCENES.GHDD)
@@ -5335,7 +5335,7 @@ UI = {
               -- Show the retry so a longer probe reads as "still looking" and not as a
               -- freeze. Only an already-failing setup ever sees past attempt 1.
               PLDR.UsbProbeProgress = function(attempt, total)
-                report("Looking for USB drive... ("..tostring(attempt).."/"..tostring(total)..")", 0.38)
+                report(PLDR.L("Looking for USB drive...").." ("..tostring(attempt).."/"..tostring(total)..")", 0.38)
               end
               local usb_roots = PLDR.GetRootsByType("usb")
               PLDR.UsbProbeProgress = nil
@@ -6201,7 +6201,7 @@ function UI.SmbFieldCycle(field, dir)
 end
 function UI.SmbFieldOpenEditor(field)
   local d = UI.SmbEnsureDraft()
-  local title = "Edit "..(UI._SMB_LABELS[field.key] or field.key)
+  local title = PLDR.L("Edit").." "..PLDR.L(UI._SMB_LABELS[field.key] or field.key)
   if type(UI.PathEditor) == "table" and type(UI.PathEditor.Open) == "function" then
     UI.PathEditor.Open(title, tostring(d[field.key] or ""), function(value)
       local dd = UI.SmbEnsureDraft()
@@ -6217,7 +6217,7 @@ function UI.SmbFieldOpenEditor(field)
       if tostring(cleaned) ~= typed and type(UI.Notif_queue) == "table" then
         -- Covers both a rejected shape (falls to the field default) and a
         -- whitespace trim -- either way the user sees the value actually kept.
-        UI.Notif_queue.add((UI._SMB_LABELS[field.key] or field.key).." adjusted -- using \""..tostring(cleaned).."\"", "warn")
+        UI.Notif_queue.add(PLDR.L(UI._SMB_LABELS[field.key] or field.key).." "..PLDR.L("adjusted -- using").." \""..tostring(cleaned).."\"", "warn")
       end
       dd[field.key] = cleaned
       UI.SmbDirty = true


### PR DESCRIPTION
Two independent fixes, both from maintainer/tester reports.

**1. The SMB "frozen" progress bar** (maintainer, on rolling): installing the SMB modules sat on one static *Applying SMB modules* message through 8 slow memory-card writes — long enough that a normal user reads it as a crash. `ApplySmbModules` now takes an optional progress hook and the commit arm repaints per file: *Applying SMB modules (3/8) smbman.irx*.

**2. 39 composed-toast sites pre-translated**: the toast queue applies `L()` to the *whole* string at add time, so any concatenated suffix (a path, a reason, a diag bracket, a counter) silently reverted a translated toast to English — the class behind sAGA's "Language is English, not translated" photo. Every composed call site in ui.lua/system.lua now pre-translates its static head. The new keys land with the six-language union sync (translations for all 6 languages are drafted and pending application).

Both safe by construction: an unknown key falls back to English, so no string can regress. lua54 parse-clean; host harness 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)