### PR TITLE
revert(ata): rip the exFAT diagnostics back out of rolling -- they hang the page

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -4279,60 +4279,6 @@ function PLDR.IsMx4sioAutoEnterPending()
   return ok and exists == true
 end
 
--- exFAT-ATA probe crash-marker + staged-progress hook (EXP11 diagnostics).
--- The 42%-freeze investigation showed the whole ATA bring-up runs inside
--- blocking native calls with NO timeout (SifExecModuleBuffer, fileXio RPCs,
--- an untimed filesystem-lock WaitSema): a wedge freezes the overlay on the
--- last painted frame and, until now, left no trace and recurred every boot.
--- Same bounding pattern as the MX4SIO marker just above: persist "step N in
--- flight" before each staged native call, clear when the probe returns; a
--- later boot finding the marker can SAY where the previous attempt froze.
--- The step number is the same integer the overlay paints, so a tester photo
--- and the marker agree. All best-effort pcall -- the diagnostics must never
--- themselves wedge anything. (PLDR methods, not chunk locals: this chunk is
--- near Lua's 200-local cap.)
-function PLDR.SetAtaProbeMarker(step)
-  pcall(PLDR.EnsurePopstarterDir)
-  pcall(WriteAtomic, PLDR.POPSTARTER_DIR.."/.ata_probe_pending", tostring(step or "?"))
-end
-function PLDR.ClearAtaProbeMarker()
-  PLDR._ata_marker_last = nil
-  pcall(System.removeFile, PLDR.POPSTARTER_DIR.."/.ata_probe_pending")
-end
-function PLDR.ReadAtaProbeMarker()
-  local p = PLDR.POPSTARTER_DIR.."/.ata_probe_pending"
-  local ok, exists = pcall(doesFileExist, p)
-  if not ok or exists ~= true then return nil end
-  local ok_r, data = pcall(ReadWholeFile, p)
-  if ok_r and type(data) == "string" and data ~= "" then
-    return (string.match(data, "%S+")) or "?"
-  end
-  return "?"
-end
--- One place does both jobs: repaint (via the ui.lua-installed hook) and
--- persist the marker. SCOPED TO THE MANUAL exFAT PAGE by the hook check:
--- the boot-time -page=ata flows run BEFORE settings load, where a marker
--- write's EnsurePopstarterDir would re-create a user-deleted mc POPSTARTER
--- folder (POPSTARTER_MC_FOLDER is still nil there -- the provato every-boot
--- recreation trap), and those flows can't show the next-boot toast anyway,
--- so they must neither write markers nor (see GetATAMassRootNow) clear a
--- surviving one -- that would destroy the evidence before it is read.
--- Paint FIRST, then persist, so the photo and the marker agree on N; the
--- marker write is itself MC IO inside the window under diagnosis, and if IT
--- wedges the photo says N while the marker still says the previous step --
--- that disagreement is the signature of the marker IO, not the named call.
--- The marker is written only when the INTEGER step changes, so the per-slot
--- sweep doesn't grind the memory card.
-function PLDR._AtaStage(pct, msg)
-  if type(PLDR.AtaProbeProgress) ~= "function" then return end
-  pcall(PLDR.AtaProbeProgress, pct, msg)
-  local step = math.floor((tonumber(pct) or 0) * 100 + 0.5)
-  if PLDR._ata_marker_last ~= step then
-    PLDR._ata_marker_last = step
-    PLDR.SetAtaProbeMarker(step)
-  end
-end
-
 local function RecursiveRemoveDir(dir, preserve_path, depth)
   -- F-12: bound the recursion. mc:/POPSTARTER is shallow; a pathological or looping
   -- structure must not blow the Lua stack. 16 levels is far past any real layout.
@@ -5729,26 +5675,8 @@ local function EnsureMassBackendsReady(mode)
   if mode == "ata" then
     -- ata_bd is the BDM block driver for the internal exFAT drive. Idempotent;
     -- mirrors the MX4SIO bring-up (usbmass first, then the device driver).
-    -- EXP11: staged. Each blocking module load gets its own painted integer
-    -- percent FIRST, so a frozen overlay names the stalled step (the 42%-freeze
-    -- investigation: SifExecModuleBuffer has no timeout; ata_bd's module start
-    -- runs the whole ATA probe + BDM cache alloc before returning). ensureDev9 /
-    -- ensureBDMFatFs are load-once latched, so pre-calling them reduces initATA
-    -- to settle + ata_bd + settle. All three stay pcall'd and order-identical to
-    -- the old single initATA call (EnsureAtaBdm re-runs the latched steps).
-    if type(System) == "table" then
-      if type(System.ensureDev9) == "function" then
-        PLDR._AtaStage(0.43, "exFAT HDD: starting dev9 (43)...")
-        pcall(System.ensureDev9)
-      end
-      if type(System.ensureBDMFatFs) == "function" then
-        PLDR._AtaStage(0.44, "exFAT HDD: starting the filesystem base (44)...")
-        pcall(System.ensureBDMFatFs)
-      end
-      if type(System.initATA) == "function" then
-        PLDR._AtaStage(0.45, "exFAT HDD: starting the ATA driver (45)...")
-        pcall(System.initATA)
-      end
+    if type(System) == "table" and type(System.initATA) == "function" then
+      pcall(System.initATA)
     end
     return
   end
@@ -5769,7 +5697,7 @@ local function WaitMassProbeRetry(attempt, max_attempts)
   end
 end
 
-local function BuildMassRootIdentity(mode, attempt)
+local function BuildMassRootIdentity(mode)
   EnsureMassBackendsReady(mode)
 
   local identity = {
@@ -5783,32 +5711,9 @@ local function BuildMassRootIdentity(mode, attempt)
   local seen_mx4 = {}
   local seen_ata = {}
 
-  -- EXP11 (ata only): the slot sweep below funnels every probe through fileXio
-  -- into bdmfs_fatfs's untimed filesystem lock -- which the BDM mount thread
-  -- holds across an ENTIRE mount attempt. If the mount is wedged, the first
-  -- dopen blocks forever. bdm_query's device list is a lock-free array read on
-  -- the IOP (safe even mid-mount), so ask it first: zero registered block
-  -- devices means the sweep can only wait on that lock for nothing -- skip it
-  -- for this attempt and let the retry/toast flow proceed.
-  local try_txt = (attempt ~= nil) and (" (try "..tostring(attempt).." of 4)") or ""
-  if mode == "ata" and type(System) == "table" and type(System.bdmList) == "function" then
-    PLDR._AtaStage(0.46, "exFAT HDD: asking BDM for devices (46)"..try_txt.."...")
-    local ok_l, l = pcall(System.bdmList)
-    if ok_l and type(l) == "table" then
-      local n = 0
-      for _ in pairs(l) do n = n + 1 end
-      if n == 0 then
-        return identity
-      end
-    end
-  end
-
   for slot = 0, 9 do
     local root = (slot == 0) and "mass:/" or ("mass"..tostring(slot)..":/")
     local normalized = NormalizeMassRoot(root)
-    if mode == "ata" then
-      PLDR._AtaStage(0.47, "exFAT HDD: checking slot "..tostring(slot).." (47)"..try_txt.."...")
-    end
     if normalized ~= nil and doesFolderExist(normalized) then
       if seen_present[normalized] ~= true then
         seen_present[normalized] = true
@@ -5817,9 +5722,6 @@ local function BuildMassRootIdentity(mode, attempt)
 
       -- Only classify mounted roots. Probing absent slots can be slow and can
       -- produce unstable driver readings on some hardware.
-      if mode == "ata" then
-        PLDR._AtaStage(0.48, "exFAT HDD: reading slot "..tostring(slot).."'s driver (48)"..try_txt.."...")
-      end
       local driver = PLDR.GetMassMountDriver(normalized)
       local kind = ClassifyMassRootDriver(driver)
       if kind == "mx4sio" then
@@ -6059,34 +5961,20 @@ local function BuildATAIdentityDeferred()
   local attempts = 0
   while attempts < 4 do
     attempts = attempts + 1
-    local identity = BuildMassRootIdentity("ata", attempts)
+    local identity = BuildMassRootIdentity("ata")
     if type(identity) == "table" and type(identity.ata) == "table" and #identity.ata > 0 then
-      PLDR._AtaStage(0.50, "exFAT HDD: drive found (50)...")
       return identity
     end
-    -- EXP11: WaitMassProbeRetry's refresh is a synchronous RPC to bdm_query --
-    -- on a wedged IOP it blocks forever, so it gets its own painted step.
-    PLDR._AtaStage(0.49, "exFAT HDD: re-checking backends (49, try "..tostring(attempts).." of 4)...")
     WaitMassProbeRetry(attempts, 4)
     if attempts < 4 and type(System) == "table" and type(System.sleep) == "function" then
       pcall(System.sleep, 1)
     end
   end
-  return BuildMassRootIdentity("ata", 4)
+  return BuildMassRootIdentity("ata")
 end
 
 function PLDR.GetATAMassRootNow()
   local identity = BuildATAIdentityDeferred()
-  -- EXP11: the probe RETURNED (found or not), so no native call is wedged --
-  -- clear the crash marker, but ONLY if this run actually wrote one
-  -- (_ata_marker_last is set solely by _AtaStage, which is hook-gated to the
-  -- manual exFAT page). A hook-less flow (-page=ata boot, auto-launch) must
-  -- not clear a marker left by an earlier freeze: the manual page entry is
-  -- the only place that READS it, and wiping it here would destroy the
-  -- evidence before it is ever shown.
-  if PLDR._ata_marker_last ~= nil and type(PLDR.ClearAtaProbeMarker) == "function" then
-    PLDR.ClearAtaProbeMarker()
-  end
   if type(identity) == "table" and type(identity.ata) == "table" then
     return identity.ata[1] or nil
   end

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -5253,49 +5253,16 @@ UI = {
             end, "Failed to load MX4SIO")
             if not ok then return end
           elseif UI.MainMenu.OPT == 3 then
-            -- EXP11: if a PREVIOUS exFAT probe froze the console, its crash marker
-            -- survived the reboot -- surface the frozen step number before trying
-            -- again, so even an unphotographed hang produces data (mirrors the
-            -- MX4SIO auto-enter marker; the exFAT branch had no trace at all).
-            if type(PLDR.ReadAtaProbeMarker) == "function" then
-              local stuck = PLDR.ReadAtaProbeMarker()
-              if stuck ~= nil then
-                UI.Notif_queue.add("Last exFAT HDD check never finished\nit froze at step "..tostring(stuck).." -- please report that number", "warn")
-              end
-            end
             local ok = UI.RunBusyTask("Loading HDD (exFAT)...", function (report)
-              -- Scan window starts at 0.52: integers 43..50 belong to the staged
-              -- ATA bring-up steps (a frozen percent names the stalled native call).
-              local scan_progress = UI.MakeBusyProgressReporter(report, "Scanning exFAT HDD games...", 0.52, 0.9)
+              local scan_progress = UI.MakeBusyProgressReporter(report, "Scanning exFAT HDD games...", 0.48, 0.9)
               report("Refreshing mass backends...", 0.18)
               PLDR.CleanupGameList()
               PLDR.GAMEPATH = ""
               if type(PLDR.RefreshMassBackends) == "function" then
                 pcall(PLDR.RefreshMassBackends)
               end
-              -- IOP headroom readout painted BEFORE the first blocking ATA call:
-              -- the top-ranked freeze theory is BDM's unchecked 128KiB cache alloc,
-              -- so iop128k=NO in the frozen photo confirms it in one shot.
-              local iop_line = ""
-              if type(System) == "table" and type(System.iopHeapProbe) == "function" then
-                local ok_h, h = pcall(System.iopHeapProbe)
-                if ok_h and type(h) == "table" then
-                  iop_line = h.can_alloc_128k and " [iop128k=ok]" or (" [iop128k=NO("..tostring(h.largest or "?")..")]")
-                end
-              end
-              report(PLDR.L("Locating exFAT HDD POPS folder...")..iop_line, 0.42)
-              -- Staged progress: system.lua's _AtaStage paints through this hook
-              -- (and persists the crash marker) right before each blocking call.
-              PLDR.AtaProbeProgress = function(pct, msg)
-                report(tostring(msg)..iop_line, pct)
-              end
-              -- pcall so a Lua error mid-probe can't leak the hook or strand the
-              -- marker (a stranded marker = a false "froze last time" toast).
+              report(PLDR.L("Locating exFAT HDD POPS folder..."), 0.42)
               local ok_probe, ata_root = pcall(PLDR.InitATAPopsRoot)
-              PLDR.AtaProbeProgress = nil
-              if type(PLDR.ClearAtaProbeMarker) == "function" then
-                PLDR.ClearAtaProbeMarker()
-              end
               if not ok_probe then ata_root = nil end
               if ata_root == nil then
                 UI.Notif_queue.add("No exFAT HDD detected\nformat the internal drive exFAT (BDMA Mode = ATA)", "warn")
@@ -5308,7 +5275,7 @@ UI = {
                 PLDR.ApplyGameListCache(ata_cg, ata_root, ata_ch)
                 report("Loaded exFAT HDD list from cache...", 1.0)
               else
-                report("Scanning exFAT HDD games...", 0.52)
+                report("Scanning exFAT HDD games...", 0.48)
                 PLDR.GetPS1GameLists(ata_root, true, scan_progress)
                 PLDR.SaveGameListCache(ata_cache, PLDR.GAMES, PLDR.HIDDEN)
               end


### PR DESCRIPTION
Maintainer, on **rolling**: *"Entering exFAT HDD page: Horrific lag in the 40%'s... I enter the page and its stuck loading. This was supposed to be the one thing we DID NOT TAKE from experimental."*

Right on both counts. **#518 graduated EXP11's diagnostics into rolling, and they are the regression.** The crash marker writes to the **memory card on every integer step change** — `EnsurePopstarterDir` (folder probe + 3-asset existence sweep) plus a full `WriteAtomic` tmp/rename/backup dance — roughly **25 times per page entry** across the 4-attempt retry loop. That's 200+ memory-card operations wedged inside the ATA probe, on every exFAT page entry, for every user, to diagnose a bug **one tester has**.

The EXP11 adversarial review called this exactly (*"New memory-card IO on every ata probe that did not exist before EXP11... ~24 writes"*). I filed it `severity: note` and shipped it. The tester is not where I should be discovering a warning I already had.

**Removed from rolling:** staged 43–50 percents, the crash marker and its next-boot toast, the bdm_query pre-check, the iop128k readout, the `attempt` param.

**Verified byte-identical to the pre-#518 build he confirmed working** (`d24168a`): `EnsureMassBackendsReady`, `BuildMassRootIdentity`, `BuildATAIdentityDeferred`, `GetATAMassRootNow` all diff clean. Two ui.lua deltas kept on purpose: `PLDR.L` on the "Locating..." string (translation, no I/O) and a `pcall` around `InitATAPopsRoot` (can't hang; only stops a Lua error from stranding the overlay).

The diagnostics belong in **experimental**, where sAGA tests. That's the channel's whole purpose and I put them in the wrong place.

lua54 parse-clean; host harness 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)