### PR TITLE
EXP36: resolve mass slots directly via BDM enumeration (no per-slot devctl scan)

### DIFF
--- a/EXPERIMENTAL_NOTES.md
+++ b/EXPERIMENTAL_NOTES.md
@@ -2,9 +2,23 @@
 
 **This is the opt-in EXPERIMENTAL channel.** It exists so testers can try riskier changes in isolation, without them reaching anyone who did not ask for it. The public release (**1.1.0**) and the rolling test build are both untouched by anything here.
 
-**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP35**. The check is simple: a version ending in **-EXP35** = this build; **-EXP34** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
+**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP36**. The check is simple: a version ending in **-EXP36** = this build; **-EXP35** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
 
 **How to go back:** reinstall the latest entry on the Releases page. Nothing here changes your settings, your `POPS` folders, or your games, so switching back and forth is safe.
+
+---
+
+## New in EXP36: devices identify themselves directly (no more per-slot probing)
+
+This is a device-layer cleanup that should make the MX4SIO and exFAT pages both **faster and steadier**, and is the right way to have done it from the start.
+
+**The change.** When POPSLoader opens the MX4SIO page (or the exFAT page), it already knows which driver it just loaded — so it now asks the driver **directly** which storage slot it owns, using the enumeration the PS2 SDK already provides. Previously it did the opposite: it opened *every* `mass0:`…`mass9:` slot in turn and asked each one "who are you?" That per-slot interrogation is slow, and on a drive that's still spinning up it could **stall the console** — a plausible contributor to the "carousel appears then freezes" report. The per-slot interrogation is gone from these pages; the slower query now survives in exactly one place where it's genuinely needed (working out what an *old launcher* handed us when it boots us from a generic `mass:` path).
+
+**Why it's safe.** Same drives, same files, same folders — only *how the page finds the right slot* changed, from "scan and ask everyone" to "ask the one driver we loaded." CosmicScale's exFAT drive is reached the same way, just directly. If the direct enumeration is ever unavailable, it falls back to the old scan, so nothing hard-breaks. The device layer now has 30 host-side tests (up from 29), including one that proves the page resolves its slot from the enumeration with **zero** per-slot probing.
+
+**What to test on EXP36:**
+- **MX4SIO and exFAT pages:** do they open at least as quickly as before, and steadily? (This change is aimed squarely at the freeze/stall path.)
+- Everything from EXP35 still applies — the boot no longer probes exFAT, covers live at `<device>:/ART/<name>_COV.png`.
 
 ---
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -6105,34 +6105,59 @@ local function BuildMassRootIdentity(mode)
   local seen_mx4 = {}
   local seen_ata = {}
 
-  for slot = 0, 9 do
-    local root = (slot == 0) and "mass:/" or ("mass"..tostring(slot)..":/")
-    local normalized = NormalizeMassRoot(root)
-    if normalized ~= nil and doesFolderExist(normalized) then
-      if seen_present[normalized] ~= true then
-        seen_present[normalized] = true
-        table.insert(identity.present_roots, normalized)
-      end
+  local function record(normalized, kind)
+    if normalized == nil then return end
+    if seen_present[normalized] ~= true then
+      seen_present[normalized] = true
+      table.insert(identity.present_roots, normalized)
+    end
+    if kind == "mx4sio" then
+      if seen_mx4[normalized] ~= true then seen_mx4[normalized] = true; table.insert(identity.mx4sio, normalized) end
+    elseif kind == "ata" then
+      if seen_ata[normalized] ~= true then seen_ata[normalized] = true; table.insert(identity.ata, normalized) end
+    else
+      if seen_usb[normalized] ~= true then seen_usb[normalized] = true; table.insert(identity.usb, normalized) end
+    end
+  end
 
-      -- Only classify mounted roots. Probing absent slots can be slow and can
-      -- produce unstable driver readings on some hardware.
-      local driver = PLDR.GetMassMountDriver(normalized)
-      local kind = ClassifyMassRootDriver(driver)
-      if kind == "mx4sio" then
-        if seen_mx4[normalized] ~= true then
-          seen_mx4[normalized] = true
-          table.insert(identity.mx4sio, normalized)
+  -- EXP36: resolve each mass slot DIRECTLY from the BDM device enumeration
+  -- (System.bdmList -> bdm_query.irx -> PS2SDK bdm_get_bd). Each connected block
+  -- device already carries its driver name AND its own mass unit (parId), so we
+  -- map driver->slot with ZERO per-slot devctl scan. This is the modern
+  -- SDK-blessed path (maintainer): the old "open every mass0..9 and
+  -- getMassMountDriver each" walk (a fileXioIoctl2 per slot) is what could stall
+  -- the carousel on a mid-bringup/flaky ATA slot, and devctl now survives ONLY in
+  -- the legacy-cwd normalizer (classify_mass_boot). We still doesFolderExist each
+  -- resolved root so a device that is enumerated-but-not-yet-mounted is skipped.
+  local used_bdm = false
+  if type(System) == "table" and type(System.bdmList) == "function" then
+    local ok, list = pcall(System.bdmList)
+    if ok and type(list) == "table" then
+      used_bdm = true
+      for i = 1, #list do
+        local d = list[i]
+        if type(d) == "table" and d.parId ~= nil then
+          local n = tonumber(d.parId)
+          if n ~= nil and n >= 0 then
+            local root = (n == 0) and "mass:/" or ("mass"..tostring(n)..":/")
+            local normalized = NormalizeMassRoot(root)
+            if normalized ~= nil and doesFolderExist(normalized) then
+              record(normalized, ClassifyMassRootDriver(d.name))
+            end
+          end
         end
