### PR TITLE
EXP39: exFAT freeze — load the internal drive BEFORE the boot chime (one-variable test)

### DIFF
--- a/EXPERIMENTAL_NOTES.md
+++ b/EXPERIMENTAL_NOTES.md
@@ -2,9 +2,27 @@
 
 **This is the opt-in EXPERIMENTAL channel.** It exists so testers can try riskier changes in isolation, without them reaching anyone who did not ask for it. The public release (**1.1.0**) and the rolling test build are both untouched by anything here.
 
-**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP38**. The check is simple: a version ending in **-EXP38** = this build; **-EXP37** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
+**How to tell you are running it:** Settings, then About: the Version row reads **v1.1.1-dev-EXP39**. The check is simple: a version ending in **-EXP39** = this build; **-EXP38** or lower = an older experimental, please update; plain **v1.1.1-dev** = the rolling build; **v1.1.0** = the public release.
 
 **How to go back:** reinstall the latest entry on the Releases page. Nothing here changes your settings, your `POPS` folders, or your games, so switching back and forth is safe.
+
+---
+
+## New in EXP39: the exFAT freeze — one clean variable (the boot chime)
+
+EXP38 froze on the splash. A deep source-level comparison (byte-hashing every driver against the loaders that read sAGA's drive) settled two things for good, then found the real lead:
+
+**It is NOT the drivers.** Our `ata_bd` is byte-identical to the one wLaunchELF R3Z and official OPL ship. We already shipped the *complete* byte-exact reference driver set (an earlier experiment) and it still froze — and RiptOPL ships an *older* ATA driver than ours and reads the drive fine. So the module bytes are fully exonerated. GPT parsing and 48-bit addressing are both present and working. Chasing the drivers is over.
+
+**The real difference is something only POPSLoader does:** it starts the **boot chime** *before* it brings the internal drive up, and the chime keeps playing *through* the drive load. So the drive comes up while the audio hardware is actively streaming. **No other loader does this** — R3Z has no boot sound, NHDDL loads storage on a freshly-reset console, OPL/wOPL start their sound *after* storage. And it's the one thing that differs between the placement that **works** (EXP22 — drive loads before any audio) and the one that **froze** (EXP38 — drive loads during the chime).
+
+**The change:** EXP39 keeps everything from EXP38 exactly the same, and moves **one thing** — the boot chime now starts **after** the internal drive is up, not before. The splash still covers the load; the only difference is the chime begins a moment later, in silence-then-sound instead of sound-through-load.
+
+This is a deliberate **one-variable test.** If it works, the audio-during-storage collision was the freeze and we finally have the mechanism. If it still freezes, we've cleanly ruled audio out and the next suspect (the controller-adapter drivers initializing at the same time) is already lined up.
+
+**What to test on EXP39:**
+- **sAGA / internal exFAT drive:** boot to the menu. The splash may still sit a few seconds while the drive loads (that's expected — don't power off). Does it reach the menu now, and does the exFAT HDD page list your games instead of hanging on the splash? You'll notice the boot chime starts a touch later than before — that's the fix, not a bug.
+- **MX4SIO / MMCE / USB:** confirm all still behave exactly as they did on EXP37/38.
 
 ---
 

--- a/bin/POPSLDR/title.cfg
+++ b/bin/POPSLDR/title.cfg
@@ -1,9 +1,9 @@
 title=[PS1] POPSLoader
 boot=POPSLOADER.ELF
-Title=POPSLoader 1.1.1-dev-EXP38
+Title=POPSLoader 1.1.1-dev-EXP39
 CfgVersion=8
 $ConfigSource=1
-Version=1.1.1-dev-EXP38
+Version=1.1.1-dev-EXP39
 Package=1
 Release=July 16th, 2026
 Developer=israpps.github.io & nathanneurotic.com

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -1522,8 +1522,6 @@ UI = {
           DrawTargetScene(next_scene or UI.SCENES.MMAIN)
         end
 
-        -- Start boot sound once; explicit holds must not be lengthened by audio duration.
-        TryBootSound()
         local FPS = UI.GetDisplayRefreshHz()
         local SPLASH_HOLD_FRAMES = math.floor(4.0 * FPS + 0.5)
         local CREDITS_HOLD_FRAMES = math.floor(4.0 * FPS + 0.5)
@@ -1540,6 +1538,22 @@ UI = {
         -- then resume and read the now-ready state. (boot_init_fn never returns on
         -- a -game auto-launch -- the splash just showed briefly before the launch.)
         if type(boot_init_fn) == "function" then boot_init_fn() end
+        -- EXP39: start the boot chime AFTER boot_init_fn (the storage bring-up),
+        -- not before it. boot_init_fn does the synchronous internal-exFAT (ata_bd)
+        -- load under this splash; TryBootSound -> Sound.loadADPCM lazily fires
+        -- audsrv_init + audsrv_adpcm_init and starts ADPCM PLAYBACK, so starting it
+        -- first means the ata_bd SifExecModuleBuffer runs while SPU2/audsrv DMA+RPC
+        -- traffic is live. That active-audio-during-storage window is the ONE thing
+        -- EXP22 (loads ATA before any audio -> reads sAGA's 4TB GPT drive) and EXP38
+        -- (loads ATA during the chime -> froze on this splash frame) differ on, and
+        -- NO reference loader plays audio during its storage bring-up (R3Z has no
+        -- audsrv, NHDDL resets the IOP, OPL/wOPL queue audio behind storage). The
+        -- byte-identical driver already read this drive in the pre-audio window, so
+        -- the module bytes are exonerated (EXP17/18 A/B + RiptOPL ships the same
+        -- pre-fix ATA and works). The splash still hides the storage delay; only the
+        -- chime now begins after it. (On a -game auto-launch boot_init_fn never
+        -- returns, so the chime is simply skipped -- correct for a direct launch.)
+        TryBootSound()
         StepHoldFrames(DrawSplash, SPLASH_HOLD_FRAMES)
         StepFade(DrawSplash, 0, 128, INTRO_FADE_OUT_MS)
 

--- a/etc/boot.lua
+++ b/etc/boot.lua
@@ -1,4 +1,4 @@
-POPSLDR_VER = "v1.1.1-dev-EXP38"
+POPSLDR_VER = "v1.1.1-dev-EXP39"
 
 --- Processes a HDD full path into its components.
 --- Supports both explicit PFS paths (`hdd0:__system:pfs:/osd110/hosdsys.elf`)


### PR DESCRIPTION
## What this is

EXP38 froze on the splash. A byte-level driver investigation (Codex/ChatGPT, cross-checked against this repo's own recorded A/B history) **closed the driver axis for good** and surfaced a **POPSLoader-specific lifecycle bug**. EXP39 is the clean one-variable test for it.

## The drivers are exonerated — stop chasing them

- Our `ata_bd.irx` (`16c5d9f0…`) is **byte-identical** to the one **wLaunchELF R3Z** and **official OPL** ship. Deleting our embed would fall **back** to the *pre-fix* SDK blob (`dea9799a…`) — worse, and already froze (EXP12–15).
- **EXP18** shipped the *complete byte-exact R3Z quartet* and still froze.
- **RiptOPL** ships the **pre-fix `dea9799a…` ATA** — the same core as our *failing* build — and reads sAGA's drive fine. **Same bytes, opposite result → it was never the bytes.**
- GPT parsing lives in `bdm` (present: contains `EFI PART` / `Found GPT disk`), 48-bit addressing in `ata_bd` (present). Capability is there.

## The real divergence is ours alone

In `WelcomeDraw.Play`, `TryBootSound()` runs **before** `boot_init_fn()`. `Sound.loadADPCM` lazily fires `audsrv_init` + `audsrv_adpcm_init` and **starts ADPCM playback**. `boot_init_fn()` then does the synchronous `ata_bd` `SifExecModuleBuffer` under the splash — so **the drive comes up while SPU2/audsrv DMA+RPC traffic is live.**

No reference loader does this:
- **R3Z** has no `audsrv`.
- **NHDDL** loads storage on a **freshly-reset IOP**.
- **OPL/wOPL** queue audio **behind** storage.

And it is the one variable separating the placement that **works** (EXP22 — ATA before any audio → reads the drive) from the one that **froze** (EXP38 — ATA during the chime).

## The change (one variable only)

EXP39 keeps EXP38's module bytes, order, placement, sleeps, and splash frame **exactly the same**, and moves **one thing**: `TryBootSound()` now runs **after** `boot_init_fn()`. The storage load happens in silence; the chime begins after. The splash still hides the delay.

```lua
if type(boot_init_fn) == "function" then boot_init_fn() end
TryBootSound()   -- was above boot_init_fn()
```

If it works → audio-during-storage was the freeze, and we have the mechanism. If it still freezes → audio is cleanly ruled out and the next suspect (`ds34usb`/`ds34bt` RPC init, ranked #3 in the investigation) is already lined up.

## Testing

- Host harness **32/32** (ordering-only change; no gate logic touched).
- **Hardware is the decider** — this is a one-variable experiment on sAGA's 4TB GPT drive.

## What to test

- **sAGA / internal exFAT:** boot to the menu (splash may sit a few seconds while the drive loads — expected, don't power off). Does it reach the menu and does the exFAT HDD page list games, instead of freezing on the splash? The boot chime will start a touch later than before — that's the fix.
- **MX4SIO / MMCE / USB:** unchanged from EXP37/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVVaEcq4HCnVUEgpPgad9)_