### PR TITLE
EXP35: fix two EXP34 regressions — exFAT boot black-screen + MX4SIO memory crash; hard-lock cover art

### DIFF
--- a/EXPERIMENTAL_NOTES.md
+++ b/EXPERIMENTAL_NOTES.md
@@ -2,9 +2,28 @@
 
 **This is the opt-in EXPERIMENTAL channel.** It exists so testers can try riskier changes in isolation, without them reaching anyone who did not ask for it. The public release (**1.1.0**) and the rolling test build are both untouched by anything here.
 
-**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP34**. The check is simple: a version ending in **-EXP34** = this build; **-EXP33** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
+**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP35**. The check is simple: a version ending in **-EXP35** = this build; **-EXP34** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
 
 **How to go back:** reinstall the latest entry on the Releases page. Nothing here changes your settings, your `POPS` folders, or your games, so switching back and forth is safe.
+
+---
+
+## New in EXP35: two EXP34 regressions fixed (boot black-screen, MX4SIO memory crash) + cover art hard-locked
+
+EXP34's testing turned up two regressions the new defaults introduced. EXP35 fixes both and simplifies the cover system so it can't misbehave again.
+
+**Boot no longer probes the internal exFAT drive.** EXP34 made *Internal HDD = Both* the default, and a leftover rule warmed up the exFAT drive **at every boot** because of it. On at least one console (a 4TB GPT exFAT internal drive) that boot-time probe **black-screened the machine before the menu** — an unrecoverable boot. EXP35 stops probing exFAT at boot entirely: the exFAT page brings the drive up **when you open it** (screen stays alive; if the drive is slow it says "still starting" instead of freezing), exactly like every other device. A normal boot never touches the internal drive now. *(If you deliberately launch straight to the exFAT page with a `-page=ata` argument, that still pre-warms it — you asked for that page.)*
+
+**MX4SIO no longer lags-then-crashes on cover art.** EXP34 added a folder-listing step to the cover lookup; on MX4SIO that step could run away and end in an **"Enceladus ERROR! not enough memory"** crash after browsing a few games. That step is **removed**. Combined with the change below, looking up a cover is now a single, bounded file check per game.
+
+**Cover art is hard-locked to one place and one name.** No more folder setting. Covers are read from **`<device>:/ART/<gamename>_COV.png`** — the OPL layout — full stop. (The internal HDD keeps its fixed `__common/POPS/ART/` location.) One folder, one name, so put `<GameID>_COV.png` files in `<device>:/ART/` and they show. The *Cover/details folder* setting is gone (it did nothing useful and was a foot-gun).
+
+**Honest status:** the boot-probe removal directly addresses the black-screen mechanism, and the cover crash's most likely cause (the new listing step) is gone. Both are the kind of fault only your consoles can fully confirm — so this build is the test. If MX4SIO still misbehaves *with cover art turned off* (Square), that points past the art code at the device layer, and that's the next thread to pull.
+
+**What to test on EXP35:**
+- **sAGA / anyone with an internal exFAT drive:** does it boot to the menu now (no black screen)? Then open the exFAT page and see if the drive lists.
+- **MX4SIO:** browse the game list — does it stay responsive without the memory crash? If it still stalls, try it again with **Cover Art OFF (Square)** and say whether that changes anything.
+- **Covers:** put your art at `<device>:/ART/<name>_COV.png` and confirm it shows.
 
 ---
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -9210,10 +9210,19 @@ PLDR.AutoInitStartupBackends()
 -- is usually already done-ok. PFS-only installs skip this entirely -- they
 -- never pay for a drive they don't use.
 do
-  local want_ata_boot = (PLDR.NormalizeHddFs(PLDR.HDD_FS) ~= "PFS")
-  if not want_ata_boot and type(PLDR.IsExplicitATASession) == "function" then
-    want_ata_boot = (PLDR.IsExplicitATASession() == true)
-  end
+  -- EXP35: do NOT warm up exFAT at boot just because the Internal-HDD setting
+  -- INCLUDES it. EXP34's new HDD_FS=BOTH default made this fire on EVERY boot,
+  -- and on sAGA's 4TB GPT exFAT internal drive the boot-time ata_bd bring-up
+  -- BLACK-SCREENED the console before the menu (2026-07-22) -- a boot the user
+  -- can't recover from without reinstalling. The exFAT page already kicks the
+  -- ata worker itself on entry (async, bounded to OPL's ~10s budget, screen
+  -- alive, NEVER a synchronous load -- see the GBDMHDD loader), so the boot
+  -- warm-up was only a perf pre-load, not a correctness requirement. Keep it
+  -- ONLY for an explicit -page=ata launch (the user opted straight into that
+  -- page and accepts the pre-warm); a normal boot no longer probes exFAT at all,
+  -- matching the lazy-load rule every other device already follows.
+  local want_ata_boot = (type(PLDR.IsExplicitATASession) == "function")
+                        and (PLDR.IsExplicitATASession() == true)
   if want_ata_boot and type(System) == "table" and type(System.initATAAsync) == "function" then
     pcall(System.initATAAsync)
   end