-      elseif kind == "ata" then
-        if seen_ata[normalized] ~= true then
-          seen_ata[normalized] = true
-          table.insert(identity.ata, normalized)
-        end
-      else
-        if seen_usb[normalized] ~= true then
-          seen_usb[normalized] = true
-          table.insert(identity.usb, normalized)
-        end
+      end
+    end
+  end
+
+  -- Last-resort fallback ONLY when the BDM enumeration is unavailable (bdm_query
+  -- RPC down): the legacy per-slot devctl scan, so a page never hard-breaks.
+  if not used_bdm then
+    for slot = 0, 9 do
+      local root = (slot == 0) and "mass:/" or ("mass"..tostring(slot)..":/")
+      local normalized = NormalizeMassRoot(root)
+      if normalized ~= nil and doesFolderExist(normalized) then
+        record(normalized, ClassifyMassRootDriver(PLDR.GetMassMountDriver(normalized)))
       end
     end
   end

--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,9 +1,9 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.1.1-dev-EXP35
+Title=POPSLoader 1.1.1-dev-EXP36
 CfgVersion=8
 $ConfigSource=1
-Version=1.1.1-dev-EXP35
+Version=1.1.1-dev-EXP36
 Package=1
 Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.1.1-dev-EXP35"
+POPSLDR_VER = "v1.1.1-dev-EXP36"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -960,6 +960,46 @@ t28 = E('''function()
 end''')()
 check("T28 EXP34 config defaults: ART=art, HDD=BOTH, i.Link hidden, SMB/network block", t28)
 
+# T29 EXP36: mass slots resolve DIRECTLY from System.bdmList (each BDM device's own
+# parId -> massN:/), with NO per-slot devctl scan. ata on parId 0 -> mass:/, the
+# mx4sio (sdc) device on parId 1 -> mass1:/. PLDR.GetMassMountDriver is a tripwire:
+# if the direct path is taken it must never be consulted.
+t29 = lua.execute(r'''
+  System.initMX4SIO = function() return true end
+  System.initATAAsync = function() return 2 end
+  System.initATAStatus = function() return 2 end
+  local real_dfe = doesFolderExist
+  local real_drv = PLDR.GetMassMountDriver
+  System.bdmList = function()
+    return {
+      { name = "ata", parId = 0, devNr = 0 },
+      { name = "sdc", parId = 1, devNr = 1 },
+    }
+  end
+  doesFolderExist = function(p)
+    if p == "mass:/" or p == "mass0:/" or p == "mass1:/" then return true end
+    return real_dfe(p)
+  end
+  local devctl_called = false
+  PLDR.GetMassMountDriver = function(root) devctl_called = true; return "usb" end
+  local ata_root, ata_status = PLDR.GetATAMassRootNow()
+  local mx_root, mx_status = PLDR.GetMX4SIOMassRootNow()
+  doesFolderExist = real_dfe
+  PLDR.GetMassMountDriver = real_drv
+  System.bdmList = nil
+  if ata_root ~= "mass:/" or ata_status ~= "ready" then
+    return false, "ata direct: expected mass:/ ready, got "..tostring(ata_root).."/"..tostring(ata_status)
+  end
+  if mx_root ~= "mass1:/" or mx_status ~= "ready" then
+    return false, "mx4sio direct: expected mass1:/ ready, got "..tostring(mx_root).."/"..tostring(mx_status)
+  end
+  if devctl_called then
+    return false, "getMassMountDriver was called -- the direct BDM path must not devctl-scan"
+  end
+  return true
+''')
+check("T29 EXP36 direct BDM slot resolution (parId->massN:/, no devctl scan)", t29)
+
 print()
 fails = [r for r in results if not r[1]]
 print(f"=== {len(results) - len(fails)}/{len(results)} PASS ===")


### PR DESCRIPTION
## What this is

The device-layer refactor you asked for: **use modern SDK device semantics for our own access; reserve devctl for legacy-cwd normalization only.**

## The problem

The MX4SIO and exFAT pages found their `mass:` slot by **opening every `mass0:`..`mass9:` and issuing a driver-name `ioctl2` (`getMassMountDriver`) per slot**. That per-slot interrogation is slow and, on a mid-bringup or flaky ATA slot, a plausible **carousel-stall** path — you don't want to poke a device that's still spinning up just to ask who it is.

## The fix — the direct resolver already existed, unused

`System.bdmList()` (`bdm_query.irx` → PS2SDK `bdm_get_bd()`) returns each connected block device with its **driver name** *and* its **own mass unit (`parId`)**. `BuildMassRootIdentity` now maps driver→slot **directly** from that enumeration (`parId` → `massN:/`), classifying each device's name with `ClassifyMassRootDriver`, guarded by a `doesFolderExist` so an enumerated-but-not-yet-mounted device is skipped. **Zero per-slot devctl scan on the page hot path.**

- The legacy per-slot scan survives **only** as a last-resort fallback if the BDM RPC is unavailable, so a page can never hard-break.
- `getMassMountDriver` (devctl/`ioctl2`) is otherwise untouched and still classifies an ambiguous inherited `mass:` cwd in `classify_mass_boot` — the one place its origin is genuinely unknown.
- CosmicScale's exFAT drive is reached the same way, just directly.

## Testing

- Host harness **30/30** — adds **T29**: `ata` on `parId 0` → `mass:/` and `sdc` on `parId 1` → `mass1:/`, resolved purely from `bdmList`, with `getMassMountDriver` wired as a tripwire that must never fire. **T23** still covers the fallback scan.
- No C changes — reuses the existing `bdmList` binding and `ClassifyMassRootDriver`.

Version `v1.1.1-dev-EXP36`. Tester notes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9)_