### PR TITLE
i18n: add the 39 untranslated UI strings to translator sheets (+ drop leaked template row)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -3436,7 +3436,6 @@ PLDR.I18N = {
     ["Edit POPStarter Path"] = "POPStarter útvonal szerkesztése",
     ["Enable the POPSTARTER Folder first\n(BDMA / SMB modules must live on the memory card)"] = "Először engedélyezze a POPSTARTER mappát\n(a BDMA / SMB moduloknak a memóriakártyán kell lenniük)",
     ["Enable the POPSTARTER Folder first\n(SMB modules must live on the memory card)"] = "Először engedélyezze a POPSTARTER mappát\n(az SMB-moduloknak a memóriakártyán kell lenniük)",
-    ["English (do not edit)"] = "Hungarian (put your translation here)",
     ["Exit"] = "Kilépés",
     ["FAT32-USB (None)"] = "FAT32-USB (No BDMA)",
     ["Failed to connect to SMB"] = "Nem sikerült csatlakozni az SMB-hez",

--- a/docs/translations/brazilian-portuguese.tsv
+++ b/docs/translations/brazilian-portuguese.tsv
@@ -1,15 +1,21 @@
 English (do not edit)	Brazilian Portuguese (adjust the pre-filled Portuguese)
+(could NOT save -- reverts on reboot)	(could NOT save -- reverts on reboot)
 (not set)	(não definido)
 (share root)	(raiz do share)
+(the usual settings location wasn't writable)	(the usual settings location wasn't writable)
 (unknown)	(desconhecido)
+-- launch cancelled	-- launch cancelled
 100M Full	100M Full
 100M Half	100M Half
 10M Full	10M Full
 10M Half	10M Half
 Actual output	Saída real
 Adaptive BDMA	BDMA Adaptativo
+Adaptive BDMA couldn't stage	Adaptive BDMA couldn't stage
+adjusted -- using	adjusted -- using
 APA / PFS (default)	APA / PFS (padrão)
 Applying BDMA mode	Aplicando modo BDMA
+Applying SMB modules	Applying SMB modules
 ART (at root)	ART (na raiz)
 At least one device must stay on the carousel	Ao menos um dispositivo deve ficar no carrossel
 Auto (console region)	Auto (região do console)
@@ -18,8 +24,10 @@ Backspace	Backspace
 BDMA and SMB modules -- from mc0: / mc1:. They won't	módulos BDMA e SMB -- de mc0: / mc1:. Não vão
 BDMA Mode	Modo BDMA
 BDMA mode change didn't apply\nBDMA reverted; other settings were saved	Mudança de modo BDMA não aplicada\nBDMA revertido; outras configurações foram salvas
+BDMA source backend not ready:	BDMA source backend not ready:
 Boot Page	Página de inicialização
 Boot sound	Som de inicialização
+BOOT.ELF failed to launch	BOOT.ELF failed to launch
 BOOT.ELF not found\nchecked mc0:/BOOT and mc1:/BOOT	BOOT.ELF não encontrado\nverificado mc0:/BOOT e mc1:/BOOT
 Bringing up network...	Ativando a rede...
 Building HDD game list...	Montando lista de jogos do HDD...
@@ -29,21 +37,30 @@ Can't disable while BDMA is enabled\nSet BDMA Mode to FAT32 (None) first	Não é
 Can't disable while SMB modules are installed\nSet SMB modules to Not installed first	Não é possível desativar com os módulos SMB instalados\nDefina os módulos SMB como Não instalados primeiro
 Can't reach the server\ncheck Server IP / Port in SMB settings	Não foi possível acessar o servidor\nverifique o IP / Porta do servidor nas configurações SMB
 Cancel	Cancelar
+Cannot access	Cannot access
 Carousel (default)	Carrossel (padrão)
 Carousel Devices	Dispositivos do carrossel
+Case/Symbols: lower  (R2)	Case/Symbols: lower  (R2)
+Case/Symbols: UPPER  (R2)	Case/Symbols: UPPER  (R2)
 Center aligned	Alinhado ao centro
+check the memory card, or turn Adaptive BDMA off	check the memory card, or turn Adaptive BDMA off
 Code by El_isra	Código por El_isra
 Confirm	Confirmar
 Connecting to SMB...	Conectando ao SMB...
 Couldn't apply the PS2 IP settings\ntry again or power-cycle the network adapter	Não foi possível aplicar as configurações de IP do PS2\ntente novamente ou reinicie o adaptador de rede
 Couldn't read that game selection	Não foi possível ler essa seleção de jogo
+Couldn't restore BDMA mode	Couldn't restore BDMA mode
+Couldn't save settings	Couldn't save settings
 Couldn't save settings -- POPSTARTER folder NOT deleted	Não foi possível salvar -- pasta POPSTARTER NÃO excluída
 Couldn't save settings -- POPSTARTER folder NOT restored	Não foi possível salvar -- pasta POPSTARTER NÃO restaurada
+Couldn't update hidden state	Couldn't update hidden state
+Couldn't write .hide to the HDD	Couldn't write .hide to the HDD
 Cover Art	Capa
 Cover Art disabled	Capa desativada
 Cover Art enabled	Capa ativada
 Cover/details folder	Pasta de capas/detalhes
 Credits	Créditos
+Cursor: L1 / R1	Cursor: L1 / R1
 Delete the POPSTARTER folder from the memory card?	Excluir a pasta POPSTARTER do cartão de memória?
 Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695	Design por Berion\nScripts por nuno6573 e Ripto\nBaseado em Enceladus por Daniel Santos\nTestes por P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k e Comunidade\n\nAgradecimentos especiais a:\nkrHACKen por criar o POPStarter\nuyjulian, fjtrujy, HWC e outros por sempre ajudarem\n\nEste programa é livre e de código aberto\nSe você pagou por ele, foi enganado\n\nProblemas de compatibilidade? Visite:\nyoutube.com/@hugopocked6695
 DHCP (automatic)	DHCP (automático)
@@ -52,8 +69,10 @@ Disc (DKWDRV)	Disco (DKWDRV)
 Discard & Exit	Descartar e Sair
 Display	Tela
 Display reverted -- new mode wasn't confirmed	Tela revertida -- novo modo não confirmado
+DKWDRV failed to launch	DKWDRV failed to launch
 DKWDRV Path	Caminho do DKWDRV
 Don't Save	Não salvar
+Edit	Edit
 Edit DKWDRV Path	Editar caminho do DKWDRV
 Edit POPStarter Path	Editar caminho do POPStarter
 Enable the POPSTARTER Folder first\n(BDMA / SMB modules must live on the memory card)	Ative a pasta POPSTARTER primeiro\n(módulos BDMA / SMB devem ficar no cartão de memória)
@@ -71,15 +90,18 @@ Failed to refresh list	Falha ao atualizar a lista
 FAT32-USB (None)	FAT32-USB (None)
 First disc only	Apenas o primeiro disco
 Game details	Detalhes do jogo
+Game file missing	Game file missing
 Game hidden	Jogo ocultado
 Game List	Lista de jogos
 Game list cache	Cache da lista de jogos
 Game shown	Jogo exibido
 Games path affects browsing only:\nPOPStarter can only launch games from <share>/POPS	O caminho de jogos afeta só a navegação:\nPOPStarter só inicia jogos de <share>/POPS
 HDD Alt mode needs POPSTARTER on HDD	Modo HDD Alt precisa do POPSTARTER no HDD
+HDD dir read failed:	HDD dir read failed:
 HDD list loaded from cache (R1 rescans)	Lista do HDD carregada do cache (R1 rescaneia)
 HDD list refreshed	Lista do HDD atualizada
 HDD list refreshed (no games found)	Lista do HDD atualizada (nenhum jogo encontrado)
+HDD not usable	HDD not usable
 Hidden	Oculto
 Hidden games	Jogos ocultos
 Hidden games are filtered out.\nPress R3 to reveal them, then L3 to unhide.	Jogos ocultos estão filtrados.\nPressione R3 para revelá-los, depois L3 para reexibir.
@@ -101,12 +123,19 @@ Loading HDD...	Carregando HDD...
 Loading MMCE...	Carregando MMCE...
 Loading MX4SIO...	Carregando MX4SIO...
 Loading USB...	Carregando USB...
+Locating exFAT HDD POPS folder...	Locating exFAT HDD POPS folder...
+Looking for USB drive...	Looking for USB drive...
 manually). Your POPSLoader settings are kept.	manualmente). Suas configurações do POPSLoader são mantidas.
 Memory Card	Cartão de memória
