### PR TITLE
EXP38: internal exFAT freeze — bring ata_bd up serially at boot under the splash (the reference model)

### DIFF
--- a/EXPERIMENTAL_NOTES.md
+++ b/EXPERIMENTAL_NOTES.md
@@ -2,9 +2,31 @@
 
 **This is the opt-in EXPERIMENTAL channel.** It exists so testers can try riskier changes in isolation, without them reaching anyone who did not ask for it. The public release (**1.1.0**) and the rolling test build are both untouched by anything here.
 
-**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP37**. The check is simple: a version ending in **-EXP37** = this build; **-EXP36** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
+**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP38**. The check is simple: a version ending in **-EXP38** = this build; **-EXP37** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
 
 **How to go back:** reinstall the latest entry on the Releases page. Nothing here changes your settings, your `POPS` folders, or your games, so switching back and forth is safe.
+
+---
+
+## New in EXP38: the internal exFAT drive freeze — stop diverging from OPL
+
+This is the fix for the internal **exFAT HDD freeze** — sAGA's 4TB GPT drive that stalls at *"Locating exFAT HDD POPS folder… 42%"* (and, on the boot-warm-up path, black-screened before the menu). It is **not** a module problem, a memory problem, or a "can't read GPT" problem — the drivers that read his drive are already in the build, byte-for-byte the same ones that read it on EXP22.
+
+**What was actually wrong.** Every working loader — OPL, wLaunchELF R3Z, NHDDL — brings its whole storage stack up **the same way: together, in one go, under a loading screen, before anything else touches the drive bus.** POPSLoader had drifted into doing the opposite — loading the internal-drive driver (`ata_bd`) **late and by itself**, either mid-session when you open the page or on a background worker racing other startup work. On a big drive that late/split bring-up **wedges the drive bus** — which is the 42% hang (and, when it raced boot, the black screen). Same driver, wrong moment.
+
+**The fix — do what the reference loaders do.** When the internal drive is enabled (Internal HDD = **exFAT** or **Both**, the default), POPSLoader now brings the `ata_bd` stack up **at boot, in one shot, while the welcome splash is on screen** — before the menu, before anything else uses the bus. This is the *exact* arrangement sAGA confirmed reads his drive ("works just fine" on EXP22), with the two reasons it was pulled last time both removed:
+- **No black screen** — it runs under the splash (the picture is already up), so the few seconds the drive needs show the splash, not a black panel.
+- **No race** — it finishes completely before the menu appears, instead of a background worker still churning as the menu loads (that race was the earlier black-screen).
+
+**Scope — what this does *not* touch.** `ata_bd` lives on the dev9 (ATA) bus. This change **does not load or touch MMCE** (that's `mmceman` on the SIO2 bus — a completely separate thing) and does not change how MX4SIO or USB load. PFS-only setups skip it entirely and pay nothing.
+
+**Honest status.** This restores the one configuration your drive is *known* to read, moved to a spot where it can't black-screen and can't race. I can't prove it on your hardware from here — so this build is the test. The one thing worth a second look is **MX4SIO** (it shares the block-device core with `ata_bd`): it was collateral damage the *last* time this was tried, but that was bundled with a driver swap we've since settled on, and the SDK drivers we now ship are the same ones OPL runs with `ata_bd` and MX4SIO resident together. If MX4SIO regresses, that's the next thread — but I expect it to be clean.
+
+**What to test on EXP38:**
+- **sAGA / internal exFAT drive:** boot to the menu (no black screen), then open the **exFAT HDD** page — does the game list finally come up instead of hanging at 42%? (The splash may sit a few seconds longer at boot while the drive comes up — that's the drive loading, and it's expected.)
+- **MX4SIO:** browse the MX4SIO list as usual and confirm it's still healthy — no new hang or crash.
+- **MMCE and USB:** confirm they behave exactly as they did on EXP37 (they shouldn't change at all).
+- **PFS-only users:** boot should be as fast as before (this doesn't run for you).
 
 ---
 

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2357,6 +2357,24 @@ function PLDR.IsExplicitATASession()
   return page == "ATA" or page == "EXFAT"
 end
 
+-- EXP38: TRUE when the internal exFAT (ata_bd) block stack should be brought up at
+-- boot, SYNCHRONOUSLY, under the welcome splash (see do_boot_init). This is the
+-- reference model -- OPL/R3Z/NHDDL load the whole block stack in one serial window
+-- under a loading screen -- and the EXP22 arrangement sAGA confirmed reads his 4TB
+-- GPT drive. Gated so PFS-only installs pay nothing:
+--   * Internal HDD = EXFAT or BOTH  -> the exFAT page is reachable this session.
+--   * an explicit -page=ata launch  -> the user opted straight into exFAT.
+-- Named + pure so the host harness can lock it (this fix has been reverted before).
+function PLDR.WantExfatBootBringup()
+  local hdd_fs = (type(PLDR.NormalizeHddFs) == "function")
+                 and PLDR.NormalizeHddFs(PLDR.HDD_FS) or "PFS"
+  if hdd_fs == "EXFAT" or hdd_fs == "BOTH" then
+    return true
+  end
+  return (type(PLDR.IsExplicitATASession) == "function")
+         and (PLDR.IsExplicitATASession() == true)
+end
+
 PLDR.VIDEO_STANDARD_AUTO = "AUTO"
 PLDR.VIDEO_STANDARD_NTSC = "NTSC"
 PLDR.VIDEO_STANDARD_PAL = "PAL"
@@ -9228,31 +9246,37 @@ end
 -- below as an upvalue). Inner block kept at its original indentation for a clean diff.
 local function do_boot_init()
 PLDR.AutoInitStartupBackends()
--- EXP32: kick the ata_bd worker in the BOOT window when this install uses the
--- exFAT page (Internal HDD = EXFAT/BOTH, or an explicit -page=ata session).
--- This restores the one arrangement hardware-proven on the SCPH-30004 class
--- (EXP22): the identical blob loading into a near-empty IOP right after the
--- boot module set, before any page RPC traffic exists to interleave with it.
--- The worker keeps boot responsive (probe runs behind the splash/carousel;
--- no ~5s boot cost), and by the time the user opens the exFAT page the state
--- is usually already done-ok. PFS-only installs skip this entirely -- they
--- never pay for a drive they don't use.
+-- EXP38: bring the internal exFAT block stack (ata_bd) up HERE, SYNCHRONOUSLY,
+-- under the welcome splash -- the REFERENCE model. OPL, wLaunchELF_R3Z and NHDDL
+-- all load their whole block-device stack together in ONE serial window under a
+-- loading screen, before anything else touches the bus. POPSLoader diverged into
+-- lazy per-page loading, and THAT divergence is the exFAT freeze: ata_bd loaded
+-- late (mid-session, onto a busy IOP) OR async (a worker racing other IOP traffic)
+-- wedges its own bring-up (EXP24: "the IOP census at load time IS the variable;
+-- no reference loads BDM-atad late onto a full IOP").
+--
+-- This is the EXP22 arrangement sAGA confirmed reads his 4TB GPT drive ("works
+-- just fine"), with the two reasons it was reverted BOTH removed:
+--   * NO black screen -- do_boot_init runs UNDER the splash (graphics already up),
+--     so the seconds ata_bd needs show the frozen splash, not a black panel. That
+--     is exactly why the "slow device bring-up" belongs here (see the header note).
+--   * NO async race -- the EXP32/35 kick used initATAAsync (a WORKER) that kept
+--     running past do_boot_init and wedged the splash->menu transition on sAGA's
+--     drive (the 2026-07-22 black screen the EXP35 gate was chasing). A SYNCHRONOUS
+--     load blocks do_boot_init and finishes BEFORE the transition: serial, no
+--     concurrent bus traffic, exactly the EXP22 condition that worked.
+--
+-- Gated on exFAT actually being enabled (Internal HDD = EXFAT/BOTH, or a -page=ata
+-- session) so PFS-only installs pay nothing; and ata_bd self-exits fast when SPD
+-- reports no ATA device, so a driveless console barely notices. ata_bd is dev9-only
+-- -- this does NOT load or touch mmceman/SIO2 (MMCE) or the MX4SIO stack, and it
+-- shares the load-once EnsureAtaBdm with the APA/PFS boot path. The exFAT PAGE then
+-- finds the stack already up (initATA is load-once) and just reads it.
 do
-  -- EXP35: do NOT warm up exFAT at boot just because the Internal-HDD setting
-  -- INCLUDES it. EXP34's new HDD_FS=BOTH default made this fire on EVERY boot,
-  -- and on sAGA's 4TB GPT exFAT internal drive the boot-time ata_bd bring-up
-  -- BLACK-SCREENED the console before the menu (2026-07-22) -- a boot the user
-  -- can't recover from without reinstalling. The exFAT page already kicks the
-  -- ata worker itself on entry (async, bounded to OPL's ~10s budget, screen
-  -- alive, NEVER a synchronous load -- see the GBDMHDD loader), so the boot
-  -- warm-up was only a perf pre-load, not a correctness requirement. Keep it
-  -- ONLY for an explicit -page=ata launch (the user opted straight into that
-  -- page and accepts the pre-warm); a normal boot no longer probes exFAT at all,
-  -- matching the lazy-load rule every other device already follows.
-  local want_ata_boot = (type(PLDR.IsExplicitATASession) == "function")
-                        and (PLDR.IsExplicitATASession() == true)
-  if want_ata_boot and type(System) == "table" and type(System.initATAAsync) == "function" then
-    pcall(System.initATAAsync)
+  local want_ata_boot = (type(PLDR.WantExfatBootBringup) == "function")
+                        and (PLDR.WantExfatBootBringup() == true)
+  if want_ata_boot and type(System) == "table" and type(System.initATA) == "function" then
+    pcall(System.initATA)
   end
 end
 -- One-time hygiene: clear a leftover crash-marker file from marker-era builds

--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,9 +1,9 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.1.1-dev-EXP37
+Title=POPSLoader 1.1.1-dev-EXP38
 CfgVersion=8
 $ConfigSource=1
-Version=1.1.1-dev-EXP37
+Version=1.1.1-dev-EXP38
 Package=1
 Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.1.1-dev-EXP37"
+POPSLDR_VER = "v1.1.1-dev-EXP38"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -1030,6 +1030,45 @@ t30 = lua.execute(r'''
 ''')
 check("T30 EXP37 cover folder-gate: absent ART folder skips the per-game file open", t30)
 
+# T31 EXP38: the internal exFAT (ata_bd) block stack is brought up at boot,
+# SYNCHRONOUSLY under the welcome splash, ONLY when exFAT is reachable this session
+# (Internal HDD = EXFAT/BOTH, or a -page=ata launch). This is the EXP22 arrangement
+# sAGA confirmed reads his 4TB GPT drive; it was reverted once (EXP35) after the
+# ASYNC variant black-screened, so pin the gate: it must NOT silently drift back to
+# PFS-only warm-up, and PFS installs must still pay nothing.
+t31 = lua.execute(r'''
+  if type(PLDR.WantExfatBootBringup) ~= "function" then
+    return false, "PLDR.WantExfatBootBringup missing"
+  end
+  local saved_fs, saved_args = PLDR.HDD_FS, PLDR.LAUNCH_ARGS
+  local function want(fs, page)
+    PLDR.HDD_FS = fs
+    PLDR.LAUNCH_ARGS = page and {page = page} or {}
+    return PLDR.WantExfatBootBringup() == true
+  end
+  local cases = {
+    -- fs,      page,  want,  why
+    {"PFS",     nil,   false, "PFS-only must NOT warm up ata at boot"},
+    {nil,       nil,   false, "missing key resolves PFS -> no warm-up"},
+    {"garbage", nil,   false, "unknown value resolves PFS -> no warm-up"},
+    {"EXFAT",   nil,   true,  "exFAT-only warms up"},
+    {"BOTH",    nil,   true,  "BOTH warms up (sAGA's default case)"},
+    {"both",    nil,   true,  "case-insensitive"},
+    {"PFS",     "ATA", true,  "-page=ata forces warm-up even under PFS"},
+  }
+  for _, c in ipairs(cases) do
+    local got = want(c[1], c[2])
+    if got ~= c[3] then
+      PLDR.HDD_FS, PLDR.LAUNCH_ARGS = saved_fs, saved_args
+      return false, string.format("%s: fs=%s page=%s -> %s (want %s)",
+        c[4], tostring(c[1]), tostring(c[2]), tostring(got), tostring(c[3]))
+    end
+  end
+  PLDR.HDD_FS, PLDR.LAUNCH_ARGS = saved_fs, saved_args
+  return true
+''')
+check("T31 EXP38 boot exFAT warm-up gate (EXFAT/BOTH/-page=ata warm; PFS/missing skip)", t31)
+
 print()
 fails = [r for r in results if not r[1]]
 print(f"=== {len(results) - len(fails)}/{len(results)} PASS ===")


### PR DESCRIPTION
## What this is

The fix for the internal **exFAT HDD freeze** — sAGA's 4TB GPT drive stalling at *"Locating exFAT HDD POPS folder… 42%"*, and the boot-warm-up variant that black-screened before the menu.

It is **not** a module problem, a memory problem, or a "can't read GPT" problem. The drivers that read his drive are already in this build — `bdm`/`bdmfs_fatfs` are the GPT-aware SDK set, and `ata_bd.irx` is **byte-identical** to the one that read his drive on EXP22 (confirmed via `git diff GPT-FIX-CHECKPOINT..HEAD`). The bug is **when** we bring `ata_bd` up.

## Root cause — we diverged from every working loader

OPL, wLaunchELF R3Z, and NHDDL all bring their whole block-device stack up **the same way**: together, serially, under a loading screen, before anything else touches the drive bus. POPSLoader had drifted into loading `ata_bd` **late and alone** — either mid-session when the exFAT page opens, or async on a worker racing other startup work. On a large drive that late/split bring-up **wedges the drive bus**:

- **Page-time load** (populated IOP) → the worker "succeeds" but leaves ATA/BDM state wedged, so the UI thread's next `bdmList`/mount call hangs → the **42% freeze**.
- **Async boot kick** racing the main thread's boot I/O → wedges the shared IOP → the **black screen** (why EXP35 gated it off, which then forced sAGA's normal MC/USB boot down the page-time path).

This is exactly the maintainer's own EXP24 finding, in `luasystem.cpp`: *"the IOP census at load time IS the variable; no reference loads BDM-atad late onto a full IOP."*

## The fix — do what the references do

When the internal drive is enabled (Internal HDD = **EXFAT/BOTH**, or a `-page=ata` launch), bring the `ata_bd` stack up **at boot, SYNCHRONOUSLY**, inside `do_boot_init` — which already runs **under the welcome splash**. This is the EXP22 arrangement sAGA confirmed reads his drive, with both revert reasons removed:

- **No black screen** — `do_boot_init` runs under the splash (graphics already up), so the seconds `ata_bd` needs show the frozen splash, not a black panel. This is literally what the "slow device bring-up" slot is for.
- **No async race** — the EXP32/35 kick used `initATAAsync` (a worker) that kept running past `do_boot_init` and wedged the splash→menu transition. A **synchronous** load blocks `do_boot_init` and finishes **before** the transition: serial, no concurrent bus traffic — exactly the EXP22 condition that worked.

Was: `initATAAsync` (worker) gated on `IsExplicitATASession` only → sAGA's normal boot never warmed exFAT and hit the late-load freeze. Now: `initATA` (synchronous) gated on `PLDR.WantExfatBootBringup()`.

## Scope — what this does NOT touch

`ata_bd` is on the **dev9 (ATA)** bus. This change does **not** load or touch `mmceman` (MMCE — that's the SIO2 bus, a completely separate driver), and does not change how MX4SIO or USB load. PFS-only installs skip it entirely and pay nothing. `ata_bd` self-exits fast when SPD reports no ATA device, so a driveless console barely notices.

## Testing

- Host harness **32/32** — adds **T31**: the `WantExfatBootBringup` truth table (EXFAT/BOTH/`-page=ata` warm; PFS/missing/unknown skip). The gate is extracted to a pure, named function and pinned by the test because **this fix has been reverted once** (EXP22→EXP35) — locking its truth table stops it silently drifting back to PFS-only/async.

## Honest status

This restores the one configuration sAGA's drive is *known* to read, moved to a spot where it can't black-screen and can't race. I can't prove it on his hardware from here — **this build is the test.** The one thing worth watching is **MX4SIO** (it shares the BDM core with `ata_bd`): it was collateral the *last* time this was tried, but that was bundled with a driver swap we've since settled on, and the SDK drivers we now ship are the same ones OPL runs with `ata_bd` and MX4SIO resident together. Tester steps are in `EXPERIMENTAL_NOTES.md`.

## Note on contents

`experimental` is currently at EXP36 (`a97a9bd`) and doesn't yet carry the already-merged **EXP37** cover-art fix, so this PR includes that commit too — merging brings experimental to EXP38 **with** EXP37 intact (no regression). The new work here is the EXP38 commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9)_