### PR TITLE
EXP31: freesio2/freepad — SIO2 arbitration for the MX4SIO 42% freeze (MMCE + MX4SIO coexistence)

### DIFF
--- a/EXPERIMENTAL_NOTES.md
+++ b/EXPERIMENTAL_NOTES.md
@@ -1,7 +1,26 @@
 # POPSLoader: Experimental Build 🧪
 
-**This is the opt-in EXPERIMENTAL channel.** Right now there is nothing experimental in it: this build is **content-identical to the 1.1.0 release and the rolling build** (only the version stamp differs, so reports always name their channel). Every experiment from the 1.1.0 cycle graduated: the storage wave (the 42% fixes, internal exFAT/GPT support, the MMCE/MX4SIO restart dialog, fast staging, cover-art fit) all shipped in **1.1.0**.
+**This is the opt-in EXPERIMENTAL channel.** It exists so testers can try riskier changes in isolation, without them reaching anyone who did not ask for it. The public release (**1.1.0**) and the rolling test build are both untouched by anything here.
 
-**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP30**. Plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release; all three are the same content today.
+**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP31**. The check is simple: a version ending in **-EXP31** = this build; **-EXP30** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
 
-When the next experiment starts, it lands here first, and this file will describe it. Until then, the release or the rolling build are the better installs. Older experiment notes live in the git history of this file.
+**How to go back:** reinstall the latest entry on the Releases page. Nothing here changes your settings, your `POPS` folders, or your games, so switching back and forth is safe.
+
+---
+
+## New in EXP31: MX4SIO that still freezes at 42% with an MMCE adapter also plugged in
+
+**This is for FifthFox's report: the MX4SIO page stuck forever at "Locating MX4SIO POPS folder... 42%", on a slim (SCPH-70012) that has BOTH an MMCE memory-card adapter AND an MX4SIO/SD2PS2TD SD adapter installed at the same time. The same card works in RiptOPL and wLaunchELF-R3Z on that exact console, so the card is fine — this is us.**
+
+**What we found.** The MX4SIO SD driver does not own the SIO2 bus by itself; it *hooks* the shared `sio2man` module and lets `sio2man` take turns between it and everything else on that bus — the controller, the memory-card reader, MMCE. POPSLoader ships Sony's stock `sio2man`, which does not arbitrate those turns. So when a **second** SIO2 device is physically in the console (your MMCE adapter sitting alongside the MX4SIO adapter), the memory-card reader and the MX4SIO card talk over each other on the bus and the read never comes back — the screen is frozen on the last thing it painted, "…42%". That is why the earlier driver-matching fix did not help you: it fixed a different 42% cause and never touched the bus manager. Single-adapter rigs (only MX4SIO, or only MMCE) do not hit it, which is why it did not reproduce here.
+
+**What changed.** EXP31 swaps the SIO2 bus manager to **freesio2** (and its matching **freepad**), the queue-based versions that **OPL, wLaunchELF-R3Z and RiptOPL all use** — the launchers where your card already works. That is the whole change: same driver binaries the working references run, nothing else. It is a build-time blob swap, so it is easy to pull back if it misbehaves.
+
+**Honest status:** this is the fix the *working* launchers use, not yet a fix we have watched clear your console — SIO2 timing is only provable on real hardware, so EXP31 is exactly that test.
+
+**What to test (FifthFox, whenever you are back):** update to EXP31 with **both** adapters installed as before, open the **MX4SIO** page, and give it up to two minutes.
+- If your games list appears — that is the win we are after.
+- If it says **"No MX4SIO device detected"** after a few seconds instead of freezing — tell us; that means the deadlock is gone but detection still needs work (a different, smaller step), not another hard freeze.
+- If it still freezes at 42% — tell us that too; then freesio2 is not the whole story and the next build adds a safety net so the page can never hard-freeze.
+
+Because this swaps the bus manager that *everything* on SIO2 shares, please also give these a quick confirm on EXP31: **controllers still navigate the menu**, **memory-card save/settings still work**, **MMCE still lists games**, and (if you use it) **USB-pad / DualShock emulation still works**. If any of those regressed, that is important — say so and we pair freesio2 back with the stock pad driver.

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,29 @@ IRXTAG = $(subst -,_,$(notdir $(addsuffix _irx, $(basename $<))))
 $(EE_ASM_DIR)ps2ip.c: ps2ip-nm.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ ps2ip_irx
 