+Missing BDMA source (tried):	Missing BDMA source (tried):
+Missing BDMA UI source (tried):	Missing BDMA UI source (tried):
+Missing SMB module (tried):	Missing SMB module (tried):
 MMCE has no POPS folder\nexpected mmce0:/POPS/	MMCE não tem pasta POPS\nesperado mmce0:/POPS/
 Multi-disc games	Jogos multi-disco
 NetBIOS isn't supported\nset Address type = IP + a Server IP	NetBIOS não é suportado\ndefina Tipo de endereço = IP + um IP do servidor
+No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9	No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9
 No cover. Looked for:	Sem capa. Procurado em:
+No DKWDRV found at this path	No DKWDRV found at this path
 No exFAT HDD detected\nformat the internal drive exFAT (BDMA Mode = ATA)	Nenhum HDD exFAT detectado\nformate o drive interno em exFAT (Modo BDMA = ATA)
 No games found	Nenhum jogo encontrado
 No games found on hdd0:\n(__.POPS partitions are empty)	Nenhum jogo encontrado em hdd0:\n(partições __.POPS estão vazias)
@@ -114,6 +143,7 @@ No games found on this device	Nenhum jogo encontrado neste dispositivo
 No MMCE device detected\nchecked mmce0: and mmce1:	Nenhum dispositivo MMCE detectado\nverificado mmce0: e mmce1:
 No MX4SIO device detected	Nenhum dispositivo MX4SIO detectado
 No network link\ncheck the Ethernet cable / adapter	Sem link de rede\nverifique o cabo / adaptador Ethernet