--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,9 +1,9 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.1.1-dev-EXP34
+Title=POPSLoader 1.1.1-dev-EXP35
 CfgVersion=8
 $ConfigSource=1
-Version=1.1.1-dev-EXP34
+Version=1.1.1-dev-EXP35
 Package=1
 Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -229,39 +229,25 @@ local function BuildCoverCandidates(vcd_path, use_hdd_common_art, entry)
     return {}
   end
   local base = StripExtension(vcd_path)
-  -- Cover/details FOLDER is user-selectable (Settings > Game List > "Cover/details folder",
-  -- PLDR.ART_LOCATION). EXP34: exactly ONE location is probed (maintainer directive -- no
-  -- beside-the-.vcd fallback), and the OPL standard "<name>_COV.png" is the ONLY accepted
-  -- cover name (no legacy "<name>.png"). Locations: "art" (default) = a top-level
-  -- <device>:/ART/ folder (OPL's mass:/ART layout); "pops_art" = a <gamedir>/ART/ subfolder;
-  -- "pops" = the game's own folder beside the .vcd. Within that one folder the disc-marker-
-  -- stripped name is tried first (one file serves every disc of a multi-disc game), then the
-  -- exact per-disc name. The .txt details sidecar rides this list (<name>_COV.png -> <name>.txt).
-  -- CoverCache lists each folder ONCE (dir_listing) so a missing cover is an instant set
-  -- lookup, never a per-file FAT dir-walk (the MX4SIO/USB "art lookup lag").
+  -- EXP35: cover location is HARD-LOCKED to <device-root>/ART/<name>_COV.png on
+  -- removable devices (OPL standard, maintainer decision -- no ART_LOCATION choice
+  -- anymore). ONE folder (the device root's ART/), ONE name (the OPL "_COV.png"),
+  -- so at most one bounded fopen per game. A multi-disc game falls back to the
+  -- disc-marker-stripped name so one cover serves every disc. The <name>.txt
+  -- details sidecar rides the same folder. (HDD/PFS keeps its fixed
+  -- __common/POPS/ART/ layout -- handled in the use_hdd_common_art branch above.)
   local dir, name = string.match(base, "^(.*/)([^/]+)$")
   if dir == nil then dir, name = "", base end
   local stripped = StripDiscMarker(name)
   local has_stripped = (stripped ~= "" and stripped ~= name)
-  local loc = (type(PLDR) == "table" and PLDR.ART_LOCATION) or "art"
+  local artdir = (string.match(dir, "^(%a+%d*:/)") or dir).."ART/"
   local out, seen = {}, {}
-  local function add_variant(d, bn)
-    -- OPL standard "<name>_COV.png" only.
-    local pc = d..bn.."_COV.png"
-    if not seen[pc] then seen[pc] = true; out[#out + 1] = pc end
+  local function add_variant(bn)
+    local p = artdir..bn.."_COV.png"
+    if not seen[p] then seen[p] = true; out[#out + 1] = p end
   end
-  local function add_dir(d)
-    if d == nil or d == "" then return end
-    if has_stripped then add_variant(d, stripped) end
-    add_variant(d, name)
-  end
-  if loc == "art" then
-    add_dir((string.match(dir, "^(%a+%d*:/)") or dir).."ART/")
-  elseif loc == "pops" then
-    add_dir(dir)   -- the game's own folder (beside the .vcd)
-  else  -- "pops_art" (and any unknown value): <gamedir>/ART/
-    add_dir(dir.."ART/")
-  end
+  if has_stripped then add_variant(stripped) end
+  add_variant(name)
   return out
 end
 -- Read a game's "<name>.txt" details sidecar. Bounded so a stray huge file can't
@@ -325,7 +311,6 @@ local CoverCache = {
   entries = {},
   order = {},
   failed = {},
-  dir_listing = {},  -- EXP34: dir -> set of lowercased filenames present (or false = listing unavailable, don't gate)
   last_key = nil,
   last_img = nil,
   last_desc = nil,
@@ -343,7 +328,6 @@ function CoverCache:Clear()
   end
   self.order = {}
   self.failed = {}
-  self.dir_listing = {}  -- EXP34: drop cached folder listings (R1 refresh / device switch = fresh disk view)
   self.last_key = nil
   self.last_img = nil
   self.last_desc = nil
@@ -371,50 +355,16 @@ function CoverCache:ReleaseTextures()
   self.last_desc_lines = nil
   self.desc_scroll = 0
   self.last_cover_probe = nil
-  -- self.failed AND self.dir_listing intentionally preserved: both reflect on-disk
-  -- state keyed by absolute path, so re-entering the SAME device skips the re-walk;
+  -- self.failed intentionally preserved: it reflects on-disk state keyed by absolute
+  -- path, so re-entering the SAME device skips re-probing covers already known absent;
   -- a different device uses different paths (no collision) and R1 does a full Clear.
 end
--- EXP34: existence via ONE cached directory listing instead of blind per-file fopens.
--- A missing cover was a full FAT dir-chain walk per candidate (seconds on SD-over-SIO2
--- / USB 1.1 -- the reported "art lookup lag" / MX4SIO "extended freeze"). Now each folder
--- is listed once (memoized in dir_listing) and a cover's existence is an O(1) set lookup;
--- only a genuinely-present file is ever opened. If a folder can't be listed, cache a
--- sentinel and fall back to the fopen path so a listing-hostile driver never regresses.
-function CoverCache:ListDirSet(dir)
-  if type(System) ~= "table" or type(System.listDirectory) ~= "function" then return false end
-  local function build(d)
-    local ok, DIR = pcall(System.listDirectory, d)
-    if not ok or type(DIR) ~= "table" then return nil end
-    local s = {}
-    for i = 1, #DIR do
-      local e = DIR[i]
-      if type(e) == "table" and type(e.name) == "string" and not e.directory then
-        s[string.lower(e.name)] = true
-      end
-    end
-    return s
-  end
-  local s = build(dir)
-  if s == nil then
-    -- Retry without the trailing slash (some fileXio backends want the bare dir).
-    local bare = string.gsub(dir, "/+$", "")
-    if bare ~= "" and bare ~= dir then s = build(bare) end
-  end
-  if s == nil then return false end
-  return s
-end
-function CoverCache:DirHas(path)
-  local dir, file = string.match(path, "^(.*/)([^/]+)$")
-  if dir == nil or file == nil then return true end  -- unparseable: don't gate
-  local set = self.dir_listing[dir]
-  if set == nil then
-    set = self:ListDirSet(dir)
-    self.dir_listing[dir] = set
-  end
-  if set == false then return true end  -- listing unavailable: don't gate (fall back to fopen)
-  return set[string.lower(file)] == true
-end
+-- EXP35: the EXP34 dir-listing existence cache (CoverCache:ListDirSet / :DirHas,
+-- backed by self.dir_listing) was REMOVED -- it ran System.listDirectory
+-- (opendir/readdir) on the cover folder, which on the MX4SIO bdmfs_fatfs backend
+-- correlated with a per-navigation lag ending in "not enough memory" (2026-07-22).
+-- Cover existence is a single bounded Graphics.loadImage (fopen) again; misses are
+-- memoized in self.failed. See CoverCache:GetOrLoad.
 function CoverCache:EvictIfNeeded()
   while #self.order > self.max do
     local evict_key = table.remove(self.order, 1)
@@ -440,13 +390,14 @@ function CoverCache:GetOrLoad(path)
     self.failed[path] = true
     return nil
   end
-  -- EXP34: gate on the cached folder listing so a missing cover is an instant set
-  -- lookup, not an fopen dir-walk. DirHas returns true when it can't list the folder,
-  -- so a listing-hostile driver still falls through to the fopen path below.
-  if not self:DirHas(path) then
-    self.failed[path] = true
-    return nil
-  end
+  -- EXP35: the EXP34 dir-listing gate was REMOVED here. On MX4SIO the maintainer
+  -- hit per-navigation lag ending in an "Enceladus ERROR! not enough memory" crash
+  -- (2026-07-22); `System.listDirectory` (opendir/readdir) on `mass:/ART/` over the
+  -- bdmfs_fatfs backend is the prime suspect (a runaway/leaky dir walk on a missing
+  -- or quirky folder), and it was the one thing EXP34 newly ran on the cover path.
+  -- Cover existence is back to a single bounded `Graphics.loadImage` (fopen) below --
+  -- and thanks to the EXP34 single-location + `_COV`-only change that is ONE candidate
+  -- per game, not the old 4-candidate ladder, with `self.failed` memoizing each miss.
   -- Load straight through Graphics.loadImage (fopen) with no separate doesFileExist() open()
   -- pre-probe. In ps2sdk fopen and open both funnel through the SAME libcglue _open
   -- (ee/libcglue/src/glue.c -> __path_absolute), so an open() existence check and an fopen()
@@ -4483,29 +4434,10 @@ UI = {
           function() UI.DetailsAlign = DetailsAlignStep(UI.DetailsAlign, -1) end,
           function() return tostring(UI.DetailsAlign) ~= tostring(UI.SettingsEntryDetailsAlign) end
         )
-        -- Where REMOVABLE-device cover .png + details .txt are looked for (HDD keeps its
-        -- __common/POPS/ART layout). "POPS/ART" is the default; the game's own POPS folder
-        -- (beside the .vcd) is always also checked as a back-compat fallback.
-        local ART_LOCATION_SEQ = {"pops_art", "pops", "art"}
-        -- Spell the paths out with the device prefix. "POPS/ART" alone was
-        -- ambiguous enough that R3Z3N had to ask "I presume you mean
-        -- device:/POPS/ART?" (review round 3) -- so just say so.
-        local ART_LOCATION_TXT = {pops = "device:/POPS", pops_art = "device:/POPS/ART", art = "device:/ART"}
-        local function ArtLocationStep(cur, dir)
-          local idx = 1
-          for i = 1, #ART_LOCATION_SEQ do
-            if ART_LOCATION_SEQ[i] == cur then idx = i; break end
-          end
-          idx = ((idx - 1 + dir) % #ART_LOCATION_SEQ) + 1
-          return ART_LOCATION_SEQ[idx]
-        end
-        AddCycle(
-          "Cover/details folder",
-          function() return ART_LOCATION_TXT[UI.ArtLocation] or "device:/POPS/ART" end,
-          function() UI.ArtLocation = ArtLocationStep(UI.ArtLocation, 1) end,
-          function() UI.ArtLocation = ArtLocationStep(UI.ArtLocation, -1) end,
-          function() return tostring(UI.ArtLocation) ~= tostring(UI.SettingsEntryArtLocation) end
-        )
+        -- EXP35: the "Cover/details folder" (ART_LOCATION) row was REMOVED -- cover
+        -- art is now HARD-LOCKED to <device-root>/ART/<name>_COV.png (OPL standard,
+        -- maintainer). There is no folder choice to make anymore; ART_LOCATION is kept
+        -- inert in the settings file only so older sidecars still parse.
         AddCycle(
           "Game list cache",
           function() return UI.GameListCache and "On" or "Off" end,

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.1.1-dev-EXP34"
+POPSLDR_VER = "v1.1.1-dev-EXP35"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)


### PR DESCRIPTION
## What this is

Field fixes for two regressions EXP34's new defaults introduced, plus the maintainer's cover-art simplification.

## 1. Boot black-screen (sAGA — 4TB GPT exFAT internal, mc1/FMCB boot)

EXP34 made `HDD_FS=BOTH` the default. That flipped the boot-time exFAT warm-up gate — `want_ata_boot = NormalizeHddFs(HDD_FS) ~= "PFS"` — **ON for every boot**, so `do_boot_init` kicked `ata_bd` at boot even for users who never open the exFAT page. On a 4TB GPT exFAT drive that boot-time bring-up **black-screened the console before the menu** (unrecoverable).

The exFAT page already inits `ata` **lazily on entry** (async, bounded to OPL's ~10s budget, screen-alive, *never* synchronous — see the `GBDMHDD` loader). So the boot warm-up was only a perf pre-load, not a correctness requirement. **Gated it to an explicit `-page=ata` session only** — a normal boot no longer probes exFAT at all, matching the lazy-load rule every other device follows.

## 2. MX4SIO "not enough memory" crash + per-navigation lag (maintainer)

Browsing the MX4SIO list lagged on each game and eventually crashed with *"Enceladus ERROR! not enough memory"*. **Removed the EXP34 cover dir-listing cache** (`CoverCache:ListDirSet`/`:DirHas` + `self.dir_listing`): it ran `System.listDirectory` (`opendir`/`readdir`) on the cover folder, and on the MX4SIO `bdmfs_fatfs` backend that's the prime suspect for a runaway/leaky walk. Cover existence is a single bounded `Graphics.loadImage` (`fopen`) again, misses memoized in `self.failed`. `load_image`/`freeImage` were both verified leak-free on the missing-cover and evict paths.

## 3. Cover art hard-locked (maintainer directive)

`BuildCoverCandidates` (removable) is now fixed to **`<device-root>/ART/<name>_COV.png`** — the OPL standard, no `ART_LOCATION` choice. Removed the *Cover/details folder* settings row (it did nothing hard-locked). HDD keeps its fixed `__common/POPS/ART/`. `ART_LOCATION` stays inert in the settings file so old sidecars still parse.

## Testing

- Host harness **29/29**.
- The boot-warm-up and cover changes are hardware-provable only; the notes ask sAGA to confirm the boot reaches the menu, and the maintainer to retry MX4SIO (and once with Cover Art OFF, which isolates any residual to the device layer vs the art code).

Version stamped `v1.1.1-dev-EXP35`. Tester notes added to `EXPERIMENTAL_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9)_