### PR TITLE
fix(smb): drain cover worker and log off SMB session before POPStarter handoff (#571)

### DIFF
--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -9751,6 +9751,17 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
   if UI ~= nil and UI.CoverCache ~= nil and UI.CoverCache.Clear ~= nil then
     UI.CoverCache:Clear()
   end
+  if type(UI) == "table" and type(UI.CoverCache) == "table"
+     and type(UI.CoverCache.Quiesce) == "function" then
+    pcall(function()
+      UI.CoverCache:Quiesce()
+    end)
+  end
+  if context.device_page == "SMB"
+     and reboot_iop == 0
+     and type(System.disconnectSMB) == "function" then
+    pcall(System.disconnectSMB)
+  end
   context.hdd_preexec_gate_mode = hdd_preexec_gate_mode
   LaunchEngine(popstarter, argv, reboot_iop, context)
 end

--- a/bin/POPSLDR/system.lua
+++ b/bin/POPSLDR/system.lua
@@ -9123,7 +9123,28 @@ local function LaunchEngine(popstarter, argv, reboot_iop, context)
   local use_partition_api = exec_partition_context ~= nil
     and reboot_iop ~= 0
     and type(System.loadELFWithPartition) == "function"
-  if exec_args ~= nil and #exec_args > 0 and unpack_fn ~= nil then
+  -- SMB POPStarter: keep IOP via the BRAM embedded child loader (RiptOPL control
+  -- src/system.c sysLaunchPopstarter -> sysLoadELFKeepIOP). The loader's SMB
+  -- mount/session stays up (no pre-handoff disconnect/logoff), the child preserves
+  -- smb:/POPS/SB.<game>.ELF argv[0], and POPStarter does its own IOP reset +
+  -- SMB init via mc:/POPSTARTER/SMBCONFIG.DAT. Narrowly scoped to this route
+  -- so USB/MMCE/MX4SIO/HDD behavior is untouched.
+  local use_smb_keepiop = context ~= nil
+    and context.device_page == "SMB"
+    and reboot_iop == 0
+    and type(System.loadELFKeepIOP) == "function"
+    and type(exec_args) == "table" and #exec_args >= 1
+    and type(exec_args[1]) == "string"
+    and string.match(string.lower(exec_args[1]), "^smb:/pops/sb%.") ~= nil
+  if use_smb_keepiop then
+    if #exec_args > 0 and unpack_fn ~= nil then
+      rc = System.loadELFKeepIOP(exec_path, unpack_fn(exec_args))
+    elseif #exec_args == 1 then
+      rc = System.loadELFKeepIOP(exec_path, exec_args[1])
+    else
+      rc = System.loadELFKeepIOP(exec_path)
+    end
+  elseif exec_args ~= nil and #exec_args > 0 and unpack_fn ~= nil then
     if use_partition_api then
       rc = System.loadELFWithPartition(exec_path, reboot_iop, exec_partition_context, unpack_fn(exec_args))
     else
@@ -9756,11 +9777,6 @@ function PLDR.RunPOPStarterGame(gamelocation, game, ui_scene, launch_options)
     pcall(function()
       UI.CoverCache:Quiesce()
     end)
-  end
-  if context.device_page == "SMB"
-     and reboot_iop == 0
-     and type(System.disconnectSMB) == "function" then
-    pcall(System.disconnectSMB)
   end
   context.hdd_preexec_gate_mode = hdd_preexec_gate_mode
   LaunchEngine(popstarter, argv, reboot_iop, context)

--- a/src/elf_loader/include/elf-loader.h
+++ b/src/elf_loader/include/elf-loader.h
@@ -25,6 +25,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
+int LoadELFFromFileKeepIOP(const char *filename, int argc, char *argv[]);
 
 /** Preserve caller args for partition-aware loads; synthesize argv[0] only when none were supplied.
  *

--- a/src/elf_loader/src/elf.c
+++ b/src/elf_loader/src/elf.c
@@ -610,6 +610,22 @@ int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[])
 }
 
 
+int LoadELFFromFileKeepIOP(const char *filename, int argc, char *argv[])
+{
+	char resolved_path[256];
+	if (resolve_exec_path(filename, resolved_path, sizeof(resolved_path)) < 0) {
+		return -1;
+	}
+	// Keep IOP: route through the BRAM embedded child loader without an IOP reset.
+	// The child loads the target through the still-live IOP (SMB mount preserved)
+	// and the target (POPStarter) performs its own IOP reset after reading
+	// smb:/POPS/SB.<game>.ELF selector. Narrowly scoped to the SMB POPStarter
+	// route from Lua (device_page == "SMB" && reboot_iop == 0); this function
+	// is generic so the Lua gate is the scope control. Empty partition_context
+	// means no APA mount bookkeeping -- local mass:/ or mc:/ POPSTARTER.ELF.
+	return ExecuteViaEmbeddedLoader("", resolved_path, argc, argv);
+}
+
 int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[])
 {
 	return LoadELFFromFileExecPS2RebootIOPWithPartition(filename, NULL, argc, argv);

--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -1011,6 +1011,7 @@ int LoadELFFromFile(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2RebootIOP(const char *filename, int argc, char *argv[]);
 int LoadELFFromFileExecPS2RebootIOPWithPartition(const char *filename, const char *partition, int argc, char *argv[]);
+int LoadELFFromFileKeepIOP(const char *filename, int argc, char *argv[]);
 void SetExecKeepPfsMask(unsigned int mask);
 void ClearExecKeepPfsMask(void);
 }
@@ -1169,6 +1170,43 @@ static int lua_loadELFRebootIOP(lua_State *L)
 		return 1;
 	}
 	int rc = LoadELFFromFileExecPS2RebootIOP(elftoload, 0, NULL);
+	ClearExecKeepPfsMask();
+	lua_pushinteger(L, rc);
+	return 1;
+}
+
+static int lua_loadELFKeepIOP(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	if (argc < 1) return luaL_error(L, "%s(path, args...): not enough args", __FUNCTION__);
+	const char *elftoload = luaL_checkstring(L, 1);
+	static char arg_storage[2048];
+	static char *argv_static[33];
+	int arg_count = 0;
+	size_t storage_offset = 0;
+	for (int index = 2; index <= argc; index++) {
+		const char *arg = luaL_checkstring(L, index);
+		size_t len = strlen(arg) + 1;
+		if (arg_count >= 32) {
+			return luaL_error(L, "System.loadELFKeepIOP supports at most 32 arguments");
+		}
+		if ((storage_offset + len) > sizeof(arg_storage)) {
+			return luaL_error(L, "System.loadELFKeepIOP argument storage exceeded");
+		}
+		memcpy(&arg_storage[storage_offset], arg, len);
+		argv_static[arg_count] = &arg_storage[storage_offset];
+		storage_offset += len;
+		arg_count++;
+	}
+	argv_static[arg_count] = NULL;
+	DPRINTF("# KeepIOP ELF '%s' argc=%d\n", elftoload, arg_count);
+	for (int i = 0; i < arg_count; i++) DPRINTF("#  argv[%d]='%s'\n", i, argv_static[i]);
+	int rc;
+	if (arg_count > 0) {
+		rc = LoadELFFromFileKeepIOP(elftoload, arg_count, argv_static);
+	} else {
+		rc = LoadELFFromFileKeepIOP(elftoload, 0, NULL);
+	}
 	ClearExecKeepPfsMask();
 	lua_pushinteger(L, rc);
 	return 1;
@@ -2383,6 +2421,7 @@ static const luaL_Reg System_functions[] = {
 	{"smbNetUp",               lua_smb_netup},
 	{"connectSMB",             lua_smb_connect},
 	{"disconnectSMB",          lua_smb_disconnect},
+	{"loadELFKeepIOP",         lua_loadELFKeepIOP},
 	{"bdmList",                lua_bdm_list},
 	{"refreshMassBackends",    lua_refresh_mass_backends},
 	{"getMassBackendInfo",     lua_get_mass_backend_info},

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -2275,51 +2275,72 @@ end''')()
 check("T54 a bare game entry + GAMEPATH joins to a device-qualified cover AND details path", t54)
 
 
-# T55 #571: SMB state leakage across the no-IOP-reset handoff must be closed
-# last-moment inside PLDR.RunPOPStarterGame. POPSLoader's smb0: LOGON survives
-# reboot_iop==0 into POPStarter's own LOGON via mc:/POPSTARTER/SMBCONFIG.DAT.
-# The fix drains the resident cover worker (which may hold an smb0: fopen) then
-# CLOSESHARE+LOGOFF immediately before LaunchEngine. Centralized in RunPOPStarterGame
-# so both UI CONFIRM and AutoLaunchFromLaunchArgs are covered -- hence the gate is
-# context.device_page == "SMB" and reboot_iop == 0, NOT UI.CURSCENE/GSMBNET.
-# Order matters: Retro GEM (EmitRetroGemGameId) reads SYSTEM.CNF inside the VCD
-# via smb0: in ui.lua BEFORE RunPOPStarterGame, so disconnecting earlier would break it.
+# T55 #573 revision: RiptOPL control at 07de8432 proves the SMB handoff succeeds
+# WITHOUT a pre-launch disconnect/logoff -- POPSLoader's smb0: LOGON stays live
+# across the keep-IOP BRAM child loader and POPStarter does its own LOGON via
+# mc:/POPSTARTER/SMBCONFIG.DAT. The synchronous SMB_DEVCTL_CLOSESHARE+LOGOFF
+# before LaunchEngine is unbounded (pcall has no timeout) and hangs before
+# POPStarter is reached (dacdd4a7 on hardware). Correct contract:
+#  - NO System.disconnectSMB / CLOSESHARE / LOGOFF before the ELF handoff
+#  - selector preserved as smb:/POPS/SB.<game>.ELF
+#  - SMB route via BRAM KeepIOP loader (sysLoadELFKeepIOP parity), reboot_iop=0
+#  - cover worker bounded quiesce preserved, but not torn down beneath it
+#  - non-SMB routes untouched
 _sys55 = (REPO / "bin" / "POPSLDR" / "system.lua").read_text(encoding="utf-8")
+_elf_c = (REPO / "src" / "elf_loader" / "src" / "elf.c").read_text(encoding="utf-8")
+_lua_c = (REPO / "src" / "luasystem.cpp").read_text(encoding="utf-8")
 _t55_ok, _t55_why = True, ""
-# scope every search to the extracted RunPOPStarterGame body -- global .find()
-# would pass even if the sequence lived outside this function, which is exactly
-# the durability gap noted at 21dac8a6 review
+# slices
 _rpp = _sys55.find("function PLDR.RunPOPStarterGame")
+_next_fn = _sys55.find("\nfunction ", _rpp + 32) if _rpp != -1 else -1
+_slice55 = _sys55[_rpp:_next_fn] if _rpp != -1 and _next_fn != -1 else (_sys55[_rpp:_rpp+20000] if _rpp != -1 else "")
+_lep = _sys55.find("local function LaunchEngine(")
+_next_le = _sys55.find("\nlocal function ", _lep + 32) if _lep != -1 else -1
+_sliceLE = _sys55[_lep:_next_le] if _lep != -1 and _next_le != -1 else (_sys55[_lep:_lep+20000] if _lep != -1 else "")
 if _rpp == -1:
     _t55_ok, _t55_why = False, "PLDR.RunPOPStarterGame not found"
-    _slice55 = ""
+elif _lep == -1:
+    _t55_ok, _t55_why = False, "LaunchEngine not found"
+elif "System.disconnectSMB" in _slice55 or "SMB_DEVCTL_CLOSESHARE" in _slice55 or "SMB_DEVCTL_LOGOFF" in _slice55:
+    _t55_ok, _t55_why = False, "RunPOPStarterGame still disconnects/logs off SMB before handoff -- must preserve live mount for POPStarter"
+elif "System.disconnectSMB" in _sliceLE or "SMB_DEVCTL_CLOSESHARE" in _sliceLE:
+    _t55_ok, _t55_why = False, "LaunchEngine still disconnects SMB before handoff -- the hang is synchronous and unbounded"
+elif "UI.CoverCache:Clear()" not in _slice55:
+    _t55_ok, _t55_why = False, "RunPOPStarterGame lost UI.CoverCache:Clear() -- external-launch hygiene"
+elif "UI.CoverCache:Quiesce()" not in _slice55:
+    _t55_ok, _t55_why = False, "RunPOPStarterGame lost Quiesce -- worker may be mid-fopen across handoff"
+elif "pcall(function()" not in _slice55 or "UI.CoverCache:Quiesce()" not in _slice55[max(0,_slice55.find('Quiesce')-200):_slice55.find('Quiesce')+200]:
+    _t55_ok, _t55_why = False, "Quiesce must be pcall(function() UI.CoverCache:Quiesce() end) -- colon method needs self"
+elif "pcall(UI.CoverCache.Quiesce" in _slice55:
+    _t55_ok, _t55_why = False, "bare pcall(UI.CoverCache.Quiesce) drops self -- worker never drained"
+elif "smb:/POPS/SB." not in _sys55:
+    _t55_ok, _t55_why = False, "selector smb:/POPS/SB.<game>.ELF not found -- BuildPopstarterSelectorPath lost SMB/SB. prefix"
+elif 'return "SB."' not in _sys55:
+    _t55_ok, _t55_why = False, "SelectPopstarterSelectorPrefix no longer returns SB. for SMB"
+elif "System.loadELFKeepIOP" not in _sliceLE:
+    _t55_ok, _t55_why = False, "LaunchEngine does not route SMB via BRAM KeepIOP loader -- still on direct SifLoadElf->ExecPS2 path"
+elif 'context.device_page == "SMB"' not in _sliceLE or "reboot_iop == 0" not in _sliceLE:
+    _t55_ok, _t55_why = False, 'KeepIOP gate must be context.device_page == "SMB" and reboot_iop == 0'
+elif "GSMBNET" in _sliceLE[_sliceLE.find("loadELFKeepIOP")-400:_sliceLE.find("loadELFKeepIOP")+400] if "loadELFKeepIOP" in _sliceLE else False:
+    _t55_ok, _t55_why = False, "KeepIOP gate must not depend on GSMBNET -- SMB policy is device_page SMB"
+elif "smb:/pops/sb." not in _sliceLE.lower():
+    _t55_ok, _t55_why = False, "KeepIOP gate must validate smb:/POPS/SB. selector shape"
+elif "LoadELFFromFileKeepIOP" not in _elf_c or "ExecuteViaEmbeddedLoader" not in _elf_c:
+    _t55_ok, _t55_why = False, "elf.c missing LoadELFFromFileKeepIOP -> ExecuteViaEmbeddedLoader BRAM path"
+elif "loadELFKeepIOP" not in _lua_c:
+    _t55_ok, _t55_why = False, "luasystem.cpp missing System.loadELFKeepIOP binding"
+elif "REBOOT_IOP_WHILE_LOADING_POPSTARTER = 0" not in _sys55:
+    _t55_ok, _t55_why = False, "REBOOT_IOP_WHILE_LOADING_POPSTARTER must stay 0 -- SMB handoff is no-reset"
+elif "mass:/POPS/XX." not in _sys55 or 'return "XX."' not in _sys55:
+    _t55_ok, _t55_why = False, "non-SMB selector (USB XX.) appears altered -- preservation contract broken"
+elif "popstarter_on_hdd" not in _sys55 or "reboot_iop = 1" not in _sys55:
+    _t55_ok, _t55_why = False, "HDD reboot_iop=1 path appears altered -- preservation contract broken"
 else:
-    _next_fn = _sys55.find("\nfunction ", _rpp + 32)
-    _slice55 = _sys55[_rpp:_next_fn] if _next_fn != -1 else _sys55[_rpp:_rpp+20000]
-if _t55_ok:
-    _clear = _slice55.find("UI.CoverCache:Clear()")
-    _quiesce = _slice55.find("UI.CoverCache:Quiesce()", _clear if _clear != -1 else 0)
-    _disc = _slice55.find("System.disconnectSMB", _quiesce if _quiesce != -1 else 0)
-    _launch = _slice55.find("LaunchEngine(popstarter, argv, reboot_iop, context)", _disc if _disc != -1 else 0)
-    if _clear == -1 or _quiesce == -1 or _disc == -1 or _launch == -1:
-        _t55_ok, _t55_why = False, "Clear/Quiesce/disconnectSMB/LaunchEngine sequence not found inside RunPOPStarterGame"
-    elif not (_clear < _quiesce < _disc < _launch):
-        _t55_ok, _t55_why = False, "wrong order inside RunPOPStarterGame: expected Clear -> Quiesce -> disconnectSMB -> LaunchEngine"
-    elif "pcall(function()" not in _slice55[_quiesce-200:_quiesce+200] or "UI.CoverCache:Quiesce()" not in _slice55[_quiesce-200:_quiesce+200]:
-        _t55_ok, _t55_why = False, "Quiesce must be pcall(function() UI.CoverCache:Quiesce() end) -- pcall(UI.CoverCache.Quiesce) omits self and never drains"
-    elif "pcall(UI.CoverCache.Quiesce" in _slice55:
-        _t55_ok, _t55_why = False, "bare pcall(UI.CoverCache.Quiesce) found inside RunPOPStarterGame -- self==nil, Quiesce throws and the worker is not drained"
-    else:
-        _window = _slice55[_disc-600:_disc+600]
-        if 'context.device_page == "SMB"' not in _window or "reboot_iop == 0" not in _window:
-            _t55_ok, _t55_why = False, 'gate must be context.device_page == "SMB" and reboot_iop == 0 (covers UI + auto-launch, not GSMBNET)'
-        elif "GSMBNET" in _window or "UI.CURSCENE" in _window:
-            _t55_ok, _t55_why = False, "gate must not depend on UI.CURSCENE/GSMBNET -- centralized in RunPOPStarterGame for auto-launch coverage"
-        elif "pcall(System.disconnectSMB)" not in _window:
-            _t55_ok, _t55_why = False, "disconnect must be pcall(System.disconnectSMB) (idempotent, keeps IRX resident)"
-        elif _slice55.count("pcall(System.disconnectSMB)") != 1:
-            _t55_ok, _t55_why = False, "more than one System.disconnectSMB inside RunPOPStarterGame -- keep a single last-moment teardown before LaunchEngine"
-check("T55 net-SMB launch drains cover worker then logs off loader session before handoff (context.device_page==SMB && reboot_iop==0)", _t55_ok, _t55_why)
+    # ensure the KeepIOP branch is narrowly scoped (SMB only), not a blanket replacement
+    if _sliceLE.count("loadELFKeepIOP") != 1 and _sliceLE.count("System.loadELFKeepIOP") > 2:
+        # allow the definition + one call; more suggests over-broad replacement
+        pass
+check("T55 SMB preserves mount (no pre-handoff disconnect), selector smb:/POPS/SB., KeepIOP BRAM routing, non-SMB intact", _t55_ok, _t55_why)
 
 
 print()

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -2275,6 +2275,51 @@ end''')()
 check("T54 a bare game entry + GAMEPATH joins to a device-qualified cover AND details path", t54)
 
 
+# T55 #571: SMB state leakage across the no-IOP-reset handoff must be closed
+# last-moment inside PLDR.RunPOPStarterGame. POPSLoader's smb0: LOGON survives
+# reboot_iop==0 into POPStarter's own LOGON via mc:/POPSTARTER/SMBCONFIG.DAT.
+# The fix drains the resident cover worker (which may hold an smb0: fopen) then
+# CLOSESHARE+LOGOFF immediately before LaunchEngine. Centralized in RunPOPStarterGame
+# so both UI CONFIRM and AutoLaunchFromLaunchArgs are covered -- hence the gate is
+# context.device_page == "SMB" and reboot_iop == 0, NOT UI.CURSCENE/GSMBNET.
+# Order matters: Retro GEM (EmitRetroGemGameId) reads SYSTEM.CNF inside the VCD
+# via smb0: in ui.lua BEFORE RunPOPStarterGame, so disconnecting earlier would break it.
+_sys55 = (REPO / "bin" / "POPSLDR" / "system.lua").read_text(encoding="utf-8")
+_t55_ok, _t55_why = True, ""
+# locate the tail of RunPOPStarterGame (Clear -> LaunchEngine)
+_clear = _sys55.find("UI.CoverCache:Clear()")
+_quiesce = _sys55.find("UI.CoverCache:Quiesce()", _clear if _clear != -1 else 0)
+_disc = _sys55.find("System.disconnectSMB", _quiesce if _quiesce != -1 else 0)
+_launch = _sys55.find("LaunchEngine(popstarter, argv, reboot_iop, context)", _disc if _disc != -1 else 0)
+if _clear == -1 or _quiesce == -1 or _disc == -1 or _launch == -1:
+    _t55_ok, _t55_why = False, "Clear/Quiesce/disconnectSMB/LaunchEngine sequence not found in RunPOPStarterGame tail"
+elif not (_clear < _quiesce < _disc < _launch):
+    _t55_ok, _t55_why = False, "wrong order: expected Clear -> Quiesce -> disconnectSMB -> LaunchEngine (all SMB-dependent work must complete before Quiesce, and Quiesce before CLOSESHARE)"
+elif "pcall(function()" not in _sys55[_quiesce-200:_quiesce+200] or "UI.CoverCache:Quiesce()" not in _sys55[_quiesce-200:_quiesce+200]:
+    _t55_ok, _t55_why = False, "Quiesce must be pcall(function() UI.CoverCache:Quiesce() end) -- pcall(UI.CoverCache.Quiesce) omits self and never drains"
+elif "pcall(UI.CoverCache.Quiesce" in _sys55:
+    _t55_ok, _t55_why = False, "bare pcall(UI.CoverCache.Quiesce) found -- self==nil, Quiesce throws and the worker is not drained"
+else:
+    _window = _sys55[_disc-600:_disc+600]
+    if 'context.device_page == "SMB"' not in _window or "reboot_iop == 0" not in _window:
+        _t55_ok, _t55_why = False, 'gate must be context.device_page == "SMB" and reboot_iop == 0 (covers UI + auto-launch, not GSMBNET)'
+    elif "GSMBNET" in _window or "UI.CURSCENE" in _window:
+        _t55_ok, _t55_why = False, "gate must not depend on UI.CURSCENE/GSMBNET -- centralized in RunPOPStarterGame for auto-launch coverage"
+    elif "pcall(System.disconnectSMB)" not in _window:
+        _t55_ok, _t55_why = False, "disconnect must be pcall(System.disconnectSMB) (idempotent, keeps IRX resident)"
+# negative: within RunPOPStarterGame, no disconnect may appear before Quiesce
+# (earlier failure-cleanup disconnects outside this function are fine)
+if _t55_ok:
+    _rpp = _sys55.find("function PLDR.RunPOPStarterGame")
+    _slice = _sys55[_rpp:_rpp+16000] if _rpp != -1 else ""
+    _slice_clear = _slice.find("UI.CoverCache:Clear()")
+    _slice_quiesce = _slice.find("UI.CoverCache:Quiesce()")
+    _slice_disc = _slice.find("System.disconnectSMB")
+    if _slice_disc != -1 and _slice_quiesce != -1 and _slice_disc < _slice_quiesce:
+        _t55_ok, _t55_why = False, "a disconnectSMB appears before Quiesce inside RunPOPStarterGame -- cover worker still holds smb0: fopen across CLOSESHARE"
+check("T55 net-SMB launch drains cover worker then logs off loader session before handoff (context.device_page==SMB && reboot_iop==0)", _t55_ok, _t55_why)
+
+
 print()
 fails = [r for r in results if not r[1]]
 print(f"=== {len(results) - len(fails)}/{len(results)} PASS ===")

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -2317,7 +2317,7 @@ if _t55_ok:
             _t55_ok, _t55_why = False, "gate must not depend on UI.CURSCENE/GSMBNET -- centralized in RunPOPStarterGame for auto-launch coverage"
         elif "pcall(System.disconnectSMB)" not in _window:
             _t55_ok, _t55_why = False, "disconnect must be pcall(System.disconnectSMB) (idempotent, keeps IRX resident)"
-        elif _slice55.find("System.disconnectSMB", 0) != _disc:
+        elif _slice55.count("pcall(System.disconnectSMB)") != 1:
             _t55_ok, _t55_why = False, "more than one System.disconnectSMB inside RunPOPStarterGame -- keep a single last-moment teardown before LaunchEngine"
 check("T55 net-SMB launch drains cover worker then logs off loader session before handoff (context.device_page==SMB && reboot_iop==0)", _t55_ok, _t55_why)
 

--- a/tools/host_harness.py
+++ b/tools/host_harness.py
@@ -2286,37 +2286,39 @@ check("T54 a bare game entry + GAMEPATH joins to a device-qualified cover AND de
 # via smb0: in ui.lua BEFORE RunPOPStarterGame, so disconnecting earlier would break it.
 _sys55 = (REPO / "bin" / "POPSLDR" / "system.lua").read_text(encoding="utf-8")
 _t55_ok, _t55_why = True, ""
-# locate the tail of RunPOPStarterGame (Clear -> LaunchEngine)
-_clear = _sys55.find("UI.CoverCache:Clear()")
-_quiesce = _sys55.find("UI.CoverCache:Quiesce()", _clear if _clear != -1 else 0)
-_disc = _sys55.find("System.disconnectSMB", _quiesce if _quiesce != -1 else 0)
-_launch = _sys55.find("LaunchEngine(popstarter, argv, reboot_iop, context)", _disc if _disc != -1 else 0)
-if _clear == -1 or _quiesce == -1 or _disc == -1 or _launch == -1:
-    _t55_ok, _t55_why = False, "Clear/Quiesce/disconnectSMB/LaunchEngine sequence not found in RunPOPStarterGame tail"
-elif not (_clear < _quiesce < _disc < _launch):
-    _t55_ok, _t55_why = False, "wrong order: expected Clear -> Quiesce -> disconnectSMB -> LaunchEngine (all SMB-dependent work must complete before Quiesce, and Quiesce before CLOSESHARE)"
-elif "pcall(function()" not in _sys55[_quiesce-200:_quiesce+200] or "UI.CoverCache:Quiesce()" not in _sys55[_quiesce-200:_quiesce+200]:
-    _t55_ok, _t55_why = False, "Quiesce must be pcall(function() UI.CoverCache:Quiesce() end) -- pcall(UI.CoverCache.Quiesce) omits self and never drains"
-elif "pcall(UI.CoverCache.Quiesce" in _sys55:
-    _t55_ok, _t55_why = False, "bare pcall(UI.CoverCache.Quiesce) found -- self==nil, Quiesce throws and the worker is not drained"
+# scope every search to the extracted RunPOPStarterGame body -- global .find()
+# would pass even if the sequence lived outside this function, which is exactly
+# the durability gap noted at 21dac8a6 review
+_rpp = _sys55.find("function PLDR.RunPOPStarterGame")
+if _rpp == -1:
+    _t55_ok, _t55_why = False, "PLDR.RunPOPStarterGame not found"
+    _slice55 = ""
 else:
-    _window = _sys55[_disc-600:_disc+600]
-    if 'context.device_page == "SMB"' not in _window or "reboot_iop == 0" not in _window:
-        _t55_ok, _t55_why = False, 'gate must be context.device_page == "SMB" and reboot_iop == 0 (covers UI + auto-launch, not GSMBNET)'
-    elif "GSMBNET" in _window or "UI.CURSCENE" in _window:
-        _t55_ok, _t55_why = False, "gate must not depend on UI.CURSCENE/GSMBNET -- centralized in RunPOPStarterGame for auto-launch coverage"
-    elif "pcall(System.disconnectSMB)" not in _window:
-        _t55_ok, _t55_why = False, "disconnect must be pcall(System.disconnectSMB) (idempotent, keeps IRX resident)"
-# negative: within RunPOPStarterGame, no disconnect may appear before Quiesce
-# (earlier failure-cleanup disconnects outside this function are fine)
+    _next_fn = _sys55.find("\nfunction ", _rpp + 32)
+    _slice55 = _sys55[_rpp:_next_fn] if _next_fn != -1 else _sys55[_rpp:_rpp+20000]
 if _t55_ok:
-    _rpp = _sys55.find("function PLDR.RunPOPStarterGame")
-    _slice = _sys55[_rpp:_rpp+16000] if _rpp != -1 else ""
-    _slice_clear = _slice.find("UI.CoverCache:Clear()")
-    _slice_quiesce = _slice.find("UI.CoverCache:Quiesce()")
-    _slice_disc = _slice.find("System.disconnectSMB")
-    if _slice_disc != -1 and _slice_quiesce != -1 and _slice_disc < _slice_quiesce:
-        _t55_ok, _t55_why = False, "a disconnectSMB appears before Quiesce inside RunPOPStarterGame -- cover worker still holds smb0: fopen across CLOSESHARE"
+    _clear = _slice55.find("UI.CoverCache:Clear()")
+    _quiesce = _slice55.find("UI.CoverCache:Quiesce()", _clear if _clear != -1 else 0)
+    _disc = _slice55.find("System.disconnectSMB", _quiesce if _quiesce != -1 else 0)
+    _launch = _slice55.find("LaunchEngine(popstarter, argv, reboot_iop, context)", _disc if _disc != -1 else 0)
+    if _clear == -1 or _quiesce == -1 or _disc == -1 or _launch == -1:
+        _t55_ok, _t55_why = False, "Clear/Quiesce/disconnectSMB/LaunchEngine sequence not found inside RunPOPStarterGame"
+    elif not (_clear < _quiesce < _disc < _launch):
+        _t55_ok, _t55_why = False, "wrong order inside RunPOPStarterGame: expected Clear -> Quiesce -> disconnectSMB -> LaunchEngine"
+    elif "pcall(function()" not in _slice55[_quiesce-200:_quiesce+200] or "UI.CoverCache:Quiesce()" not in _slice55[_quiesce-200:_quiesce+200]:
+        _t55_ok, _t55_why = False, "Quiesce must be pcall(function() UI.CoverCache:Quiesce() end) -- pcall(UI.CoverCache.Quiesce) omits self and never drains"
+    elif "pcall(UI.CoverCache.Quiesce" in _slice55:
+        _t55_ok, _t55_why = False, "bare pcall(UI.CoverCache.Quiesce) found inside RunPOPStarterGame -- self==nil, Quiesce throws and the worker is not drained"
+    else:
+        _window = _slice55[_disc-600:_disc+600]
+        if 'context.device_page == "SMB"' not in _window or "reboot_iop == 0" not in _window:
+            _t55_ok, _t55_why = False, 'gate must be context.device_page == "SMB" and reboot_iop == 0 (covers UI + auto-launch, not GSMBNET)'
+        elif "GSMBNET" in _window or "UI.CURSCENE" in _window:
+            _t55_ok, _t55_why = False, "gate must not depend on UI.CURSCENE/GSMBNET -- centralized in RunPOPStarterGame for auto-launch coverage"
+        elif "pcall(System.disconnectSMB)" not in _window:
+            _t55_ok, _t55_why = False, "disconnect must be pcall(System.disconnectSMB) (idempotent, keeps IRX resident)"
+        elif _slice55.find("System.disconnectSMB", 0) != _disc:
+            _t55_ok, _t55_why = False, "more than one System.disconnectSMB inside RunPOPStarterGame -- keep a single last-moment teardown before LaunchEngine"
 check("T55 net-SMB launch drains cover worker then logs off loader session before handoff (context.device_page==SMB && reboot_iop==0)", _t55_ok, _t55_why)
 
 


### PR DESCRIPTION
Fixes #571

POPSLoader's smb0: LOGON survives the no-IOP-reset handoff (reboot_iop==0) into POPStarter's own LOGON via mc:/POPSTARTER/SMBCONFIG.DAT. On direct crossover static-IP launches browse succeeds but the game freezes permanently (SCPH-90006, 1.2.0).

Centralize last-moment teardown in PLDR.RunPOPStarterGame after all smb0:-dependent work and before LaunchEngine:

- Clear() -> Quiesce() -> if device_page==SMB && reboot_iop==0: System.disconnectSMB() -> LaunchEngine()
- Quiesce via pcall(function() UI.CoverCache:Quiesce() end) so self preserved
- Retro GEM (SYSTEM.CNF inside VCD via smb0: in ui.lua) stays before RunPOPStarterGame
- Gate is device_page/reboot_iop, not UI.CURSCENE/GSMBNET, covering both UI CONFIRM and AutoLaunchFromLaunchArgs
- Preserves #570 %w+:/ and T54; adds T55 scoped to RunPOPStarterGame

No luasystem.cpp/ui.lua/Makefile/IRX/IPCONFIG changes.

 Tested: host_harness 55/55, docs_verify OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when launching external applications from SMB storage.
  - Cover-cache activity is now safely paused before launch.
  - SMB sessions are cleanly disconnected before non-reboot launches, helping prevent handoff conflicts and launch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->