+No POPSTARTER found at this path	No POPSTARTER found at this path
 No Share selected	Nenhum Share selecionado
 No Share set in SMB settings\n(server returned no shares)	Nenhum Share definido nas configurações SMB\n(servidor não retornou shares)
 No USB backend detected\nreseat the drive and try again	Nenhum backend USB detectado\nreconecte o drive e tente novamente
@@ -126,6 +156,7 @@ On (default)	Ligado (padrão)
 On (per-device)	Ligado (por dispositivo)
 Opening SMB list...	Abrindo lista SMB...
 Overscan (CRT inset)	Overscan (recuo CRT)
+Path saved, file not found:	Path saved, file not found:
 POPS (beside game)	POPS (ao lado do jogo)
 POPSLoader\nfor POPStarter	POPSLoader\npara POPStarter
 POPSTARTER Folder	Pasta POPSTARTER
@@ -135,13 +166,16 @@ POPSTARTER Path	Caminho do POPSTARTER
 Press CIRCLE again to discard what you typed	Pressione CIRCLE novamente para descartar o que digitou
 Profile	Perfil
 Profile defaults restored	Padrões do perfil restaurados
+re-select it under Settings > Storage to restage	re-select it under Settings > Storage to restage
 Rebuilding HDD game list...	Reconstruindo lista de jogos do HDD...
 Refreshing HDD list...	Atualizando lista do HDD...
 Refreshing list...	Atualizando lista...
 Rescanning HDD partitions...	Rescaneando partições do HDD...
 Reset	Redefinir
 Reset Defaults	Restaurar padrões
+Resolved:	Resolved:
 Retrying USB scan...	Tentando escanear USB novamente...