+# EXP31 -- SIO2 arbitration for MX4SIO coexistence.
+# mx4sio_bd is an SD-over-SPI block device that does NOT raw-drive SIO2: it hooks the
+# sio2man MODULE (sio2man_hook_init, confirmed in the mx4sio_bd.irx imports) and relies
+# on sio2man to serialize its transfers against the other SIO2 clients -- mcman's
+# memory-card polling, padman's per-vblank controller reads, mmceman. Stock ps2sdk
+# sio2man does no such arbitration, so when a SECOND SIO2/MC-slot device is physically
+# present (a tester's MMCE adapter alongside the MX4SIO/SD2PS2TD adapter) the MX4SIO
+# probe collides with mcman on the shared bus and the fileXio call never returns --
+# the "Locating MX4SIO POPS folder... 42%" freeze that SURVIVES the matched-BDM-set fix
+# (that fix only unified bdm/bdmfs_fatfs/usbmass_bd/mx4sio_bd; it never touched sio2man).
+# OPL / wLaunchELF_R3Z / RiptOPL all ship freesio2 (the queue-based sio2man
+# reimplementation) paired with freepad, and run mmceman+mx4sio_bd concurrently with no
+# exclusion. Build sio2man_irx / padman_irx from those blobs -- a MATCHED pair, exactly
+# as open-ps2-loader does; shipping freesio2 with stock padman would be a novel untested
+# combo (the same class of mistake as the c1debd1 half-swap). The C externs
+# (sio2man_irx / padman_irx in main.cpp) are UNCHANGED -- only the source blob differs.
+# Explicit rules override the generic %.c:%.irx below; sources resolve via the vpath.
+$(EE_ASM_DIR)sio2man.c: freesio2.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ sio2man_irx
+
+$(EE_ASM_DIR)padman.c: freepad.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ padman_irx
+
 $(EE_ASM_DIR)%.c: %.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ $(IRXTAG)
 

--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,9 +1,9 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.1.1-dev-EXP30
+Title=POPSLoader 1.1.1-dev-EXP31
 CfgVersion=8
 $ConfigSource=1
-Version=1.1.1-dev-EXP30
+Version=1.1.1-dev-EXP31
 Package=1
 Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.1.1-dev-EXP30"
+POPSLDR_VER = "v1.1.1-dev-EXP31"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)


### PR DESCRIPTION
## What this is

EXP31 for the **experimental** channel — the residual MX4SIO 42% freeze FifthFox still hits **on 1.1.0** (he has the latest; it wasn't a stale build).

## The bug

On FifthFox's rig — SCPH-70012 slim with **both** an MMCE adapter *and* an MX4SIO/SD2PS2TD adapter installed at once — the MX4SIO page freezes forever at `Locating MX4SIO POPS folder... 42%`. The same card works in **RiptOPL** and **wLaunchELF-R3Z** on that exact console, so it's us. The maintainer can't reproduce it because single-adapter testing never creates the condition.

## Root cause (why the matched-BDM-set fix didn't help)

`mx4sio_bd` does **not** raw-drive SIO2 — `strings` on the driver binary shows it imports `sio2man` and calls `sio2man_hook_init`. It *hooks* the `sio2man` module and relies on `sio2man` to serialize its SD-over-SPI transfers against the other SIO2 clients (`mcman`'s memory-card polling, `padman`'s controller reads, `mmceman`).

POPSLoader ships Sony's **stock `sio2man`**, which does no such arbitration. The SIO2-owner exclusion guard only reads the `mmceman`/`mx4sio_bd` load-latches (`getSio2Owner`, `luasystem.cpp:230`), so it's blind to the always-resident `mcman` polling a *physically present* MMCE card. With two SIO2/MC-slot devices live, the post-load `fileXio` probe (`GetMassMountDriver`/`doesFolderExist`, no timeout) collides with `mcman` on the bus and never returns → permanent 42% freeze. This is the same "no mutual arbitration" mechanism `STATE.md:178` documents for the 48% MMCE-after-MX4SIO case — but on the MX4SIO-first side the guard can't fire.

## The change

Swap the SIO2 bus manager to **`freesio2`** (queue-based `sio2man` reimplementation) + its matching **`freepad`** — the exact pair OPL / wLaunchELF-R3Z / RiptOPL all ship, i.e. the launchers where FifthFox's card already works. Shipped as a **matched pair** (not `freesio2` alone) to avoid a novel untested driver combo — the `c1debd1` half-swap lesson.

- **Build-time blob swap only.** Explicit Makefile rules (mirroring the existing `ps2ip.c` rule) emit the same `sio2man_irx` / `padman_irx` symbols, so `main.cpp` and all C are unchanged. **Zero code-logic changes** → nothing new to break, trivially revertible.
- Version stamped `1.1.1-dev-EXP31`; tester-facing `EXPERIMENTAL_NOTES.md` entry added.

## Scope / follow-up

Deliberately kept to the **single variable** (the driver swap) per the experimental channel's design, so the HW result is interpretable. If `freesio2` alone doesn't fully clear it, the planned **EXP32** adds an async-probe backstop (move MX4SIO detection to a worker with a bounded poll, like `initATAAsync`) so the page can never *hard-freeze* regardless.

## Honesty / risk

This is the fix the *working* references use — not yet one confirmed on FifthFox's console. SIO2 timing is HW-only-verifiable, so this build **is** the test. Because it swaps the manager all SIO2 shares, the notes ask FifthFox to also confirm **controllers, memory-card, MMCE, and USB-pad emulation** still work; if any regressed we pair `freesio2` back with stock `padman`.

## Validation

- Host harness **21/21**, `boot.lua` parses.
- Full EE build + `ps2dev:v2.0.0` `freesio2.irx`/`freepad.irx` availability are validated by CI (`compilation.yml`) on this push.

## Publishing note

`experimental-release.yml` builds/publishes **only on push to `experimental`** (no PR trigger, by design). **Merging this PR** into `experimental` is what cuts the EXP31 pre-release for FifthFox to install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9)_