### PR TITLE
ui: Add Disabled choice to Internal HDD and relocate Overscan to Display section

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -2601,6 +2601,7 @@ PLDR.I18N = {
     ["Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695"] = "Conception par Berion\nScripts par nuno6573 et Ripto\nBasé sur Enceladus par Daniel Santos\nTests par P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k et la communauté\n\nRemerciements spéciaux à :\nkrHACKen pour avoir créé POPStarter\nuyjulian, fjtrujy, HWC et d'autres pour leur aide constante\n\nCe programme est libre et open source\nSi vous l'avez payé, vous avez été arnaqué\n\nProblèmes de compatibilité ? Visitez :\nyoutube.com/@hugopocked6695",
     ["Device List"] = "Liste des appareils",
     ["Disc (DKWDRV)"] = "Disque (DKWDRV)",
+    ["Disabled"] = "Désactivé",
     ["Discard & Exit"] = "Abandonner et quitter",
     ["Display"] = "Affichage",
     ["Display reverted -- new mode wasn't confirmed"] = "Affichage rétabli -- nouveau mode non confirmé",
@@ -2834,6 +2835,7 @@ PLDR.I18N = {
     ["Delete the POPSTARTER folder from the memory card?"] = "POPSTARTER-Ordner von der Memory Card löschen?",
     ["Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695"] = "Design von Berion\nSkripte von nuno6573 und Ripto\nBasiert auf Enceladus von Daniel Santos\nGetestet von P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k und Community\n\nBesonderer Dank an:\nkrHACKen für POPStarter\nuyjulian, fjtrujy, HWC und andere für die stete Hilfe\n\nDieses Programm ist frei und Open Source\nWenn du dafür bezahlt hast, wurdest du betrogen\n\nKompatibilitätsprobleme? Besuche:\nyoutube.com/@hugopocked6695",
     ["Device List"] = "Geräteliste",
+    ["Disabled"] = "Deaktiviert",
     ["Discard & Exit"] = "Verwerfen & Beenden",
     ["Display"] = "Anzeige",
     ["Display reverted -- new mode wasn't confirmed"] = "Anzeige zurückgesetzt -- neuer Modus nicht bestätigt",
@@ -3063,6 +3065,7 @@ PLDR.I18N = {
     ["Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695"] = "Design por Berion\nScripts por nuno6573 e Ripto\nBaseado em Enceladus por Daniel Santos\nTestes por P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k e Comunidade\n\nAgradecimentos especiais a:\nkrHACKen por criar o POPStarter\nuyjulian, fjtrujy, HWC e outros por sempre ajudarem\n\nEste programa é livre e de código aberto\nSe você pagou por ele, foi enganado\n\nProblemas de compatibilidade? Visite:\nyoutube.com/@hugopocked6695",
     ["Device List"] = "Lista de dispositivos",
     ["Disc (DKWDRV)"] = "Disco (DKWDRV)",
+    ["Disabled"] = "Desativado",
     ["Discard & Exit"] = "Descartar e Sair",
     ["Display"] = "Tela",
     ["Display reverted -- new mode wasn't confirmed"] = "Tela revertida -- novo modo não confirmado",
@@ -3297,6 +3300,7 @@ PLDR.I18N = {
     ["Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695"] = "Diseño de Berion\nScripts de nuno6573 y Ripto\nBasado en Enceladus de Daniel Santos\nPruebas de P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k y la comunidad\n\nAgradecimientos especiales a:\nkrHACKen por crear POPStarter\nuyjulian, fjtrujy, HWC y otros por ayudar siempre\n\nEste programa es libre y de código abierto\nSi lo compraste, te estafaron\n\n¿Problemas de compatibilidad? Visita:\nyoutube.com/@hugopocked6695",
     ["Device List"] = "Lista de dispositivos",
     ["Disc (DKWDRV)"] = "Disco (DKWDRV)",
+    ["Disabled"] = "Desactivado",
     ["Discard & Exit"] = "Descartar y salir",
     ["Display"] = "Pantalla",
     ["Display reverted -- new mode wasn't confirmed"] = "Pantalla revertida -- el nuevo modo no se confirmó",
@@ -3526,6 +3530,7 @@ PLDR.I18N = {
     ["Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695"] = "Design di Berion\nScript di nuno6573 e Ripto\nBasato su Enceladus di Daniel Santos\nTest di P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k e la Community\n\nRingraziamenti speciali a:\nkrHACKen per aver creato POPStarter\nuyjulian, fjtrujy, HWC e altri per l'aiuto costante\n\nQuesto programma è gratuito e open source\nSe l'hai pagato, sei stato truffato\n\nProblemi di compatibilità? Visita:\nyoutube.com/@hugopocked6695",
     ["Device List"] = "Elenco dispositivi",
     ["Disc (DKWDRV)"] = "Disco (DKWDRV)",
+    ["Disabled"] = "Disattivato",
     ["Discard & Exit"] = "Scarta ed esci",
     ["Display"] = "Schermo",
     ["Display reverted -- new mode wasn't confirmed"] = "Schermo ripristinato -- nuova modalità non confermata",
@@ -3776,6 +3781,7 @@ PLDR.I18N = {
     ["DHCP (automatic)"] = "DHCP (automatikus)",
     ["DHCP failed\nset a static IP in SMB settings"] = "A DHCP nem sikerült\nÁllítson be statikus IP-címet az SMB-beállításokban",
     ["Disc (DKWDRV)"] = "Fizikai lemez (DKWDRV)",
+    ["Disabled"] = "Kikapcsolva",
     ["Discard & Exit"] = "Elvetés & Kilépés",
     ["Display"] = "Megjelenés",
     ["Display reverted -- new mode wasn't confirmed"] = "A kijelzőmód visszaállt -- az új mód nem került megerősítésre",
@@ -4838,11 +4844,12 @@ end
 -- silently collapses any third value back to PFS. Anything unrecognized -- and a
 -- MISSING key -- still resolves to PFS, so no existing install changes until the
 -- user opts in (the back-compat contract from 1f2d7ca).
-PLDR.HDD_FS_VALUES = {"PFS", "EXFAT", "BOTH"}
+PLDR.HDD_FS_VALUES = {"PFS", "EXFAT", "BOTH", "DISABLED"}
 function PLDR.NormalizeHddFs(v)
   local u = string.upper(tostring(v or ""))
   if u == "EXFAT" then return "EXFAT" end
   if u == "BOTH" then return "BOTH" end
+  if u == "DISABLED" or u == "NONE" or u == "OFF" then return "DISABLED" end
   return "PFS"
 end
 
@@ -4852,7 +4859,7 @@ function PLDR.IsDeviceHidden(key)
   local ukey = string.upper(tostring(key))
   -- Which internal-HDD page(s) the carousel shows: Settings > Device List > Internal HDD.
   -- BOTH (the default since EXP34) shows both; PFS or EXFAT shows exactly one (R3Z3N:
-  -- APA-Jail and PFS can coexist). This is ONLY a visibility rule -- it has never gated a
+  -- APA-Jail and PFS can coexist); DISABLED hides both. This is ONLY a visibility rule -- it has never gated a
   -- driver, mount or IRX. The stacks were already unified onto ONE load-once ata_bd serving
   -- APA/PFS and exFAT together (`EnsureAtaBdm`, src/luasystem.cpp; called by BOTH
   -- luaHDD.cpp's Load_HDD_IRX and lua_ata_init, carrying R3Z3N's two 1s settles).
@@ -4871,6 +4878,7 @@ function PLDR.IsDeviceHidden(key)
     end
     local fs = PLDR.NormalizeHddFs(PLDR.HDD_FS)
     if fs == "BOTH" then return false end
+    if fs == "DISABLED" then return true end
     return ukey ~= fs
   end
   local csv = string.upper(tostring(PLDR.HIDDEN_DEVICES or ""))

--- a/bin/POPSLDR/ui.lua
+++ b/bin/POPSLDR/ui.lua
@@ -4691,6 +4691,19 @@ UI = {
           function() UI.SetHideTextMode(not UI.HideTextMode, false) end,
           HideTextDirty
         )
+        AddCycle(
+          "Overscan (CRT inset)",
+          function() return (UI.Overscan or 0) == 0 and "Off" or tostring(UI.Overscan) end,
+          function()
+            UI.Overscan = math.min((UI.Overscan or 0) + 5, 100)
+            if type(Screen) == "table" and type(Screen.setOverscan) == "function" then pcall(Screen.setOverscan, UI.Overscan) end
+          end,
+          function()
+            UI.Overscan = math.max((UI.Overscan or 0) - 5, 0)
+            if type(Screen) == "table" and type(Screen.setOverscan) == "function" then pcall(Screen.setOverscan, UI.Overscan) end
+          end,
+          function() return (UI.Overscan or 0) ~= (UI.SettingsEntryOverscan or 0) end
+        )
 
         AddSection("Startup")
         AddCycle(
@@ -4767,12 +4780,12 @@ UI = {
         end
 
         -- Internal-HDD page(s) on the carousel: Sony APA/PFS (default), APA-Jail exFAT,
-        -- or BOTH. "Both" is new (R3Z3N: the two can coexist) and is purely a visibility
+        -- BOTH, or Disabled. "Both" is new (R3Z3N: the two can coexist) and is purely a visibility
         -- choice -- the driver stacks were already unified onto one shared, load-once
         -- ata_bd that serves APA/PFS and exFAT together, settles included. A -page=ata
         -- launch still auto-enters exFAT and hides PFS regardless of this setting.
-        local HDD_FS_SEQ = {"PFS", "EXFAT", "BOTH"}
-        local HDD_FS_TXT = {PFS = "APA / PFS (default)", EXFAT = "exFAT", BOTH = "Both"}
+        local HDD_FS_SEQ = {"PFS", "EXFAT", "BOTH", "DISABLED"}
+        local HDD_FS_TXT = {PFS = "APA / PFS (default)", EXFAT = "exFAT", BOTH = "Both", DISABLED = "Disabled"}
         local function HddFsStep(cur, dir)
           local idx = 1
           for i = 1, #HDD_FS_SEQ do
@@ -4782,7 +4795,7 @@ UI = {
         end
         AddCycle(
           "Internal HDD",
-          function() return HDD_FS_TXT[UI.HddFs] or "APA / PFS (default)" end,
+          function() return PLDR.L(HDD_FS_TXT[UI.HddFs] or "APA / PFS (default)") end,
           function() UI.HddFs = HddFsStep(UI.HddFs, -1) end,
           function() UI.HddFs = HddFsStep(UI.HddFs, 1) end,
           function() return tostring(UI.HddFs) ~= tostring(UI.SettingsEntryHddFs) end
@@ -4866,19 +4879,6 @@ UI = {
           function() UI.RetroGemGameId = not UI.RetroGemGameId end,
           function() UI.RetroGemGameId = not UI.RetroGemGameId end,
           function() return (UI.RetroGemGameId == true) ~= (UI.SettingsEntryRetroGemGameId == true) end
-        )
-        AddCycle(
-          "Overscan (CRT inset)",
-          function() return (UI.Overscan or 0) == 0 and "Off" or tostring(UI.Overscan) end,
-          function()
-            UI.Overscan = math.min((UI.Overscan or 0) + 5, 100)
-            if type(Screen) == "table" and type(Screen.setOverscan) == "function" then pcall(Screen.setOverscan, UI.Overscan) end
-          end,
-          function()
-            UI.Overscan = math.max((UI.Overscan or 0) - 5, 0)
-            if type(Screen) == "table" and type(Screen.setOverscan) == "function" then pcall(Screen.setOverscan, UI.Overscan) end
-          end,
-          function() return (UI.Overscan or 0) ~= (UI.SettingsEntryOverscan or 0) end
         )
 
         -- SMB / Network (Stage 1: config only -- the network stack loads lazily on

--- a/docs/translations/brazilian-portuguese.tsv
+++ b/docs/translations/brazilian-portuguese.tsv
@@ -78,6 +78,7 @@ DONE	DONE
 Delete the POPSTARTER folder from the memory card?	Excluir a pasta POPSTARTER do cartão de memória?
 Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695	Design por Berion\nScripts por nuno6573 e Ripto\nBaseado em Enceladus por Daniel Santos\nTestes por P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k e Comunidade\n\nAgradecimentos especiais a:\nkrHACKen por criar o POPStarter\nuyjulian, fjtrujy, HWC e outros por sempre ajudarem\n\nEste programa é livre e de código aberto\nSe você pagou por ele, foi enganado\n\nProblemas de compatibilidade? Visite:\nyoutube.com/@hugopocked6695
 Disc (DKWDRV)	Disco (DKWDRV)
+Disabled	Desativado
 Discard & Exit	Descartar e Sair
 Display	Tela
 Display reverted -- new mode wasn't confirmed	Tela revertida -- novo modo não confirmado

--- a/docs/translations/hungarian.tsv
+++ b/docs/translations/hungarian.tsv
@@ -84,6 +84,7 @@ Delete the POPSTARTER folder from the memory card?	Törli a POPSTARTER mappát a
 Design by Berion\nScripts by nuno6573 and Ripto\nBased on Enceladus by Daniel Santos\nTesting by P4NCHOL1NO, VizoR, provato,\nnuno6573, oldman63, saildot4k, and Community\n\nSpecial Thanks To:\nkrHACKen for making POPStarter\nuyjulian, fjtrujy, HWC, and others for always helping\n\nThis program is free and open source\nIf you bought it, you have been scammed\n\nCompatibility problems? Visit:\nyoutube.com/@hugopocked6695	Tervezés: Berion\nSzkriptek: nuno6573 és Ripto\nBázis: Daniel Santos 'Enceladus' című munkája\nTesztelés: P4NCHOL1NO, VizoR, provato,\nnuno6573, sAGA/oldman63, saildot4k és a közösség\n\nKülön köszönet:\nkrHACKennek a POPStarter elkészítéséért\nuyjuliannek, fjtrujy-nak, HWC-nek és másoknak a folyamatos segítségért\n\nEz a program ingyenes és nyílt forráskódú\nHa megvásárolta, akkor átverték\n\nKompatibilitási problémák? Látogasson el ide:\nyoutube.com/@hugopocked6695
 Device List	Eszközlista
 Disc (DKWDRV)	Fizikai lemez (DKWDRV)
+Disabled	Kikapcsolva
 Discard & Exit	Elvetés & Kilépés
 Display	Megjelenés
 Display reverted -- new mode wasn't confirmed	A kijelzőmód visszaállt -- az új mód nem került megerősítésre

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -733,6 +733,10 @@ t18 = E('''function()
     {"PFS",       "ATA",  true,  true,  "-page=ata REVEALS exFAT when set to PFS -- and must NOT hide PFS"},
     {"BOTH",      "ATA",  true,  true,  "-page=ata never removes a page from BOTH (CosmicScale 2026-07-28)"},
     {"EXFAT",     "ATA",  false, true,  "set to exFAT + -page=ata: unchanged, PFS stays hidden by the SETTING"},
+    {"DISABLED",  nil,    false, false, "DISABLED hides both PFS and exFAT"},
+    {"disabled",  nil,    false, false, "DISABLED is case-insensitive"},
+    {"OFF",       nil,    false, false, "OFF alias resolves to DISABLED"},
+    {"NONE",      nil,    false, false, "NONE alias resolves to DISABLED"},
   }
   for _, c in ipairs(cases) do
     local p, e = vis(c[1], c[2])


### PR DESCRIPTION
### Summary
Addresses tester feedback (nuno6573):
1. **Internal HDD toggle**: Added a Disabled (DISABLED/OFF/NONE) choice to *Settings -> Device List -> Internal HDD* (PFS, EXFAT, BOTH, DISABLED). This allows PS2 Slim or driveless setup users to completely hide Internal HDD pages from the carousel menu.
2. **Overscan location**: Moved *Overscan (CRT inset)* from *Settings -> Game List* into *Settings -> Display* section.
3. **i18n & Harness**: Added localized translations for Disabled across all 6 supported languages (FR, DE, PT, ES, IT, HU) and updated host harness test T18.

### Verification
- Host harness test suite ran cleanly (53/53 PASS).