+return code:	return code:
 Return to OSDSYS?	Voltar ao OSDSYS?
 return until you turn this back On (or re-add them	voltar até você ligar isso de novo (ou readicioná-los
 Right aligned	Alinhado à direita
@@ -149,6 +183,7 @@ Save	Salvar
 Save Changes	Salvar alterações
 Save Settings	Salvar configurações
 Save your changes before leaving?	Salvar suas alterações antes de sair?
+Saved to	Saved to
 Saving settings	Salvando configurações
 Saving...	Salvando...
 Saving/Applying...	Salvando/Aplicando...
@@ -166,6 +201,7 @@ Share not found\ncheck the Share name (host must allow SMB1)	Share não encontra
 Show all discs	Mostrar todos os discos
 Showing hidden games (dimmed) -- press L3 to unhide	Mostrando jogos ocultos (esmaecidos) -- pressione L3 para reexibir
 Shown	Exibido
+Slot:	Slot:
 SMB / Network	SMB / Rede
 SMB connect failed	Falha na conexão SMB
 SMB connection dropped	Conexão SMB perdida
@@ -177,11 +213,13 @@ SMB modules didn't install/remove\nmodule setting reverted; other settings were 
 SMB modules failed to load	Falha ao carregar módulos SMB
 Startup	Inicialização
 Static (manual)	Estático (manual)
+status:	status:
 Storage	Armazenamento
 This backend isn't implemented yet	Este backend ainda não foi implementado
 This removes the POPSTARTER pack -- including the	Isso remove o pacote POPSTARTER -- incluindo os
 UI text hidden	Texto da interface ocultado
 UI text shown	Texto da interface exibido
+Unknown BDMA mode:	Unknown BDMA mode:
 Video Standard	Padrão de vídeo
 Visible	Visível
 Visible (manage)	Visível (gerenciar)
@@ -190,3 +228,4 @@ X = Keep      O = Revert	X = Manter      O = Reverter
 X = Select      O = Cancel	X = Selecionar      O = Cancelar
 X = Yes      O = No	X = Sim      O = Não
 Yes	Sim
+You can still add a "<game>.hide" next to the .VCD from a PC.	You can still add a "<game>.hide" next to the .VCD from a PC.

--- a/docs/translations/hungarian.tsv
+++ b/docs/translations/hungarian.tsv
@@ -1,25 +1,36 @@
 English (do not edit)	Hungarian (put your translation here)
+(could NOT save -- reverts on reboot)	(could NOT save -- reverts on reboot)
 (not set)	(nincs beállítva)
 (share root)	(gyökérkönyvtár megosztása)
+(the usual settings location wasn't writable)	(the usual settings location wasn't writable)
 (unknown)	(ismeretlen)
+-- launch cancelled	-- launch cancelled
 100M Full	100M teljes
 100M Half	100M fél
 10M Full	10M teljes
 10M Half	10M fél
+About	Névjegy
 Actual output	Aktuális kimenet
 Adaptive BDMA	Adaptív BDMA
+Adaptive BDMA couldn't stage	Adaptive BDMA couldn't stage
+adjusted -- using	adjusted -- using
 APA / PFS (default)	APA / PFS (alapértelmezett)
 Applying BDMA mode	BDMA mód alkalmazása
+Applying SMB modules	Applying SMB modules
 ART (at root)	ART (a főkönyvtárban)
 At least one device must stay on the carousel	Legalább egy eszköznek meg kell maradnia
 Auto (console region)	Automatikus (konzol régiója)
+Automatic	Automatikus
 Back	Vissza
 Backspace	Visszatörlés
 BDMA Mode	BDMA mód
 BDMA mode change didn't apply\nBDMA reverted; other settings were saved	A BDMA-mód váltása nem került alkalmazásra\nA BDMA-mód visszaállt; az egyéb beállítások mentésre kerültek
+BDMA source backend not ready:	BDMA source backend not ready:
 Boot Page	Startlap
 Boot sound	Starthang
+BOOT.ELF failed to launch	BOOT.ELF failed to launch
 BOOT.ELF not found\nchecked mc0:/BOOT and mc1:/BOOT	A BOOT.ELF fájl nem található\nEllenőrizve: mc0:/BOOT és mc1:/BOOT
+Booted from:	Indítva innen:
 Bringing up network...	Hálózat felépítése...
 Building HDD game list...	HDD játéklista összeállítása...
 Building USB game list...	USB játéklista összeállítása...
@@ -28,31 +39,46 @@ Can't disable while BDMA is enabled\nSet BDMA Mode to FAT32 (None) first	A BDMA 
 Can't disable while SMB modules are installed\nSet SMB modules to Not installed first	Az SMB-modulok telepítése mellett nem lehet letiltani\nElőször állítsa az SMB-modulokat „Nincs telepítve” állapotra
 Can't reach the server\ncheck Server IP / Port in SMB settings	Nem sikerült kapcsolatot létesíteni a szerverrel\nEllenőrizze a szerver IP-címét és portját az SMB-beállításokban
 Cancel	Mégsem
+Cannot access	Cannot access
 Carousel (default)	Carousel (alapértelmezett)
 Carousel Devices	Carousel eszközök
+Case/Symbols: lower  (R2)	Case/Symbols: lower  (R2)
+Case/Symbols: UPPER  (R2)	Case/Symbols: UPPER  (R2)
 Center aligned	Középre igazítva
+check the memory card, or turn Adaptive BDMA off	check the memory card, or turn Adaptive BDMA off
+Checking POPSTARTER...	POPSTARTER ellenőrzése...
+Checking the game file...	A játékfájl ellenőrzése...
 Code by El_isra	Kódolás: El_isra
 Confirm	Megerősítés
 Connecting to SMB...	Csatlakozás az SMB-hez...
 Couldn't apply the PS2 IP settings\ntry again or power-cycle the network adapter	A PS2 IP-beállításai nem alkalmazhatók\npróbálja meg újra, vagy indítsa újra a hálózati adaptert
 Couldn't read that game selection	Nem sikerült elolvasni ezt a játékválasztást
+Couldn't restore BDMA mode	Couldn't restore BDMA mode
+Couldn't save settings	Couldn't save settings
 Couldn't save settings -- POPSTARTER folder NOT deleted	A beállítások mentése nem sikerült -- a POPSTARTER mappa NEM került törlésre
 Couldn't save settings -- POPSTARTER folder NOT restored	A beállítások mentése nem sikerült -- a POPSTARTER mappa NEM került visszaállításra
+Couldn't update hidden state	Couldn't update hidden state
+Couldn't write .hide to the HDD	Couldn't write .hide to the HDD
 Cover Art	Borítókép
 Cover Art disabled	Borítóképek letiltva
 Cover Art enabled	Borítóképek engedélyezve
 Cover/details folder	Borító/Részletek mappa
 Credits	Köszönetek
+Cursor: L1 / R1	Cursor: L1 / R1
+Defaults restored	Alapértelmezések visszaállítva
 Delete the POPSTARTER folder from the memory card?	Törli a POPSTARTER mappát a memóriakártyáról?
 Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695	Tervezés: Berion\nSzkriptek: nuno6573 és Ripto\nBázis: Daniel Santos „Enceladus” című munkája\nTesztelés: P4NCHOL1NO, VizoR, provato,\nnuno6573, sAGA/oldman63, saildot4k és a közösség\n\nKülön köszönet:\nkrHACKennek a POPStarter elkészítéséért\nuyjuliannek, fjtrujy-nak, HWC-nek és másoknak a folyamatos segítségért\n\nEz a program ingyenes és nyílt forráskódú\nHa megvásárolta, akkor átverték\n\nKompatibilitási problémák? Látogasson el ide:\nyoutube.com/@hugopocked6695
+Device List	Eszközlista
 DHCP (automatic)	DHCP (automatikus)
 DHCP failed\nset a static IP in SMB settings	A DHCP nem sikerült\nÁllítson be statikus IP-címet az SMB-beállításokban
 Disc (DKWDRV)	Fizikai lemez (DKWDRV)
 Discard & Exit	Elvetés & Kilépés
 Display	Kijelző
 Display reverted -- new mode wasn't confirmed	A kijelzőmód visszaállt -- az új mód nem került megerősítésre
+DKWDRV failed to launch	DKWDRV failed to launch
 DKWDRV Path	DKWDRV útvonal
 Don't Save	Ne mentse el
+Edit	Edit
 Edit DKWDRV Path	DKWDRV útvonal szerkesztése
 Edit POPStarter Path	POPStarter útvonal szerkesztése
 Enable the POPSTARTER Folder first\n(BDMA / SMB modules must live on the memory card)	Először engedélyezze a POPSTARTER mappát\n(a BDMA / SMB moduloknak a memóriakártyán kell lenniük)
@@ -70,25 +96,32 @@ Failed to refresh list	A lista frissítése nem sikerült
 FAT32-USB (None)	FAT32-USB (No BDMA)
 First disc only	Csak az első lemez
 Game details	Játék részletek
+Game file missing	Game file missing
 Game hidden	Játék elrejtése
 Game List	Játéklista
 Game list cache	Játéklista-gyorsítótár
 Game shown	Játék megjelenítése
 Games path affects browsing only:\nPOPStarter can only launch games from <share>/POPS	A játékok elérési útvonala kizárólag a böngészést érinti:\nA POPStarter csak a <share>/POPS mappából indíthat játékokat
 HDD Alt mode needs POPSTARTER on HDD	A HDD Alt módhoz POPSTARTER szükséges a HDD-n
+HDD dir read failed:	HDD dir read failed:
 HDD list loaded from cache (R1 rescans)	A HDD-lista betöltődött a gyorsítótárból (R1 a lista frissítése)
 HDD list refreshed	A HDD-lista frissült
 HDD list refreshed (no games found)	A HDD-lista frissült (nincs játék)
+HDD not usable	HDD not usable
 Hidden	Rejtett
 Hidden games	Rejtett játékok
 Hidden games are filtered out.\nPress R3 to reveal them, then L3 to unhide.	A rejtett játékok kiszűrésre kerülnek.\nNyomja meg az R3 gombot az elrejtéshez, az L3 gombot a megjelenítéshez.
 Hidden games filtered out again	Az elrejtett játékok kiszűrve
 Hide Text	Szöveg elrejtése
 Hide UI Text	UI szövegek elrejtése
+How to hide a game	Hogyan lehet elrejteni egy játékot
+if not confirmed	múlva, ha nincs megerősítve
 Installed	Telepített
 Internal HDD	Belső HDD
+Keep	Megtart
 Keep this display mode?	Megtartja ezt a megjelenítési módot?
 Keyboard Layout	Billentyűzetkiosztás
+L3 on the game list	L3 a játéklistán
 Launch	Indítás
 Launch DKWDRV?	Elindítja a DKWDRV-t?
 Left aligned	Balra igazítva
@@ -100,11 +133,20 @@ Loading HDD...	HDD betöltése...
 Loading MMCE...	MMCE betöltése...
 Loading MX4SIO...	MX4SIO betöltése...
 Loading USB...	USB betöltése...
+Locating exFAT HDD POPS folder...	Locating exFAT HDD POPS folder...
+Looking for USB drive...	Looking for USB drive...
 Memory Card	Memóriakártya
+Menu	Menü
+Missing BDMA source (tried):	Missing BDMA source (tried):
+Missing BDMA UI source (tried):	Missing BDMA UI source (tried):
+Missing SMB module (tried):	Missing SMB module (tried):
 MMCE has no POPS folder\nexpected mmce0:/POPS/	Az MMCE-n nincs POPS mappa\nelvárás az mmce0:/POPS/ mappa
 Multi-disc games	Többlemezes játékok
 NetBIOS isn't supported\nset Address type = IP + a Server IP	A NetBIOS nem támogatott\nállítsa be a címtípust: IP + egy szerver IP-címe
+No	Nem
+No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9	No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9
 No cover. Looked for:	Nincs borító. Itt kerestük:
+No DKWDRV found at this path	No DKWDRV found at this path
 No exFAT HDD detected\nformat the internal drive exFAT (BDMA Mode = ATA)	Nincs észlelt exFAT merevlemez\nformázza le a belső meghajtót exFAT formátumra (BDMA mód = ATA)
 No games found	Nincsenek játékok
 No games found on hdd0:\n(__.POPS partitions are empty)	Nincsenek játékok a hdd0-n:\n(a __.POPS partíciók üresek)
@@ -112,6 +154,8 @@ No games found on this device	Az eszközön nem találhatóak játékok
 No MMCE device detected\nchecked mmce0: and mmce1:	Nem észlelhető MMCE-eszköz\nellenőrizve itt: mmce0: és mmce1:
 No MX4SIO device detected	Nem észlelhető MX4SIO eszköz
 No network link\ncheck the Ethernet cable / adapter	Nincs hálózati kapcsolat\nEllenőrizze az Ethernet-kábelt / adaptert
+No POPSTARTER found at this path	No POPSTARTER found at this path
+No POPSTARTER.ELF found\nchecked the game device, the launcher folder and mc0:/mc1:	Nem található a POPSTARTER.ELF fájl\nellenőrizve itt: a játék eszköze, az indító mappája és mc0:/mc1:
 No Share selected	Nincs kiválasztott megosztás
 No Share set in SMB settings\n(server returned no shares)	Az SMB-beállításokban nincs megadva megosztás\n(a szerver nem adott vissza megosztásokat)
 No USB backend detected\nreseat the drive and try again	Nem észlelhető USB-háttérrendszer\nHelyezze be ismételten a meghajtót, majd próbálja újra
@@ -123,7 +167,9 @@ On	Be
 On (default)	Be (alapértelmezett)
 On (per-device)	Be (eszközönként)
 Opening SMB list...	SMB-lista megnyitása...
+Operation failed	Sikertelen művelet
 Overscan (CRT inset)	Overscan (CRT betét)
+Path saved, file not found:	Path saved, file not found:
 POPS (beside game)	POPS (a játék mellett)
 POPSLoader\nfor POPStarter	POPSLoader\na POPStarter kezeléséhez
 POPSTARTER Folder	POPSTARTER mappa
@@ -131,21 +177,28 @@ POPSTARTER folder deleted from the memory card	A POPSTARTER mappa törölve lett
 POPSTARTER folder restored on the memory card\n(set a BDMA mode to re-add the exFAT/SMB modules)	A POPSTARTER mappa visszaállítva a memóriakártyán\n(állítsa be a BDMA módot az exFAT/SMB modulok újbóli hozzáadásához)
 POPSTARTER Path	POPSTARTER útvonal
 Press CIRCLE again to discard what you typed	Nyomja meg újra a KÖR gombot, hogy törölje a beírt szöveget
+Press CROSS again to discard what you typed	Nyomja meg újra a KERESZT gombot a beírtak elvetéséhez
 Profile	Profil
 Profile defaults restored	Alapértelmezett profilbeállítások visszaállítva
+re-select it under Settings > Storage to restage	re-select it under Settings > Storage to restage
 Rebuilding HDD game list...	A HDD-n lévő játékok listájának ismételt összeállítása...
 Refreshing HDD list...	A HDD-lista frissítése...
 Refreshing list...	Lista frissítése...
 Rescanning HDD partitions...	A merevlemez-partíciók újraszkennelése...
 Reset	Visszaállítás
 Reset Defaults	Alapértelmezések visszaállítása
+Resolved:	Resolved:
 Retrying USB scan...	Az USB-ellenőrzés újraindítása...
+return code:	return code:
 Return to OSDSYS?	Kilépés az OSDSYS-be?
+Revert	Visszavon
+Reverting in	Visszaállítás
 Right aligned	Jobbra igazítva
 Save	Mentés
 Save Changes	Változások mentése
 Save Settings	Beállítások mentése
 Save your changes before leaving?	Elmenti a módosításokat, mielőtt kilép?
+Saved to	Saved to
 Saving settings	Beállítások mentése
 Saving...	Mentés...
 Saving/Applying...	Mentés/Alkalmazás...
@@ -163,6 +216,7 @@ Share not found\ncheck the Share name (host must allow SMB1)	A megosztás nem ta
 Show all discs	Az összes lemez megjelenítése
 Showing hidden games (dimmed) -- press L3 to unhide	Rejtett játékok megjelenítése (elhalványítva) -- az L3 megnyomásával láthatóvá tehetők
 Shown	Megjelenítve
+Slot:	Slot:
 SMB / Network	SMB / Hálózat
 SMB connect failed	Az SMB-kapcsolat sikertelen
 SMB connection dropped	Az SMB-kapcsolat megszakadt
@@ -172,12 +226,18 @@ SMB modules are not installed\nGames list but won't boot without them --\ninstal
 SMB modules are not installed\nGames will list but won't boot -- install them\nvia Settings > SMB modules first	Az SMB-modulok nincsenek telepítve\nA játékok megjelennek a listában, de nem indulnak el -- először telepítse őket\na Beállítások > SMB-modulok menüpontban
 SMB modules didn't install/remove\nmodule setting reverted; other settings were saved	Az SMB-modulok telepítése/eltávolítása nem sikerült\nA modul beállításai visszaálltak; az egyéb beállítások mentésre kerültek
 SMB modules failed to load	Az SMB-modulok betöltése nem sikerült
+Staging drivers for this device	Illesztőprogramok előkészítése ehhez az eszközhöz
+Starting the game...	A játék indítása...
 Startup	Indítás
 Static (manual)	Statikus (manuális)
+status:	status:
 Storage	Tároló
 This backend isn't implemented yet	Ez a háttérrendszer még nincs megvalósítva
+This removes the POPSTARTER pack -- including the\nBDMA and SMB modules -- from mc0: / mc1:. They won't\nreturn until you turn this back On (or re-add them\nmanually). Your POPSLoader settings are kept.	Ezzel eltávolítja a POPSTARTER csomagot -- beleértve a\nBDMA és SMB modulokat -- az mc0: / mc1: eszközökről.\nAddig nem jelennek meg, amíg ezt újra be nem kapcsolja\n(vagy kézzel újra hozzá nem adja). A beállítások megmaradnak.
+Triangle	Háromszög
 UI text hidden	UI szövegek elrejtve
 UI text shown	UI szövegek megjelenítve
+Unknown BDMA mode:	Unknown BDMA mode:
 Video Standard	Videó szabvány
 Visible	Látható
 Visible (manage)	Látható (kezelhető)
@@ -186,25 +246,4 @@ X = Keep      O = Revert	X = Megtart      O = Visszavon
 X = Select      O = Cancel	X = Kiválaszt      O = Mégsem
 X = Yes      O = No	X = Igen      O = Nem
 Yes	Igen
-About	Névjegy
-Automatic	Automatikus
-Booted from:	Indítva innen:
-Defaults restored	Alapértelmezések visszaállítva
-Device List	Eszközlista
-How to hide a game	Hogyan lehet elrejteni egy játékot
-if not confirmed	múlva, ha nincs megerősítve
-Keep	Megtart
-L3 on the game list	L3 a játéklistán
-Menu	Menü
-No	Nem
-Operation failed	Sikertelen művelet
-Press CROSS again to discard what you typed	Nyomja meg újra a KERESZT gombot a beírtak elvetéséhez
-Revert	Visszavon
-Reverting in	Visszaállítás
-Triangle	Háromszög
-No POPSTARTER.ELF found\nchecked the game device, the launcher folder and mc0:/mc1:	Nem található a POPSTARTER.ELF fájl\nellenőrizve itt: a játék eszköze, az indító mappája és mc0:/mc1:
-Checking POPSTARTER...	POPSTARTER ellenőrzése...
-Checking the game file...	A játékfájl ellenőrzése...
-Starting the game...	A játék indítása...
-Staging drivers for this device	Illesztőprogramok előkészítése ehhez az eszközhöz
-This removes the POPSTARTER pack -- including the\nBDMA and SMB modules -- from mc0: / mc1:. They won't\nreturn until you turn this back On (or re-add them\nmanually). Your POPSLoader settings are kept.	Ezzel eltávolítja a POPSTARTER csomagot -- beleértve a\nBDMA és SMB modulokat -- az mc0: / mc1: eszközökről.\nAddig nem jelennek meg, amíg ezt újra be nem kapcsolja\n(vagy kézzel újra hozzá nem adja). A beállítások megmaradnak.
+You can still add a "<game>.hide" next to the .VCD from a PC.	You can still add a "<game>.hide" next to the .VCD from a PC.


### PR DESCRIPTION
## What this is

Groundwork so **oldman63 can finish the Hungarian translations in a PR**. This one adds the missing strings to the sheets; the actual Hungarian goes in on top (his credit).

## The situation

Every string oldman63 has already translated is compiled into the build. Hungarian is in fact the **most complete** language (FR/DE/PT/ES/IT are each 20-27 strings behind it). Nothing of his was dropped.

What was actually "not done": **39 on-screen strings were never added to any translator sheet**, so they render in English for every language, Hungarian included. Those are the ones he red-marked.

## Changes

1. **Removed a leaked template row** from `PLDR.I18N.HU` in `system.lua` (`["English (do not edit)"] = "Hungarian (put your translation here)"`). That was row 1 of the spreadsheet, injected by mistake. Whoever injects a `.tsv` next must skip the header row.
2. **Added all 39 strings to `hungarian.tsv` and `brazilian-portuguese.tsv`** as English-in-both-columns placeholders, with the exact keys, so a translator only overwrites the right column and the string still matches at injection time.

## Safety

- Every existing Hungarian row preserved **byte-for-byte** (verified: 0 lost, 0 altered, 39 added).
- Untranslated (`English == English`) rows are skipped on injection, so **the build is unchanged** until a translator fills them in.
- `system.lua` parses (lupa; the const-loop-var note is the known Lua 5.4 false positive), host harness 21/21.

## For the translator

The 39 new rows are the ones where both columns are identical. Fill in the right column with the Hungarian:

`(could NOT save -- reverts on reboot)`, `(the usual settings location wasn't writable)`, `-- launch cancelled`, `Adaptive BDMA couldn't stage`, `Applying SMB modules`, `BDMA source backend not ready:`, `BOOT.ELF failed to launch`, `Cannot access`, `Case/Symbols: UPPER  (R2)`, `Case/Symbols: lower  (R2)`, `Couldn't restore BDMA mode`, `Couldn't save settings`, `Couldn't update hidden state`, `Couldn't write .hide to the HDD`, `Cursor: L1 / R1`, `DKWDRV failed to launch`, `Edit`, `Game file missing`, `HDD dir read failed:`, `HDD not usable`, `Locating exFAT HDD POPS folder...`, `Looking for USB drive...`, `Missing BDMA UI source (tried):`, `Missing BDMA source (tried):`, `Missing SMB module (tried):`, `No '__.POPS' partitions on hdd0:\nformat one with __.POPS / __.POPS0...9`, `No DKWDRV found at this path`, `No POPSTARTER found at this path`, `Path saved, file not found:`, `Resolved:`, `Saved to`, `Slot:`, `Unknown BDMA mode:`, `You can still add a "<game>.hide" next to the .VCD from a PC.`, `adjusted -- using`, `check the memory card, or turn Adaptive BDMA off`, `re-select it under Settings > Storage to restage`, `return code:`, `status:`

(Some of those tail-fragments like `return code:` / `status:` / `Slot:` get a value appended after them; translate only if it reads naturally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)